### PR TITLE
Fix KSZombie for Objective-C 2

### DIFF
--- a/Source/KSCrash/Recording/Tools/KSZombie.m
+++ b/Source/KSCrash/Recording/Tools/KSZombie.m
@@ -160,9 +160,9 @@ static IMP g_originalDealloc_ ## CLASS; \
 static void handleDealloc_ ## CLASS(id self, SEL _cmd) \
 { \
     handleDealloc(self); \
-	typedef void (*fn)(id,SEL); \
-	fn f = (fn)g_originalDealloc_ ## CLASS; \
-	f(self, _cmd); \
+    typedef void (*fn)(id,SEL); \
+    fn f = (fn)g_originalDealloc_ ## CLASS; \
+    f(self, _cmd); \
 } \
 static void installDealloc_ ## CLASS() \
 { \

--- a/Source/KSCrash/Recording/Tools/KSZombie.m
+++ b/Source/KSCrash/Recording/Tools/KSZombie.m
@@ -160,7 +160,9 @@ static IMP g_originalDealloc_ ## CLASS; \
 static void handleDealloc_ ## CLASS(id self, SEL _cmd) \
 { \
     handleDealloc(self); \
-    g_originalDealloc_ ## CLASS(self, _cmd); \
+	typedef void (*fn)(id,SEL); \
+	fn f = (fn)g_originalDealloc_ ## CLASS; \
+	f(self, _cmd); \
 } \
 static void installDealloc_ ## CLASS() \
 { \

--- a/iOS/Example-Apps-iOS.xcodeproj/xcshareddata/xcschemes/Advanced-Example.xcscheme
+++ b/iOS/Example-Apps-iOS.xcodeproj/xcshareddata/xcschemes/Advanced-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/iOS/Example-Apps-iOS.xcodeproj/xcshareddata/xcschemes/Crash-Tester.xcscheme
+++ b/iOS/Example-Apps-iOS.xcodeproj/xcshareddata/xcschemes/Crash-Tester.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/iOS/Example-Apps-iOS.xcodeproj/xcshareddata/xcschemes/Simple-Example.xcscheme
+++ b/iOS/Example-Apps-iOS.xcodeproj/xcshareddata/xcschemes/Simple-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/iOS/Example-Apps-iOS.xcodeproj/xcshareddata/xcschemes/Swift-Tester.xcscheme
+++ b/iOS/Example-Apps-iOS.xcodeproj/xcshareddata/xcschemes/Swift-Tester.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/iOS/KSCrash-iOS.xcodeproj/project.pbxproj
+++ b/iOS/KSCrash-iOS.xcodeproj/project.pbxproj
@@ -816,6 +816,7 @@
 				CB52178D17EB735D007CB3C1 /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		CB52178D17EB735D007CB3C1 /* Products */ = {
 			isa = PBXGroup;

--- a/iOS/KSCrash-iOS.xcodeproj/project.pbxproj
+++ b/iOS/KSCrash-iOS.xcodeproj/project.pbxproj
@@ -531,7 +531,6 @@
 		EDF2BF1A1CCF15AD004BADF4 /* KSCrashSentry_MachException.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D5317EB765C0056DA83 /* KSCrashSentry_MachException.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BF1B1CCF15AD004BADF4 /* KSSysCtl.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8217EB765C0056DA83 /* KSSysCtl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BF1C1CCF15AD004BADF4 /* KSSystemInfoC.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8517EB765C0056DA83 /* KSSystemInfoC.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		EDF2BF291CCF1A27004BADF4 /* KSCrash_static-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = EDF2BF281CCF1A27004BADF4 /* KSCrash_static-Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1590,7 +1589,7 @@
 		CB52178417EB735D007CB3C1 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = "Karl Stenerud";
 				TargetAttributes = {
 					03DE7B691C84DEF700F789BA = {
@@ -1643,7 +1642,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EDF2BF291CCF1A27004BADF4 /* KSCrash_static-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/KSCrash-iOS.xcodeproj/xcshareddata/xcschemes/KSCrash.xcscheme
+++ b/iOS/KSCrash-iOS.xcodeproj/xcshareddata/xcschemes/KSCrash.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/iOS/KSCrash-iOS.xcodeproj/xcshareddata/xcschemes/KSCrashLib.xcscheme
+++ b/iOS/KSCrash-iOS.xcodeproj/xcshareddata/xcschemes/KSCrashLib.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Currently, `master` doesn't compile with Objective-C 2 since `IMP` is no longer callable. This is a simple workaround for this. Xcode also recommended updating project settings, so I accepted the automatic changes to make the warning go away.