### PR TITLE
Remove reference to KSCrashLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,17 +362,6 @@ be useful for other purposes, so I've exposed an API for it.
 
 
 
-KSCrashLite
------------
-
-KSCrashLite is intended for use in custom crash frameworks that have special
-needs. It doesn't include any sinks (except for console); it is expected that
-the user will supply their own. Unlike the regular KSCrash framework,
-KSCrashLite has no dependencies on MessageUI.framework or zlib (it still
-requires SystemConfiguration.framework).
-
-
-
 Examples
 --------
 


### PR DESCRIPTION
Since KSCrashLite has not existed in some time (per #7), this patch removes the reference  from the readme.