### PR TITLE
Add missing framework and library to use documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,12 @@ How to Use KSCrash
 
 1. Add the framework to your project (or add the KSCrash project as a
    dependency)
+   
+2. Add the SystemConfiguration framework and libz.dylib to your project
 
-2. Add the flag "-ObjC" to **Other Linker Flags** in your **Build Settings**
+3. Add the flag "-ObjC" to **Other Linker Flags** in your **Build Settings**
 
-3. Add the following to your **[application: didFinishLaunchingWithOptions:]**
+4. Add the following to your **[application: didFinishLaunchingWithOptions:]**
    method in your app delegate:
 
 .


### PR DESCRIPTION
This adds to the documentation the instruction to add SystemConfiguration.framework and libz.dylib to the users project in order to use KSCrash.
