### PR TITLE
add nil detect in toStringWithQuotesEscaped to prevent crash

### DIFF
--- a/Source/KSCrash/Reporting/Tools/KSHTTPMultipartPostBody.m
+++ b/Source/KSCrash/Reporting/Tools/KSHTTPMultipartPostBody.m
@@ -156,7 +156,7 @@
 
 - (NSString*) toStringWithQuotesEscaped:(NSString*) value
 {
-    return [value stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
+    return value == nil ? @"" : [value stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
 }
 
 - (NSData*) data


### PR DESCRIPTION
when field.name is nil, it will crash.
