### PR TITLE
Guard duplicate imports of KSCrashReportFilter

### DIFF
--- a/Source/KSCrash/Reporting/Filters/KSCrashReportFilter.h
+++ b/Source/KSCrash/Reporting/Filters/KSCrashReportFilter.h
@@ -24,9 +24,11 @@
 // THE SOFTWARE.
 //
 
+#ifndef KSCrashReportFilter_h
+#define KSCrashReportFilter_h
+
 
 #import <Foundation/Foundation.h>
-
 
 /** Callback for filter operations.
  *
@@ -205,3 +207,5 @@ typedef void(^KSCrashReportFilterCompletion)(NSArray* filteredReports,
 - (id) initWithKeys:(id) firstKeyPath, ... NS_REQUIRES_NIL_TERMINATION;
 
 @end
+
+#endif


### PR DESCRIPTION
Building the KSCrash.framework target within Mac.xcworkspace currently fails due to duplicate header imports of KSCrashReportFilter.h. This adds a guard define to prevent this issue.

Targentially related, are you interested in accepting a PR of a configuration file for testing KSCrash via a CI service?