### PR TITLE
Disable zombie catching by default

### DIFF
--- a/Source/KSCrash/Recording/KSCrash.h
+++ b/Source/KSCrash/Recording/KSCrash.h
@@ -124,7 +124,7 @@ typedef enum
 /** If YES, monitor all Objective-C/Swift deallocations and keep track of any
  * accesses after deallocation.
  *
- * Default: YES
+ * Default: NO
  */
 @property(nonatomic,readwrite,assign) bool catchZombies;
 

--- a/Source/KSCrash/Recording/KSCrash.m
+++ b/Source/KSCrash/Recording/KSCrash.m
@@ -158,7 +158,7 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(KSCrash)
         self.searchThreadNames = NO;
         self.searchQueueNames = NO;
         self.introspectMemory = YES;
-        self.catchZombies = YES;
+        self.catchZombies = NO;
         self.maxStoredReports = 5;
     }
     return self;


### PR DESCRIPTION
I don't think that enabling this functionality by default is a good idea. 