### PR TITLE
fix podspec lint warnings

### DIFF
--- a/KSCrash.podspec
+++ b/KSCrash.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author       = { "Karl Stenerud" => "kstenerud@gmail.com" }
   s.platform     = :ios, '5.0'
   s.source       = { :git => "https://github.com/kstenerud/KSCrash.git", :commit => "a231b0c821e478efe0aedfdb61fa2c2576d927a4" }
-  s.source_files = 'KSCrash/KSCrash/*.{h,m,mm,c}'
-  # s.public_header_files = 'Classes/**/*.h'
-  s.frameworks = 'Foundation', 'SystemConfiguration'
+  s.source_files = 'KSCrash/KSCrash/*.{h,m,mm,c}'  
+  s.frameworks = 'Foundation', 'SystemConfiguration', 'MessageUI'
+  s.libraries = 'c++', 'z'
 end


### PR DESCRIPTION
I have added KSCrash to public podspecs repository. So, now  "pod search KSCrash" works.
Link is here:

https://github.com/CocoaPods/Specs/blob/master/KSCrash/0.0.1/KSCrash.podspec

To do so, I was faced with KSCrash.podspec "pod spec lint" warnings. This commit just fix all warnings in existed podspec.

Podspec is updated as well (https://github.com/kstenerud/KSCrash/issues/35)
