### PR TITLE
Use UInteger instead to prevent warning

### DIFF
--- a/Source/KSCrash/Recording/KSCrashReport.c
+++ b/Source/KSCrash/Recording/KSCrashReport.c
@@ -1285,9 +1285,9 @@ static void writeBinaryImage(const KSCrashReportWriter* const writer,
         writer->addUUIDElement(writer, KSCrashField_UUID, image.uuid);
         writer->addIntegerElement(writer, KSCrashField_CPUType, image.cpuType);
         writer->addIntegerElement(writer, KSCrashField_CPUSubType, image.cpuSubType);
-        writer->addIntegerElement(writer, KSCrashField_ImageMajorVersion, image.majorVersion);
-        writer->addIntegerElement(writer, KSCrashField_ImageMinorVersion, image.minorVersion);
-        writer->addIntegerElement(writer, KSCrashField_ImageRevisionVersion, image.revisionVersion);
+        writer->addUIntegerElement(writer, KSCrashField_ImageMajorVersion, image.majorVersion);
+        writer->addUIntegerElement(writer, KSCrashField_ImageMinorVersion, image.minorVersion);
+        writer->addUIntegerElement(writer, KSCrashField_ImageRevisionVersion, image.revisionVersion);
     }
     writer->endContainer(writer);
 }


### PR DESCRIPTION
Strangely only appeared when installing it through carthage and not when building the project.