### PR TITLE
Fix buffer over-read in json_decode

### DIFF
--- a/Source/KSCrash-Tests/KSJSONCodec_Tests.m
+++ b/Source/KSCrash-Tests/KSJSONCodec_Tests.m
@@ -1491,4 +1491,26 @@ static NSString* toString(NSData* data)
     XCTAssertTrue([result count] == 0, @"");
 }
 
+- (void) testFloatParsingDoesntOverflow
+{
+    NSError *error = (NSError*)self;
+
+    char * buffer = malloc(0x1000000);
+    for (int i = 0; i < 0x1000000; i++) {
+        buffer[i] = ';';
+    }
+
+    memcpy(buffer, "{\"test\":1.1}", 12);
+
+    NSData *data = [NSData dataWithBytesNoCopy:buffer length:0x1000000 freeWhenDone:YES];
+
+    NSDictionary *result = [KSJSONCodec decode: data
+                                    options:0
+                                         error:&error];
+    XCTAssertNotNil(result, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertTrue([result count] == 1, @"");
+
+}
+
 @end

--- a/Source/KSCrash/Recording/Tools/KSJSONCodec.c
+++ b/Source/KSCrash/Recording/Tools/KSJSONCodec.c
@@ -1141,7 +1141,7 @@ int ksjsoncodec_i_decodeElement(const char** ptr,
             // it would be undefined to call sscanf/sttod etc. directly.
             // instead we create a temporary string.
             double value;
-            size_t len = (unsigned)(*ptr - start);
+            size_t len = (size_t)(*ptr - start);
             char * buf = malloc(len + 1);
             strncpy(buf, start, len);
             buf[len] = '\0';

--- a/Source/KSCrash/Recording/Tools/KSJSONCodec.c
+++ b/Source/KSCrash/Recording/Tools/KSJSONCodec.c
@@ -1137,8 +1137,19 @@ int ksjsoncodec_i_decodeElement(const char** ptr,
                 return KSJSON_ERROR_INCOMPLETE;
             }
 
+            // our buffer is not necessarily NULL-terminated, so
+            // it would be undefined to call sscanf/sttod etc. directly.
+            // instead we create a temporary string.
             double value;
-            sscanf(start, "%lg", &value);
+            size_t len = (unsigned)(*ptr - start);
+            char * buf = malloc(len + 1);
+            strncpy(buf, start, len);
+            buf[len] = '\0';
+
+            sscanf(buf, "%lg", &value);
+
+            free(buf);
+
             value *= sign;
             return callbacks->onFloatingPointElement(name, value, userData);
         }


### PR DESCRIPTION
json_i_decodeElement uses sscanf() to parse floats. Unfortunately
sscanf() expects to be passed a NULL-terminated string, and so calls
strlen()internally. This causes a buffer-overread in the case that the
buffer is not NULL-terminated (e.g. when it's from [NSData
dataWithContentsOfFile:])

The fix is simple, we just copy floats into a temporary buffer before
parsing them.

I also considered using strtod(), which doesn't exhibit this bug, but apparently it's undefined behaviour to call that on a non-NULL-terminated buffer too :/.