### PR TITLE
Fix KSCrash compilation against iOS 7.0 SDK

### DIFF
--- a/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkQuincyHockey.m
+++ b/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkQuincyHockey.m
@@ -235,24 +235,28 @@ crashDescriptionKeys:(NSArray*) crashDescriptionKeys
                     break;
             }
             break;
-            
+
+#ifdef CPU_TYPE_ARM64
         case CPU_TYPE_ARM64:
             switch (cpuSubType)
             {
                 case CPU_SUBTYPE_ARM_ALL:
                     arch = @"arm64";
                     break;
-                    
+
+#ifdef CPU_SUBTYPE_ARM_V8
                 case CPU_SUBTYPE_ARM_V8:
                     arch = @"arm64";
                     break;
-                    
+#endif
+
                 default:
                     arch = @"arm64-unknown";
                     break;
             }
             break;
-            
+#endif
+
         case CPU_TYPE_X86:
             arch = @"i386";
             break;


### PR DESCRIPTION
The definitions for `CPU_TYPE_ARM64` and `CPU_SUBTYPE_ARM_V8` are not present in the 7.0 SDK. This change guards against the CPU type check for these architectures.

* [Example compilation before the patch](https://travis-ci.org/bugsnag/bugsnag-cocoa/jobs/108419504#L177):
```
KSCrash/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkQuincyHockey.m:239:14: use of undeclared identifier 'CPU_TYPE_ARM64'
        case CPU_TYPE_ARM64:
             ^

KSCrash/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkQuincyHockey.m:246:22: use of undeclared identifier 'CPU_SUBTYPE_ARM_V8'
                case CPU_SUBTYPE_ARM_V8:
                     ^
```
* [Example compilation after patch is applied](https://travis-ci.org/bugsnag/bugsnag-cocoa/jobs/108442303#L163)