### PR TITLE
Fix problem with composed symbols in bundle name

### DIFF
--- a/Source/KSCrash-Tests/KSCrashReportStore_Tests.m
+++ b/Source/KSCrash-Tests/KSCrashReportStore_Tests.m
@@ -39,6 +39,7 @@
 @interface KSCrashReportStore (Tests)
 
 - (NSString*) reportIDFromFilename:(NSString*) filename;
+- (void) setBundleName:(NSString *) bundleName;
 
 @end
 
@@ -62,6 +63,43 @@
 {
     NSFileManager* fm = [NSFileManager defaultManager];
     return [fm fileExistsAtPath:[self.tempPath stringByAppendingPathComponent:reportName]];
+}
+
+- (void) testReportIDFromValidCombinedPath
+{
+    KSCrashReportStore* store = [self store];
+
+    NSString *bundleName = @"ЙогуртЙод";
+    [store setBundleName:bundleName];
+
+    NSString* expectedReportID = @"EEEC2645-5413-48C8-85AD-89638E1BE968";
+    NSString* reportFilename = [NSString stringWithFormat:@"%@-CrashReport-%@.json", bundleName, expectedReportID];
+    NSString* reportID = [store reportIDFromFilename:reportFilename];
+    XCTAssertNotNil(reportID, @"");
+    XCTAssertEqualObjects(reportID, expectedReportID, @"");
+}
+
+- (void) testReportIDFromFileWithInvalidExtension
+{
+    KSCrashReportStore* store = [self store];
+
+    NSString* reportFilename = @"BundleID-CrashReport-REPORTID.xml";
+    NSString* reportID = [store reportIDFromFilename:reportFilename];
+    XCTAssertNil(reportID, @"");
+}
+
+- (void) testReportIDFromFileWithExtensionInBundleID
+{
+    KSCrashReportStore* store = [self store];
+
+    NSString *bundleName = @"MyApp.json";
+    [store setBundleName:bundleName];
+
+    NSString* expectedReportID = @"EEEC2645-5413-48C8-85AD-89638E1BE968";
+    NSString* reportFilename = [NSString stringWithFormat:@"%@-CrashReport-%@.json", bundleName, expectedReportID];
+    NSString* reportID = [store reportIDFromFilename:reportFilename];
+    XCTAssertNotNil(reportID, @"");
+    XCTAssertEqualObjects(reportID, expectedReportID, @"");
 }
 /* TODO
 - (void) testReportNames

--- a/Source/KSCrash/Recording/KSCrashReportStore.m
+++ b/Source/KSCrash/Recording/KSCrashReportStore.m
@@ -413,7 +413,7 @@
 
 - (NSString*) reportIDFromFilename:(NSString*) filename
 {
-    if([filename length] == 0)
+    if([filename length] == 0 || [[filename pathExtension] isEqualToString:@"json"] == NO)
     {
         return nil;
     }
@@ -421,12 +421,13 @@
     NSString* prefix = [NSString stringWithFormat:@"%@" kCrashReportSuffix,
                         self.bundleName];
     NSString* suffix = @".json";
-    if([filename rangeOfString:prefix].location == 0 &&
-       [filename rangeOfString:suffix].location != NSNotFound)
+
+    NSRange prefixRange = [filename rangeOfString:prefix];
+    NSRange suffixRange = [filename rangeOfString:suffix options:NSBackwardsSearch];
+    if(prefixRange.location == 0 && suffixRange.location != NSNotFound)
     {
-        NSUInteger prefixLength = [prefix length];
-        NSUInteger suffixLength = [suffix length];
-        NSRange range = NSMakeRange(prefixLength, [filename length] - prefixLength - suffixLength);
+        NSUInteger prefixEnd = NSMaxRange(prefixRange);
+        NSRange range = NSMakeRange(prefixEnd, suffixRange.location - prefixEnd);
         return [filename substringWithRange:range];
     }
     return nil;


### PR DESCRIPTION
This pull-request solves the problem with composed symbols in bundle name. (#122)
Also, I've fixed a possible problem with bundle name containing ".json".