### PR TITLE
Symbolication tweaks

### DIFF
--- a/Source/KSCrash/Recording/KSCrashReport.c
+++ b/Source/KSCrash/Recording/KSCrashReport.c
@@ -633,12 +633,13 @@ void kscrw_i_logBacktraceEntry(const int entryNum,
  * @param backtraceLength The length of the backtrace.
  */
 void kscrw_i_logBacktrace(const uintptr_t* const backtrace,
-                          const int backtraceLength)
+                          const int backtraceLength,
+                          const int skippedEntries)
 {
     if(backtraceLength > 0)
     {
         Dl_info symbolicated[backtraceLength];
-        ksbt_symbolicate(backtrace, symbolicated, backtraceLength);
+        ksbt_symbolicate(backtrace, symbolicated, backtraceLength, skippedEntries);
 
         for(int i = 0; i < backtraceLength; i++)
         {
@@ -662,16 +663,17 @@ void kscrw_i_logCrashThreadBacktrace(const KSCrash_SentryContext* const crash)
                                                                  thread,
                                                                  &concreteMachineContext);
 
+    int skippedEntries;
     uintptr_t* backtrace = kscrw_i_getBacktrace(crash,
                                                 thread,
                                                 machineContext,
                                                 concreteBacktrace,
                                                 &backtraceLength,
-                                                NULL);
+                                                &skippedEntries);
 
     if(backtrace != NULL)
     {
-        kscrw_i_logBacktrace(backtrace, backtraceLength);
+        kscrw_i_logBacktrace(backtrace, backtraceLength, skippedEntries);
     }
 }
 
@@ -1157,7 +1159,7 @@ void kscrw_i_writeBacktrace(const KSCrashReportWriter* const writer,
             if(backtraceLength > 0)
             {
                 Dl_info symbolicated[backtraceLength];
-                ksbt_symbolicate(backtrace, symbolicated, backtraceLength);
+                ksbt_symbolicate(backtrace, symbolicated, backtraceLength, skippedEntries);
 
                 for(int i = 0; i < backtraceLength; i++)
                 {

--- a/Source/KSCrash/Recording/Tools/KSBacktrace.h
+++ b/Source/KSCrash/Recording/Tools/KSBacktrace.h
@@ -100,10 +100,13 @@ int ksbt_backtraceSelf(uintptr_t* backtraceBuffer,
  * @param symbolsBuffer A buffer to hold the symbolicated backtrace.
  *
  * @param numEntries The number of entries to examine.
+ *
+ * @param numEntries The number of entries skipped from the start of this backtrace.
  */
 void ksbt_symbolicate(const uintptr_t* backtraceBuffer,
                       Dl_info* symbolsBuffer,
-                      int numEntries);
+                      int numEntries,
+                      int skippedEntries);
 
 
 #ifdef __cplusplus

--- a/Source/KSCrash/Recording/Tools/KSMach.h
+++ b/Source/KSCrash/Recording/Tools/KSMach.h
@@ -142,6 +142,15 @@ uintptr_t ksmach_stackPointer(const STRUCT_MCONTEXT_L* machineContext);
  */
 uintptr_t ksmach_instructionAddress(const STRUCT_MCONTEXT_L* machineContext);
 
+/** Get the address stored in the link register (arm only). This may
+ * contain the first return address of the stack.
+ *
+ * @param machineContext The machine context.
+ *
+ * @return The link register value.
+ */
+uintptr_t ksmach_linkRegister(const STRUCT_MCONTEXT_L* machineContext);
+
 /** Get the address whose access caused the last fault.
  *
  * @param machineContext The machine context.

--- a/Source/KSCrash/Recording/Tools/KSMach_Arm.c
+++ b/Source/KSCrash/Recording/Tools/KSMach_Arm.c
@@ -66,6 +66,11 @@ uintptr_t ksmach_instructionAddress(const STRUCT_MCONTEXT_L* const machineContex
     return machineContext->__ss.__pc;
 }
 
+uintptr_t ksmach_linkRegister(const STRUCT_MCONTEXT_L* const machineContext)
+{
+    return machineContext->__ss.__lr;
+}
+
 bool ksmach_threadState(const thread_t thread,
                         STRUCT_MCONTEXT_L* const machineContext)
 {

--- a/Source/KSCrash/Recording/Tools/KSMach_Arm64.c
+++ b/Source/KSCrash/Recording/Tools/KSMach_Arm64.c
@@ -68,6 +68,11 @@ uintptr_t ksmach_instructionAddress(const STRUCT_MCONTEXT_L* const machineContex
     return machineContext->__ss.__pc;
 }
 
+uintptr_t ksmach_linkRegister(const STRUCT_MCONTEXT_L* const machineContext)
+{
+    return machineContext->__ss.__lr;
+}
+
 bool ksmach_threadState(const thread_t thread,
                         STRUCT_MCONTEXT_L* const machineContext)
 {

--- a/Source/KSCrash/Recording/Tools/KSMach_x86_32.c
+++ b/Source/KSCrash/Recording/Tools/KSMach_x86_32.c
@@ -69,6 +69,11 @@ uintptr_t ksmach_instructionAddress(const STRUCT_MCONTEXT_L* const machineContex
     return machineContext->__ss.__eip;
 }
 
+uintptr_t ksmach_linkRegister(const STRUCT_MCONTEXT_L* const machineContext)
+{
+    return 0;
+}
+
 bool ksmach_threadState(const thread_t thread,
                         STRUCT_MCONTEXT_L* const machineContext)
 {

--- a/Source/KSCrash/Recording/Tools/KSMach_x86_64.c
+++ b/Source/KSCrash/Recording/Tools/KSMach_x86_64.c
@@ -70,6 +70,11 @@ uintptr_t ksmach_instructionAddress(const STRUCT_MCONTEXT_L* const machineContex
     return machineContext->__ss.__rip;
 }
 
+uintptr_t ksmach_linkRegister(const STRUCT_MCONTEXT_L* const machineContext)
+{
+    return 0;
+}
+
 bool ksmach_threadState(const thread_t thread,
                         STRUCT_MCONTEXT_L* const machineContext)
 {


### PR DESCRIPTION
After this change KSCrash is capable of generating reports that
can pass all of the CrashProbe tests. To do this I had to:
- Include the link register in the backtrace on arm.
- Detag instructions more conservatively.
- Treat addresses from stack walking as return addresses.
