### PR TITLE
Fixed 64 bit crash catching while getting backtrace and addr truncation ...

### DIFF
--- a/Source/KSCrash/Recording/Sentry/KSCrashSentry_NSException.m
+++ b/Source/KSCrash/Recording/Sentry/KSCrashSentry_NSException.m
@@ -87,7 +87,7 @@ void ksnsexc_i_handleException(NSException* exception)
         uintptr_t* callstack = malloc(numFrames * sizeof(*callstack));
         for(NSUInteger i = 0; i < numFrames; i++)
         {
-            callstack[i] = [[addresses objectAtIndex:i] unsignedIntValue];
+            callstack[i] = [[addresses objectAtIndex:i] unsignedLongValue];
         }
 
         g_context->crashType = KSCrashTypeNSException;

--- a/Source/KSCrash/Recording/Tools/KSMach_Arm64.c
+++ b/Source/KSCrash/Recording/Tools/KSMach_Arm64.c
@@ -73,8 +73,8 @@ bool ksmach_threadState(const thread_t thread,
 {
     return ksmach_fillState(thread,
                             (thread_state_t)&machineContext->__ss,
-                            ARM_THREAD_STATE,
-                            ARM_THREAD_STATE_COUNT);
+                            ARM_THREAD_STATE64,
+                            ARM_THREAD_STATE64_COUNT);
 }
 
 bool ksmach_floatState(const thread_t thread,
@@ -91,8 +91,8 @@ bool ksmach_exceptionState(const thread_t thread,
 {
     return ksmach_fillState(thread,
                             (thread_state_t)&machineContext->__es,
-                            ARM_EXCEPTION_STATE,
-                            ARM_EXCEPTION_STATE_COUNT);
+                            ARM_EXCEPTION_STATE64,
+                            ARM_EXCEPTION_STATE64_COUNT);
 }
 
 int ksmach_numRegisters(void)

--- a/Source/KSCrash/Reporting/Filters/KSCrashReportFilterAppleFmt.m
+++ b/Source/KSCrash/Reporting/Filters/KSCrashReportFilterAppleFmt.m
@@ -195,6 +195,10 @@ NSDictionary* g_registerOrders;
 
 - (NSString*) CPUType:(NSString*) CPUArch
 {
+    if([CPUArch rangeOfString:@"arm64"].location == 0)
+    {
+        return @"ARM-64";
+    }
     if([CPUArch rangeOfString:@"arm"].location == 0)
     {
         return @"ARM";
@@ -235,6 +239,10 @@ NSDictionary* g_registerOrders;
             }
             break;
         }
+#ifdef CPU_TYPE_ARM64
+        case CPU_TYPE_ARM64:
+            return @"arm64";
+#endif
         case CPU_TYPE_X86:
             return @"x86";
         case CPU_TYPE_X86_64:


### PR DESCRIPTION
...while coping backtrace of NSException. Added support for decoding arm64 arch, binary image type.
Tested using iphone 5s ios 7.0.3
