### PR TITLE
Add Advanced and Tools subspecs for Recording

### DIFF
--- a/KSCrash.podspec
+++ b/KSCrash.podspec
@@ -35,6 +35,20 @@ Pod::Spec.new do |s|
                                     'Source/KSCrash/Recording/Tools/KSArchSpecific.h',
                                     'Source/KSCrash/Recording/Tools/KSJSONCodecObjC.h',
                                     'Source/KSCrash/Recording/Tools/NSError+SimpleConstructor.h'
+
+    recording.subspec 'Advanced' do |advanced|
+      advanced.public_header_files = 'Source/KSCrash/Recording/KSCrashAdvanced.h',
+                                     'Source/KSCrash/Recording/KSCrashDoctor.h',
+                                     'Source/KSCrash/Recording/KSCrashReportFields.h',
+                                     'Source/KSCrash/Recording/KSCrashReportStore.h',
+                                     'Source/KSCrash/Recording/KSSystemInfo.h',
+                                     'Source/KSCrash/Recording/KSSystemInfoC.h'
+    end
+
+    recording.subspec 'Tools' do |tools|
+      tools.public_header_files = 'Source/KSCrash/Recording/Tools/**/*.h'
+    end
+
   end
 
   s.subspec 'Reporting' do |reporting|


### PR DESCRIPTION
Since version 1.0.1 advanced headers of Recording have been hidden. I think that the accurate place for them is proper subspecs.