### PR TITLE
Export vmaddr for images

### DIFF
--- a/Source/KSCrash/Recording/KSCrashReport.c
+++ b/Source/KSCrash/Recording/KSCrashReport.c
@@ -1621,6 +1621,7 @@ void kscrw_i_writeBinaryImage(const KSCrashReportWriter* const writer,
     // Look for the TEXT segment to get the image size.
     // Also look for a UUID command.
     uint64_t imageSize = 0;
+    uint64_t imageVmAddr = 0;
     uint8_t* uuid = NULL;
 
     for(uint32_t iCmd = 0; iCmd < header->ncmds; iCmd++)
@@ -1634,6 +1635,7 @@ void kscrw_i_writeBinaryImage(const KSCrashReportWriter* const writer,
                 if(strcmp(segCmd->segname, SEG_TEXT) == 0)
                 {
                     imageSize = segCmd->vmsize;
+                    imageVmAddr = segCmd->vmaddr;
                 }
                 break;
             }
@@ -1643,6 +1645,7 @@ void kscrw_i_writeBinaryImage(const KSCrashReportWriter* const writer,
                 if(strcmp(segCmd->segname, SEG_TEXT) == 0)
                 {
                     imageSize = segCmd->vmsize;
+                    imageVmAddr = segCmd->vmaddr;
                 }
                 break;
             }
@@ -1659,6 +1662,7 @@ void kscrw_i_writeBinaryImage(const KSCrashReportWriter* const writer,
     writer->beginObject(writer, key);
     {
         writer->addUIntegerElement(writer, KSCrashField_ImageAddress, (uintptr_t)header);
+        writer->addUIntegerElement(writer, KSCrashField_ImageVmAddress, imageVmAddr);
         writer->addUIntegerElement(writer, KSCrashField_ImageSize, imageSize);
         writer->addStringElement(writer, KSCrashField_Name, _dyld_get_image_name(index));
         writer->addUUIDElement(writer, KSCrashField_UUID, uuid);

--- a/Source/KSCrash/Recording/KSCrashReportFields.h
+++ b/Source/KSCrash/Recording/KSCrashReportFields.h
@@ -116,6 +116,7 @@
 #define KSCrashField_CPUSubType            "cpu_subtype"
 #define KSCrashField_CPUType               "cpu_type"
 #define KSCrashField_ImageAddress          "image_addr"
+#define KSCrashField_ImageVmAddress        "image_vmaddr"
 #define KSCrashField_ImageSize             "image_size"
 
 


### PR DESCRIPTION
You need to subtract image_add and add image_vmaddr in order to look up symbols using atos or similar.

At Bugsnag we use this to display useful addresses on the website in the case that we don't have a dSYM.
