### PR TITLE
Issue #75: Add support for the latest Quincy and HockeyApp versions

### DIFF
--- a/Source/Common-Examples/CrashTesterCommands.m
+++ b/Source/Common-Examples/CrashTesterCommands.m
@@ -225,6 +225,7 @@
     [self sendReportsWithMessage:@"Sending reports to Quincy..."
                             sink:[[KSCrashReportSinkQuincy sinkWithURL:kQuincyReportURL
                                                              userIDKey:nil
+                                                           userNameKey:nil
                                                        contactEmailKey:nil
                                                   crashDescriptionKeys:nil] defaultCrashReportFilterSet]
                       completion:completion];
@@ -235,6 +236,7 @@
     [self sendReportsWithMessage:@"Sending reports to Hockey..."
                             sink:[[KSCrashReportSinkHockey sinkWithAppIdentifier:kHockeyAppID
                                                                        userIDKey:nil
+                                                                     userNameKey:nil
                                                                  contactEmailKey:nil
                                                             crashDescriptionKeys:nil] defaultCrashReportFilterSet]
                       completion:completion];

--- a/Source/KSCrash/Installations/KSCrashInstallationQuincyHockey.h
+++ b/Source/KSCrash/Installations/KSCrashInstallationQuincyHockey.h
@@ -71,6 +71,7 @@
 // The values of these properties will be written to the next crash report.
 
 @property(nonatomic,readwrite,retain) NSString* userID;
+@property(nonatomic,readwrite,retain) NSString* userName;
 @property(nonatomic,readwrite,retain) NSString* contactEmail;
 @property(nonatomic,readwrite,retain) NSString* crashDescription;
 
@@ -83,6 +84,7 @@
 // following keys.
 
 @property(nonatomic,readwrite,retain) NSString* userIDKey;
+@property(nonatomic,readwrite,retain) NSString* userNameKey;
 @property(nonatomic,readwrite,retain) NSString* contactEmailKey;
 @property(nonatomic,readwrite,retain) NSString* crashDescriptionKey;
 

--- a/Source/KSCrash/Installations/KSCrashInstallationQuincyHockey.m
+++ b/Source/KSCrash/Installations/KSCrashInstallationQuincyHockey.m
@@ -36,6 +36,7 @@
 
 
 #define kQuincyDefaultKeyUserID @"user_id"
+#define kQuincyDefaultKeyUserName @"user_name"
 #define kQuincyDefaultKeyContactEmail @"contact_email"
 #define kQuincyDefaultKeyDescription @"crash_description"
 #define kQuincyDefaultKeysExtraDescription [NSArray arrayWithObjects:@"/" @KSCrashField_System, @"/" @KSCrashField_User, nil]
@@ -44,6 +45,7 @@
 @implementation KSCrashInstallationBaseQuincyHockey
 
 IMPLEMENT_REPORT_PROPERTY(userID, UserID, NSString*);
+IMPLEMENT_REPORT_PROPERTY(userName, UserName, NSString*);
 IMPLEMENT_REPORT_PROPERTY(contactEmail, ContactEmail, NSString*);
 IMPLEMENT_REPORT_PROPERTY(crashDescription, CrashDescription, NSString*);
 
@@ -55,6 +57,7 @@ IMPLEMENT_REPORT_PROPERTY(crashDescription, CrashDescription, NSString*);
     if((self = [super initWithRequiredProperties:requiredProperties]))
     {
         self.userIDKey = kQuincyDefaultKeyUserID;
+        self.userNameKey = kQuincyDefaultKeyUserName;
         self.contactEmailKey = kQuincyDefaultKeyContactEmail;
         self.crashDescriptionKey = kQuincyDefaultKeyDescription;
         self.extraDescriptionKeys = kQuincyDefaultKeysExtraDescription;
@@ -67,6 +70,8 @@ IMPLEMENT_REPORT_PROPERTY(crashDescription, CrashDescription, NSString*);
 {
     as_release(_userID);
     as_release(_userIDKey);
+    as_release(_userName);
+    as_release(_userNameKey);
     as_release(_contactEmail);
     as_release(_contactEmailKey);
     as_release(_crashDescription);
@@ -118,6 +123,7 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(KSCrashInstallationQuincy)
 {
     KSCrashReportSinkQuincy* sink = [KSCrashReportSinkQuincy sinkWithURL:self.url
                                                                userIDKey:[self makeKeyPath:self.userIDKey]
+                                                             userNameKey:[self makeKeyPath:self.userNameKey]
                                                          contactEmailKey:[self makeKeyPath:self.contactEmailKey]
                                                     crashDescriptionKeys:[self makeKeyPaths:[self allCrashDescriptionKeys]]];
     sink.waitUntilReachable = self.waitUntilReachable;
@@ -153,6 +159,7 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(KSCrashInstallationHockey)
 {
     KSCrashReportSinkHockey* sink = [KSCrashReportSinkHockey sinkWithAppIdentifier:self.appIdentifier
                                                                          userIDKey:[self makeKeyPath:self.userIDKey]
+                                                                       userNameKey:[self makeKeyPath:self.userNameKey]
                                                                    contactEmailKey:[self makeKeyPath:self.contactEmailKey]
                                                               crashDescriptionKeys:[self makeKeyPaths:[self allCrashDescriptionKeys]]];
     sink.waitUntilReachable = self.waitUntilReachable;

--- a/Source/KSCrash/Reporting/Filters/KSCrashReportFilterAppleFmt.m
+++ b/Source/KSCrash/Reporting/Filters/KSCrashReportFilterAppleFmt.m
@@ -244,7 +244,7 @@ NSDictionary* g_registerOrders;
             return @"arm64";
 #endif
         case CPU_TYPE_X86:
-            return @"x86";
+            return @"i386";
         case CPU_TYPE_X86_64:
             return @"x86_64";
     }

--- a/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkQuincyHockey.h
+++ b/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkQuincyHockey.h
@@ -44,11 +44,13 @@
 
 + (KSCrashReportSinkQuincy*) sinkWithURL:(NSURL*) url
                                userIDKey:(NSString*) userIDKey
+                             userNameKey:(NSString*) userNameKey
                          contactEmailKey:(NSString*) contactEmailKey
                     crashDescriptionKeys:(NSArray*) crashDescriptionKeys;
 
 - (id) initWithURL:(NSURL*) url
          userIDKey:(NSString*) userIDKey
+       userNameKey:(NSString*) userNameKey
    contactEmailKey:(NSString*) contactEmailKey
 crashDescriptionKeys:(NSArray*) crashDescriptionKeys;
 
@@ -66,11 +68,13 @@ crashDescriptionKeys:(NSArray*) crashDescriptionKeys;
 
 + (KSCrashReportSinkHockey*) sinkWithAppIdentifier:(NSString*) appIdentifier
                                          userIDKey:(NSString*) userIDKey
+                                       userNameKey:(NSString*) userNameKey
                                    contactEmailKey:(NSString*) contactEmailKey
                               crashDescriptionKeys:(NSArray*) crashDescriptionKeys;
 
 - (id) initWithAppIdentifier:(NSString*) appIdentifier
                    userIDKey:(NSString*) userIDKey
+                 userNameKey:(NSString*) userNameKey
              contactEmailKey:(NSString*) contactEmailKey
         crashDescriptionKeys:(NSArray*) crashDescriptionKeys;
 


### PR DESCRIPTION
The latest version of the Quincy server expects some additional XML elements in the Quincy format crash report.
- The `<uuids>` and child `<uuid>` elements list the type (app or framework), architecture, and uuid of the app binary and embedded frameworks binaries.
- The `<uuid>` element that is not contained within the `<uuids>` element contains the crash ID field that is already available in KSCrash.
- The `<username>` field contains the new optional user name supported by the Quincy and HockeyApp UIs.
- The `<installstring>` element contains a uuid value that should remain the same across all crash reports generated by the app.  I look in the NSUserDefaults for this using the same value name as the QuincyKit code and store it there if I create it.

The Quincy server parses the binary image lines in the crash report.  The list of binary architectures that it supports in those lines does not include the x86 value used by KSCrash.  It expects to see i386 for that architecture instead.  I have switched these values in the KSCrash code.  However, if anybody using KSCrash is parsing the report themselves and looking for x86 this will be a problem.  Perhaps this should only be done when reporting to Quincy and Hockey.

The URL where the HockeyApp SDK sends crash reports has changed. I have updated that URL.

This code is backwards compatible with the Quincy 2 server code.  The older server ignores the additional XML elements.
