### PR TITLE
Adjusted __cxa_throw signature in KSCrashSentry_CPPException.mm to match...

### DIFF
--- a/Source/KSCrash/Recording/Sentry/KSCrashSentry_CPPException.mm
+++ b/Source/KSCrash/Recording/Sentry/KSCrashSentry_CPPException.mm
@@ -75,9 +75,9 @@ static KSCrash_SentryContext* g_context;
 #pragma mark - Callbacks -
 // ============================================================================
 
-typedef void (*cxa_throw_type)(void*, void*, void (*)(void*));
+typedef void (*cxa_throw_type)(void*, std::type_info*, void (*)(void*));
 
-extern "C" void __cxa_throw(void* thrown_exception, void* tinfo, void (*dest)(void*))
+extern "C" void __cxa_throw(void* thrown_exception, std::type_info* tinfo, void (*dest)(void*))
 {
     if(g_captureNextStackTrace)
     {


### PR DESCRIPTION
... this in cxxabi.h

Hi. Last week I updated to Xcode 5.1 beta 3 and noticed that KSCrash fails to build there because of mismatch in __cxa_throw signature in KSCrashSentry_CPPException.mm and cxxabi.h.

As I failed to find on the Internet a version of cxxabi.h with __cxa_throw taking void\* as second parameter, I think it should suffice just to adjust KSCrashSentry_CPPException.mm version to take std::type_info*. 
I actually tried to find out what has been changed, but it seems that preprocessed files look absolutely similar in Xcode 5.0.2 and 5.1 beta 3, probably there was something in older compiler what allowed to have pointers to different types in the signatures.

Thanks!

P.S. If this pull request is accepted it would be great to have tag 0.0.2 moved.
