### PR TITLE
Update of Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ How to Use KSCrash
 1. Add the framework to your project (or add the KSCrash project as a
    dependency)
    
-2. Add the SystemConfiguration framework and libz.dylib to your project
+2. Add the SystemConfiguration framework, libc++.dylib and libz.dylib to your project
 
 3. Add the flag "-ObjC" to **Other Linker Flags** in your **Build Settings**
 


### PR DESCRIPTION
The libc++.dylib library is needed in order to compile solutions.
