### PR TITLE
Allow user reported exceptions to not suspend all threads

### DIFF
--- a/Source/KSCrash/Recording/KSCrash.h
+++ b/Source/KSCrash/Recording/KSCrash.h
@@ -144,6 +144,13 @@ typedef enum
  */
 @property(nonatomic,readwrite,retain) NSArray* doNotIntrospectClasses;
 
+/** If YES, user reported exceptions will suspend all threads during report generation.
+ * All threads will be suspended while generating a crash report for a user
+ * reported exception.
+ *
+ * Default: YES
+ */
+@property(nonatomic,readwrite,assign) bool suspendThreadsForUserReported;
 
 /** Get the singleton instance of the crash reporter.
  */

--- a/Source/KSCrash/Recording/KSCrash.m
+++ b/Source/KSCrash/Recording/KSCrash.m
@@ -110,6 +110,7 @@
 @synthesize searchQueueNames = _searchQueueNames;
 @synthesize introspectMemory = _introspectMemory;
 @synthesize doNotIntrospectClasses = _doNotIntrospectClasses;
+@synthesize suspendThreadsForUserReported = _suspendThreadsForUserReported;
 
 
 // ============================================================================
@@ -156,6 +157,7 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(KSCrash)
         self.searchThreadNames = NO;
         self.searchQueueNames = NO;
         self.introspectMemory = YES;
+        self.suspendThreadsForUserReported = YES;
     }
     return self;
 
@@ -268,6 +270,12 @@ failed:
         }
         kscrash_setDoNotIntrospectClasses(classes, count);
     }
+}
+
+- (void) setSuspendThreadsForUserReported:(bool) suspendThreadsForUserReported
+{
+    _suspendThreadsForUserReported = suspendThreadsForUserReported;
+    kscrash_setSuspendThreadsForUserReported(suspendThreadsForUserReported);
 }
 
 - (NSString*) crashReportPath

--- a/Source/KSCrash/Recording/KSCrashC.c
+++ b/Source/KSCrash/Recording/KSCrashC.c
@@ -285,6 +285,11 @@ void kscrash_setDoNotIntrospectClasses(const char** doNotIntrospectClasses, size
     }
 }
 
+void kscrash_setSuspendThreadsForUserReported(bool suspendThreadsForUserReported)
+{
+    crashContext()->config.suspendThreadsForUserReported = suspendThreadsForUserReported;
+}
+
 void kscrash_setCrashNotifyCallback(const KSReportWriteCallback onCrashNotify)
 {
     KSLOG_TRACE("Set onCrashNotify to %p", onCrashNotify);

--- a/Source/KSCrash/Recording/KSCrashC.c
+++ b/Source/KSCrash/Recording/KSCrashC.c
@@ -287,7 +287,7 @@ void kscrash_setDoNotIntrospectClasses(const char** doNotIntrospectClasses, size
 
 void kscrash_setSuspendThreadsForUserReported(bool suspendThreadsForUserReported)
 {
-    crashContext()->config.suspendThreadsForUserReported = suspendThreadsForUserReported;
+    crashContext()->crash.suspendThreadsForUserReported = suspendThreadsForUserReported;
 }
 
 void kscrash_setCrashNotifyCallback(const KSReportWriteCallback onCrashNotify)

--- a/Source/KSCrash/Recording/KSCrashC.h
+++ b/Source/KSCrash/Recording/KSCrashC.h
@@ -165,6 +165,15 @@ void kscrash_setIntrospectMemory(bool introspectMemory);
  */
 void kscrash_setDoNotIntrospectClasses(const char** doNotIntrospectClasses, size_t length);
 
+
+/** If YES, user reported exceptions will suspend all threads during report generation.
+ * All threads will be suspended while generating a crash report for a user
+ * reported exception.
+ *
+ * Default: YES
+ */
+void kscrash_setSuspendThreadsForUserReported(bool suspendThreadsForUserReported);
+    
 /** Set the callback to invoke upon a crash.
  *
  * WARNING: Only call async-safe functions from this function! DO NOT call

--- a/Source/KSCrash/Recording/KSCrashContext.h
+++ b/Source/KSCrash/Recording/KSCrashContext.h
@@ -89,9 +89,6 @@ typedef struct
     /** Rules for introspecting Objective-C objects. */
     KSCrash_IntrospectionRules introspectionRules;
     
-    /** If true, will suspend threads for user reported exceptions. */
-    bool suspendThreadsForUserReported;
-    
     /** Callback allowing the application the opportunity to add extra data to
      * the report file. Application MUST NOT call async-unsafe methods!
      */

--- a/Source/KSCrash/Recording/KSCrashContext.h
+++ b/Source/KSCrash/Recording/KSCrashContext.h
@@ -89,6 +89,9 @@ typedef struct
     /** Rules for introspecting Objective-C objects. */
     KSCrash_IntrospectionRules introspectionRules;
     
+    /** If true, will suspend threads for user reported exceptions. */
+    bool suspendThreadsForUserReported;
+    
     /** Callback allowing the application the opportunity to add extra data to
      * the report file. Application MUST NOT call async-unsafe methods!
      */

--- a/Source/KSCrash/Recording/Sentry/KSCrashSentry.h
+++ b/Source/KSCrash/Recording/Sentry/KSCrashSentry.h
@@ -58,7 +58,9 @@ typedef struct KSCrash_SentryContext
 
     /** Called by the crash handler when a crash is detected. */
     void (*onCrash)(void);
-
+    
+    /** If true, will suspend threads for user reported exceptions. */
+    bool suspendThreadsForUserReported;
 
     // Implementation defined values. Caller does not initialize these.
 

--- a/Source/KSCrash/Recording/Sentry/KSCrashSentry_User.c
+++ b/Source/KSCrash/Recording/Sentry/KSCrashSentry_User.c
@@ -60,9 +60,12 @@ void kscrashsentry_reportUserException(const char* name,
     if(g_context != NULL)
     {
         kscrashsentry_beginHandlingCrash(g_context);
-
-        KSLOG_DEBUG("Suspending all threads");
-        kscrashsentry_suspendThreads();
+        
+        if(g_context->suspendThreadsForUserReported)
+        {
+            KSLOG_DEBUG("Suspending all threads");
+            kscrashsentry_suspendThreads();
+        }
 
         KSLOG_DEBUG("Fetching call stack.");
         int callstackCount = 100;


### PR DESCRIPTION
Suspending all threads for user reported exceptions in games can cause a noticeable lag while the report is being generated so I've added a flag to control that functionality. 
