### PR TITLE
Stop trying to access NSMutableArray

### DIFF
--- a/Source/KSCrash-Tests/KSObjC_Tests.m
+++ b/Source/KSCrash-Tests/KSObjC_Tests.m
@@ -774,14 +774,8 @@
     XCTAssertEqual(count, expectedCount, @"");
     uintptr_t contents[10];
     size_t copied = ksobjc_arrayContents(arrayPtr, contents, sizeof(contents));
-    XCTAssertEqual(copied, count, @"");
-    for(size_t i = 0; i < count; i++)
-    {
-        bool isValid = ksobjc_objectType((void*)contents[i]) == KSObjCTypeObject;
-        XCTAssertTrue(isValid, @"Object %zu is not an object", i);
-        isValid = ksobjc_isValidObject((void*)contents[i]);
-        XCTAssertTrue(isValid, @"Object %zu is invalid", i);
-    }
+    size_t expectedCopied = 0;
+    XCTAssertEqual(copied, expectedCopied, @"");
 }
 
 - (void) testCopyArrayContentsMutableEmpty


### PR DESCRIPTION
Unfortunately the private structure of NSMutableArray changes
considerably between versions of iOS. (see http://git.io/CAbScg)

I tried to fix this by using ksobjc_getIvarValue, because the
field names have stayed constant throughout, but unfortunately
NSMutableArray uses bit-packing for flags which is not supported
by ksobjc_getIvarValue (or Apple's object_getInstanceVariable
for that matter).

For now I think the safest thing to do is to not dig into mutable
arrays.
