### PR TITLE
Add OS X deployment target to podspec

### DIFF
--- a/KSCrash.podspec
+++ b/KSCrash.podspec
@@ -1,11 +1,13 @@
 Pod::Spec.new do |s|
+  IOS_DEPLOYMENT_TARGET = '5.0' unless defined? IOS_DEPLOYMENT_TARGET
   s.name         = "KSCrash"
   s.version      = "0.0.9"
   s.summary      = "The Ultimate iOS Crash Reporter"
   s.homepage     = "https://github.com/kstenerud/KSCrash"
   s.license     = { :type => 'KSCrash license agreement', :file => 'LICENSE' }
   s.author       = { "Karl Stenerud" => "kstenerud@gmail.com" }
-  s.platform     = :ios, '5.0'
+  s.ios.deployment_target =  IOS_DEPLOYMENT_TARGET
+  s.osx.deployment_target =  '10.8'
   s.source       = { :git => "https://github.com/kstenerud/KSCrash.git", :tag=>s.version.to_s }
   s.frameworks = 'Foundation'
   s.libraries = 'c++', 'z'
@@ -85,6 +87,7 @@ Pod::Spec.new do |s|
     end
 
     reporting.subspec 'Sinks' do |sinks|
+      sinks.platform = :ios, IOS_DEPLOYMENT_TARGET
       sinks.frameworks = 'MessageUI'
       sinks.dependency 'KSCrash/Reporting/Filters'
       sinks.dependency 'KSCrash/Reporting/Tools'


### PR DESCRIPTION
This change allows users building for OS X and using cocoapods to require the `Recording` and `Reporting` subspecs, avoiding the `MessageUI` requirement of `Sinks`.

An example of a working `Podfile` after this change:

```ruby
platform :osx, "10.8"

pod "KSCrash/Recording", :path => "../KSCrash"
pod "KSCrash/Reporting", :path => "../KSCrash"
```

As an aside, per fec54379508f46828305ea885349bb82e0b34a78 should the deployment target for iOS be 7.0?