### PR TITLE
Fix Apple formatted crash time locale

### DIFF
--- a/Source/KSCrash/Reporting/Filters/KSCrashReportFilterAppleFmt.m
+++ b/Source/KSCrash/Reporting/Filters/KSCrashReportFilterAppleFmt.m
@@ -115,6 +115,7 @@ NSDictionary* g_registerOrders;
 + (void) initialize
 {
     g_dateFormatter = [[NSDateFormatter alloc] init];
+    [g_dateFormatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
     [g_dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss.SSS ZZZ"];
 
     NSArray* armOrder = [NSArray arrayWithObjects:


### PR DESCRIPTION
This commit fixes crashes with strings like:
```
Date/Time:       ٢٠١٦-٠٦-٠٥ ٠٢:٣٧:٤١.٠٠٠ +0300
```