### PR TITLE
Updates KSCrashC.m to only init objc symbols if introspectMemory is true

### DIFF
--- a/KSCrash.podspec
+++ b/KSCrash.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "KSCrash"
-  s.version      = "0.0.4"
+  s.version      = "0.0.5"
   s.summary      = "The Ultimate iOS Crash Reporter"
   s.homepage     = "https://github.com/kstenerud/KSCrash"
   s.license     = { :type => 'KSCrash license agreement', :file => 'LICENSE' }
@@ -11,9 +11,16 @@ Pod::Spec.new do |s|
   s.libraries = 'c++', 'z'
   s.xcconfig = { 'GCC_ENABLE_CPP_EXCEPTIONS' => 'YES' }
   
+  s.subspec 'no-arc' do |sp|
+    sp.source_files = 'Source/KSCrash/Recording/**/KSZombie.{h,m}'
+    sp.requires_arc = false
+  end
+
   s.subspec 'Recording' do |recording|
+    recording.dependency 'KSCrash/no-arc'
     recording.source_files   = 'Source/KSCrash/Recording/**/*.{h,m,mm,c,cpp}',
                                'Source/KSCrash/Reporting/Filters/KSCrashReportFilter.h' 
+    recording.exclude_files = 'Source/KSCrash/Recording/**/KSZombie.{h,m}'  
   end
 
   s.subspec 'Reporting' do |reporting|

--- a/Source/KSCrash/Recording/KSCrashC.c
+++ b/Source/KSCrash/Recording/KSCrashC.c
@@ -139,8 +139,12 @@ KSCrashType kscrash_install(const char* const crashReportFilePath,
     g_installed = 1;
 
     ksmach_init();
-    ksobjc_init();
-
+    
+    if(context->config.introspectionRules.enabled)
+    {
+        ksobjc_init();
+    }
+    
     kscrash_reinstall(crashReportFilePath,
                       recrashReportFilePath,
                       stateFilePath,

--- a/Source/KSCrash/Recording/Tools/KSMach_x86_64.c
+++ b/Source/KSCrash/Recording/Tools/KSMach_x86_64.c
@@ -70,7 +70,7 @@ uintptr_t ksmach_instructionAddress(const STRUCT_MCONTEXT_L* const machineContex
     return machineContext->__ss.__rip;
 }
 
-uintptr_t ksmach_linkRegister(const STRUCT_MCONTEXT_L* const machineContext)
+uintptr_t ksmach_linkRegister(const STRUCT_MCONTEXT_L* const machineContext __attribute__ ((unused)))
 {
     return 0;
 }

--- a/Source/KSCrash/Recording/Tools/KSObjCApple.h
+++ b/Source/KSCrash/Recording/Tools/KSObjCApple.h
@@ -119,7 +119,10 @@ typedef struct class_rw_t {
 typedef struct class_t {
     struct class_t *isa;
     struct class_t *superclass;
+#pragma clang diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     Cache cache;
+#pragma clang diagnostic pop
     IMP *vtable;
     uintptr_t data_NEVER_USE;  // class_rw_t * plus custom rr/alloc flags
 } class_t;


### PR DESCRIPTION
- Updates KSCrashC.m to only init objc symbols if introspectMemory is true
- Updates podspec to build KSZombie with no-arc 
- Silences build warnings (https://github.com/bugsnag/bugsnag-cocoa/issues/50)