### PR TITLE
Namespacing KSSafeCollections category methods.

### DIFF
--- a/Source/KSCrash-Tests/KSSafeCollections_Tests.m
+++ b/Source/KSCrash-Tests/KSSafeCollections_Tests.m
@@ -38,7 +38,7 @@
 {
     NSMutableArray* array = [NSMutableArray array];
     id object = @"blah";
-    [array addObjectIfNotNil:object];
+    [array ksc_addObjectIfNotNil:object];
     XCTAssertTrue([array count] == 1, @"");
 }
 
@@ -46,7 +46,7 @@
 {
     NSMutableArray* array = [NSMutableArray array];
     id object = nil;
-    [array addObjectIfNotNil:object];
+    [array ksc_addObjectIfNotNil:object];
     XCTAssertTrue([array count] == 0, @"");
 }
 
@@ -54,7 +54,7 @@
 {
     NSMutableArray* array = [NSMutableArray array];
     id object = @"blah";
-    [array safeAddObject:object];
+    [array ksc_safeAddObject:object];
     XCTAssertTrue([array count] == 1, @"");
 }
 
@@ -62,7 +62,7 @@
 {
     NSMutableArray* array = [NSMutableArray array];
     id object = nil;
-    [array safeAddObject:object];
+    [array ksc_safeAddObject:object];
     XCTAssertTrue([array count] == 1, @"");
 }
 
@@ -70,7 +70,7 @@
 {
     NSMutableArray* array = [NSMutableArray arrayWithObjects:@"a", @"b", nil];
     id object = @"blah";
-    [array insertObjectIfNotNil:object atIndex:1];
+    [array ksc_insertObjectIfNotNil:object atIndex:1];
     XCTAssertTrue([array count] == 3, @"");
 }
 
@@ -78,7 +78,7 @@
 {
     NSMutableArray* array = [NSMutableArray arrayWithObjects:@"a", @"b", nil];
     id object = nil;
-    [array insertObjectIfNotNil:object atIndex:1];
+    [array ksc_insertObjectIfNotNil:object atIndex:1];
     XCTAssertTrue([array count] == 2, @"");
 }
 
@@ -86,7 +86,7 @@
 {
     NSMutableArray* array = [NSMutableArray arrayWithObjects:@"a", @"b", nil];
     id object = @"blah";
-    [array safeInsertObject:object atIndex:1];
+    [array ksc_safeInsertObject:object atIndex:1];
     XCTAssertTrue([array count] == 3, @"");
 }
 
@@ -94,7 +94,7 @@
 {
     NSMutableArray* array = [NSMutableArray arrayWithObjects:@"a", @"b", nil];
     id object = nil;
-    [array safeInsertObject:object atIndex:1];
+    [array ksc_safeInsertObject:object atIndex:1];
     XCTAssertTrue([array count] == 3, @"");
 }
 
@@ -103,7 +103,7 @@
     NSMutableDictionary* dict = [NSMutableDictionary dictionary];
     id key = @"key";
     id object = @"blah";
-    [dict setObjectIfNotNil:object forKey:key];
+    [dict ksc_setObjectIfNotNil:object forKey:key];
     id result = [dict objectForKey:key];
     XCTAssertEqual(result, object, @"");
 }
@@ -113,7 +113,7 @@
     NSMutableDictionary* dict = [NSMutableDictionary dictionary];
     id key = @"key";
     id object = nil;
-    [dict setObjectIfNotNil:object forKey:key];
+    [dict ksc_setObjectIfNotNil:object forKey:key];
     id result = [dict objectForKey:key];
     XCTAssertNil(result, @"");
 }
@@ -123,7 +123,7 @@
     NSMutableDictionary* dict = [NSMutableDictionary dictionary];
     id key = @"key";
     id object = @"blah";
-    [dict safeSetObject:object forKey:key];
+    [dict ksc_safeSetObject:object forKey:key];
     id result = [dict objectForKey:key];
     XCTAssertEqual(result, object, @"");
 }
@@ -133,7 +133,7 @@
     NSMutableDictionary* dict = [NSMutableDictionary dictionary];
     id key = @"key";
     id object = nil;
-    [dict safeSetObject:object forKey:key];
+    [dict ksc_safeSetObject:object forKey:key];
     id result = [dict objectForKey:key];
     XCTAssertNotNil(result, @"");
 }
@@ -143,7 +143,7 @@
     NSMutableDictionary* dict = [NSMutableDictionary dictionary];
     id key = @"key";
     id object = @"blah";
-    [dict setValueIfNotNil:object forKey:key];
+    [dict ksc_setValueIfNotNil:object forKey:key];
     id result = [dict valueForKey:key];
     XCTAssertEqual(result, object, @"");
 }
@@ -153,7 +153,7 @@
     NSMutableDictionary* dict = [NSMutableDictionary dictionary];
     id key = @"key";
     id object = nil;
-    [dict setValueIfNotNil:object forKey:key];
+    [dict ksc_setValueIfNotNil:object forKey:key];
     id result = [dict valueForKey:key];
     XCTAssertNil(result, @"");
 }
@@ -163,7 +163,7 @@
     NSMutableDictionary* dict = [NSMutableDictionary dictionary];
     id key = @"key";
     id object = @"blah";
-    [dict safeSetValue:object forKey:key];
+    [dict ksc_safeSetValue:object forKey:key];
     id result = [dict valueForKey:key];
     XCTAssertEqual(result, object, @"");
 }
@@ -173,7 +173,7 @@
     NSMutableDictionary* dict = [NSMutableDictionary dictionary];
     id key = @"key";
     id object = nil;
-    [dict safeSetValue:object forKey:key];
+    [dict ksc_safeSetValue:object forKey:key];
     id result = [dict valueForKey:key];
     XCTAssertNotNil(result, @"");
 }

--- a/Source/KSCrash/Recording/KSCrashReportStore.m
+++ b/Source/KSCrash/Recording/KSCrashReportStore.m
@@ -198,7 +198,7 @@
         return nil;
     }
     NSMutableDictionary* recrashReport = [self readReport:[self pathToRecrashReportWithID:reportID] error:nil];
-    [crashReport setObjectIfNotNil:recrashReport forKey:@KSCrashField_RecrashReport];
+    [crashReport ksc_setObjectIfNotNil:recrashReport forKey:@KSCrashField_RecrashReport];
 
     return crashReport;
 }
@@ -327,7 +327,7 @@
 
     NSMutableDictionary* mutableReport = [report mutableCopy];
     NSMutableDictionary* mutableInfo = [[report objectForKey:@KSCrashField_Report] mutableCopy];
-    [mutableReport setObjectIfNotNil:mutableInfo forKey:@KSCrashField_Report];
+    [mutableReport ksc_setObjectIfNotNil:mutableInfo forKey:@KSCrashField_Report];
 
     // Timestamp gets stored as a unix timestamp. Convert it to rfc3339.
     [self convertTimestamp:@KSCrashField_Timestamp inReport:mutableInfo];
@@ -341,9 +341,9 @@
                   inReport:mutableReport];
 
     NSMutableDictionary* crashReport = [[report objectForKey:@KSCrashField_Crash] mutableCopy];
-    [mutableReport setObjectIfNotNil:crashReport forKey:@KSCrashField_Crash];
+    [mutableReport ksc_setObjectIfNotNil:crashReport forKey:@KSCrashField_Crash];
     KSCrashDoctor* doctor = [KSCrashDoctor doctor];
-    [crashReport setObjectIfNotNil:[doctor diagnoseCrash:report] forKey:@KSCrashField_Diagnosis];
+    [crashReport ksc_setObjectIfNotNil:[doctor diagnoseCrash:report] forKey:@KSCrashField_Diagnosis];
 
     [self symbolicateField:@[@"threads", @"backtrace", @"contents", @"symbol_name"] inReport:crashReport okIfNotFound:YES];
     [self symbolicateField:@[@"error", @"cpp_exception", @"name"] inReport:crashReport okIfNotFound:YES];
@@ -378,7 +378,7 @@
         return;
     }
 
-    [report setObjectIfNotNil:[srcDict mergedInto:dstDict] forKey:dstKey];
+    [report ksc_setObjectIfNotNil:[srcDict mergedInto:dstDict] forKey:dstKey];
     [report removeObjectForKey:srcKey];
 }
 

--- a/Source/KSCrash/Recording/KSSystemInfo.m
+++ b/Source/KSCrash/Recording/KSSystemInfo.m
@@ -365,10 +365,10 @@
     const struct mach_header* header = _dyld_get_image_header(0);
 
 #if KSCRASH_HAS_UIDEVICE
-    [sysInfo safeSetObject:[UIDevice currentDevice].systemName forKey:@KSSystemField_SystemName];
-    [sysInfo safeSetObject:[UIDevice currentDevice].systemVersion forKey:@KSSystemField_SystemVersion];
+    [sysInfo ksc_safeSetObject:[UIDevice currentDevice].systemName forKey:@KSSystemField_SystemName];
+    [sysInfo ksc_safeSetObject:[UIDevice currentDevice].systemVersion forKey:@KSSystemField_SystemVersion];
 #else
-    [sysInfo safeSetObject:@"Mac OS" forKey:@KSSystemField_SystemName];
+    [sysInfo ksc_safeSetObject:@"Mac OS" forKey:@KSSystemField_SystemName];
     NSOperatingSystemVersion version =[NSProcessInfo processInfo].operatingSystemVersion;
     NSString* systemVersion;
     if(version.patchVersion == 0)
@@ -379,36 +379,36 @@
     {
         systemVersion = [NSString stringWithFormat:@"%ld.%ld.%ld", version.majorVersion, version.minorVersion, version.patchVersion];
     }
-    [sysInfo safeSetObject:systemVersion forKey:@KSSystemField_SystemVersion];
+    [sysInfo ksc_safeSetObject:systemVersion forKey:@KSSystemField_SystemVersion];
 #endif
-    [sysInfo safeSetObject:[self stringSysctl:@"hw.machine"] forKey:@KSSystemField_Machine];
-    [sysInfo safeSetObject:[self stringSysctl:@"hw.model"] forKey:@KSSystemField_Model];
-    [sysInfo safeSetObject:[self stringSysctl:@"kern.version"] forKey:@KSSystemField_KernelVersion];
-    [sysInfo safeSetObject:[self stringSysctl:@"kern.osversion"] forKey:@KSSystemField_OSVersion];
-    [sysInfo safeSetObject:[NSNumber numberWithBool:[self isJailbroken]] forKey:@KSSystemField_Jailbroken];
-    [sysInfo safeSetObject:[self dateSysctl:@"kern.boottime"] forKey:@KSSystemField_BootTime];
-    [sysInfo safeSetObject:[NSDate date] forKey:@KSSystemField_AppStartTime];
-    [sysInfo safeSetObject:[self executablePath] forKey:@KSSystemField_ExecutablePath];
-    [sysInfo safeSetObject:[infoDict objectForKey:@"CFBundleExecutable"] forKey:@KSSystemField_Executable];
-    [sysInfo safeSetObject:[infoDict objectForKey:@"CFBundleIdentifier"] forKey:@KSSystemField_BundleID];
-    [sysInfo safeSetObject:[infoDict objectForKey:@"CFBundleName"] forKey:@KSSystemField_BundleName];
-    [sysInfo safeSetObject:[infoDict objectForKey:@"CFBundleVersion"] forKey:@KSSystemField_BundleVersion];
-    [sysInfo safeSetObject:[infoDict objectForKey:@"CFBundleShortVersionString"] forKey:@KSSystemField_BundleShortVersion];
-    [sysInfo safeSetObject:[self appUUID] forKey:@KSSystemField_AppUUID];
-    [sysInfo safeSetObject:[self currentCPUArch] forKey:@KSSystemField_CPUArch];
-    [sysInfo safeSetObject:[self int32Sysctl:@"hw.cputype"] forKey:@KSSystemField_CPUType];
-    [sysInfo safeSetObject:[self int32Sysctl:@"hw.cpusubtype"] forKey:@KSSystemField_CPUSubType];
-    [sysInfo safeSetObject:[NSNumber numberWithInt:header->cputype] forKey:@KSSystemField_BinaryCPUType];
-    [sysInfo safeSetObject:[NSNumber numberWithInt:header->cpusubtype] forKey:@KSSystemField_BinaryCPUSubType];
-    [sysInfo safeSetObject:[[NSTimeZone localTimeZone] abbreviation] forKey:@KSSystemField_TimeZone];
-    [sysInfo safeSetObject:[NSProcessInfo processInfo].processName forKey:@KSSystemField_ProcessName];
-    [sysInfo safeSetObject:[NSNumber numberWithInt:[NSProcessInfo processInfo].processIdentifier] forKey:@KSSystemField_ProcessID];
-    [sysInfo safeSetObject:[NSNumber numberWithInt:getppid()] forKey:@KSSystemField_ParentProcessID];
-    [sysInfo safeSetObject:[self deviceAndAppHash] forKey:@KSSystemField_DeviceAppHash];
-    [sysInfo safeSetObject:[KSSystemInfo buildType] forKey:@KSSystemField_BuildType];
+    [sysInfo ksc_safeSetObject:[self stringSysctl:@"hw.machine"] forKey:@KSSystemField_Machine];
+    [sysInfo ksc_safeSetObject:[self stringSysctl:@"hw.model"] forKey:@KSSystemField_Model];
+    [sysInfo ksc_safeSetObject:[self stringSysctl:@"kern.version"] forKey:@KSSystemField_KernelVersion];
+    [sysInfo ksc_safeSetObject:[self stringSysctl:@"kern.osversion"] forKey:@KSSystemField_OSVersion];
+    [sysInfo ksc_safeSetObject:[NSNumber numberWithBool:[self isJailbroken]] forKey:@KSSystemField_Jailbroken];
+    [sysInfo ksc_safeSetObject:[self dateSysctl:@"kern.boottime"] forKey:@KSSystemField_BootTime];
+    [sysInfo ksc_safeSetObject:[NSDate date] forKey:@KSSystemField_AppStartTime];
+    [sysInfo ksc_safeSetObject:[self executablePath] forKey:@KSSystemField_ExecutablePath];
+    [sysInfo ksc_safeSetObject:[infoDict objectForKey:@"CFBundleExecutable"] forKey:@KSSystemField_Executable];
+    [sysInfo ksc_safeSetObject:[infoDict objectForKey:@"CFBundleIdentifier"] forKey:@KSSystemField_BundleID];
+    [sysInfo ksc_safeSetObject:[infoDict objectForKey:@"CFBundleName"] forKey:@KSSystemField_BundleName];
+    [sysInfo ksc_safeSetObject:[infoDict objectForKey:@"CFBundleVersion"] forKey:@KSSystemField_BundleVersion];
+    [sysInfo ksc_safeSetObject:[infoDict objectForKey:@"CFBundleShortVersionString"] forKey:@KSSystemField_BundleShortVersion];
+    [sysInfo ksc_safeSetObject:[self appUUID] forKey:@KSSystemField_AppUUID];
+    [sysInfo ksc_safeSetObject:[self currentCPUArch] forKey:@KSSystemField_CPUArch];
+    [sysInfo ksc_safeSetObject:[self int32Sysctl:@"hw.cputype"] forKey:@KSSystemField_CPUType];
+    [sysInfo ksc_safeSetObject:[self int32Sysctl:@"hw.cpusubtype"] forKey:@KSSystemField_CPUSubType];
+    [sysInfo ksc_safeSetObject:[NSNumber numberWithInt:header->cputype] forKey:@KSSystemField_BinaryCPUType];
+    [sysInfo ksc_safeSetObject:[NSNumber numberWithInt:header->cpusubtype] forKey:@KSSystemField_BinaryCPUSubType];
+    [sysInfo ksc_safeSetObject:[[NSTimeZone localTimeZone] abbreviation] forKey:@KSSystemField_TimeZone];
+    [sysInfo ksc_safeSetObject:[NSProcessInfo processInfo].processName forKey:@KSSystemField_ProcessName];
+    [sysInfo ksc_safeSetObject:[NSNumber numberWithInt:[NSProcessInfo processInfo].processIdentifier] forKey:@KSSystemField_ProcessID];
+    [sysInfo ksc_safeSetObject:[NSNumber numberWithInt:getppid()] forKey:@KSSystemField_ParentProcessID];
+    [sysInfo ksc_safeSetObject:[self deviceAndAppHash] forKey:@KSSystemField_DeviceAppHash];
+    [sysInfo ksc_safeSetObject:[KSSystemInfo buildType] forKey:@KSSystemField_BuildType];
 
     NSDictionary* memory = [NSDictionary dictionaryWithObject:[self int64Sysctl:@"hw.memsize"] forKey:@KSSystemField_Size];
-    [sysInfo safeSetObject:memory forKey:@KSSystemField_Memory];
+    [sysInfo ksc_safeSetObject:memory forKey:@KSSystemField_Memory];
 
     return sysInfo;
 }

--- a/Source/KSCrash/Recording/Tools/KSSafeCollections.h
+++ b/Source/KSCrash/Recording/Tools/KSSafeCollections.h
@@ -30,25 +30,25 @@
 
 @interface NSMutableArray (KSSafeCollections)
 
-- (void) addObjectIfNotNil:(id) object;
+- (void) ksc_addObjectIfNotNil:(id) object;
 
-- (void) safeAddObject:(id) object;
+- (void) ksc_safeAddObject:(id) object;
 
-- (void) insertObjectIfNotNil:(id) object atIndex:(NSUInteger) index;
+- (void) ksc_insertObjectIfNotNil:(id) object atIndex:(NSUInteger) index;
 
-- (void) safeInsertObject:(id) object atIndex:(NSUInteger) index;
+- (void) ksc_safeInsertObject:(id) object atIndex:(NSUInteger) index;
 
 @end
 
 
 @interface NSMutableDictionary (KSSafeCollections)
 
-- (void) setObjectIfNotNil:(id) object forKey:(id) key;
+- (void) ksc_setObjectIfNotNil:(id) object forKey:(id) key;
 
-- (void) safeSetObject:(id) object forKey:(id) key;
+- (void) ksc_safeSetObject:(id) object forKey:(id) key;
 
-- (void) setValueIfNotNil:(id) value forKey:(NSString*) key;
+- (void) ksc_setValueIfNotNil:(id) value forKey:(NSString*) key;
 
-- (void) safeSetValue:(id) value forKey:(NSString*) key;
+- (void) ksc_safeSetValue:(id) value forKey:(NSString*) key;
 
 @end

--- a/Source/KSCrash/Recording/Tools/KSSafeCollections.m
+++ b/Source/KSCrash/Recording/Tools/KSSafeCollections.m
@@ -35,7 +35,7 @@ static inline id safeValue(id value)
 
 @implementation NSMutableArray (KSSafeCollections)
 
-- (void) addObjectIfNotNil:(id) object
+- (void) ksc_addObjectIfNotNil:(id) object
 {
     if(object != nil)
     {
@@ -43,12 +43,12 @@ static inline id safeValue(id value)
     }
 }
 
-- (void) safeAddObject:(id) object
+- (void) ksc_safeAddObject:(id) object
 {
     [self addObject:safeValue(object)];
 }
 
-- (void) insertObjectIfNotNil:(id) object atIndex:(NSUInteger) index
+- (void) ksc_insertObjectIfNotNil:(id) object atIndex:(NSUInteger) index
 {
     if(object != nil)
     {
@@ -56,7 +56,7 @@ static inline id safeValue(id value)
     }
 }
 
-- (void) safeInsertObject:(id) object atIndex:(NSUInteger) index
+- (void) ksc_safeInsertObject:(id) object atIndex:(NSUInteger) index
 {
     [self insertObject:safeValue(object) atIndex:index];
 }
@@ -65,7 +65,7 @@ static inline id safeValue(id value)
 
 @implementation NSMutableDictionary (KSSafeCollections)
 
-- (void) setObjectIfNotNil:(id) object forKey:(id) key
+- (void) ksc_setObjectIfNotNil:(id) object forKey:(id) key
 {
     if(object != nil && key != nil)
     {
@@ -73,12 +73,12 @@ static inline id safeValue(id value)
     }
 }
 
-- (void) safeSetObject:(id) object forKey:(id) key
+- (void) ksc_safeSetObject:(id) object forKey:(id) key
 {
     [self setObject:safeValue(object) forKey:key];
 }
 
-- (void) setValueIfNotNil:(id) value forKey:(NSString*) key
+- (void) ksc_setValueIfNotNil:(id) value forKey:(NSString*) key
 {
     if(value != nil && key != nil)
     {
@@ -86,7 +86,7 @@ static inline id safeValue(id value)
     }
 }
 
-- (void) safeSetValue:(id) value forKey:(NSString*) key
+- (void) ksc_safeSetValue:(id) value forKey:(NSString*) key
 {
     [self setValue:safeValue(value) forKey:key];
 }

--- a/Source/KSCrash/Reporting/Filters/KSCrashReportFilterAppleFmt.m
+++ b/Source/KSCrash/Reporting/Filters/KSCrashReportFilterAppleFmt.m
@@ -195,7 +195,7 @@ NSDictionary* g_registerOrders;
     {
         if([self majorVersion:report] == kExpectedMajorVersion)
         {
-            [filteredReports addObjectIfNotNil:[self toAppleFormat:report]];
+            [filteredReports ksc_addObjectIfNotNil:[self toAppleFormat:report]];
         }
     }
 


### PR DESCRIPTION
Hi there,

It happens to me that those category methods defined in `KSSafeCollections.h` name collide with some of the existing methods from my own project. A quick [GitHub search](https://github.com/search?q=safeAddObject&type=Code&utf8=✓) shows that method names such as `[NSMutableArray safeAddObject:]` are quite popular from all over the GitHub universe. 

In this pull request I renamed all the methods defined in `KSSafeCollections.h` by prefixing them with `ksc_`. This pull request is based on the [current tip](https://github.com/kstenerud/KSCrash/commit/27525817d5b8fbc756e29e62da0e048cf52640d3) of your master branch (tag 1.6.2). Please take a look.

Cheers,
Di