### PR TITLE
Framework/Module support: Fixed KSCrashMonitor.h to be public.

### DIFF
--- a/Mac/KSCrash-Mac.xcodeproj/project.pbxproj
+++ b/Mac/KSCrash-Mac.xcodeproj/project.pbxproj
@@ -257,7 +257,7 @@
 		CB8E563817EB9AFD000C56D3 /* KSCrashMonitor_System.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E562A17EB9AFD000C56D3 /* KSCrashMonitor_System.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CB8E563917EB9AFD000C56D3 /* KSCrashMonitor_System.m in Sources */ = {isa = PBXBuildFile; fileRef = CB8E562B17EB9AFD000C56D3 /* KSCrashMonitor_System.m */; };
 		CB8E564C17EB9B35000C56D3 /* KSCrashMonitor.c in Sources */ = {isa = PBXBuildFile; fileRef = CB8E563D17EB9B35000C56D3 /* KSCrashMonitor.c */; };
-		CB8E564D17EB9B35000C56D3 /* KSCrashMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E563E17EB9B35000C56D3 /* KSCrashMonitor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CB8E564D17EB9B35000C56D3 /* KSCrashMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E563E17EB9B35000C56D3 /* KSCrashMonitor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CB8E564E17EB9B35000C56D3 /* KSCrashMonitor_CPPException.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E563F17EB9B35000C56D3 /* KSCrashMonitor_CPPException.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB8E564F17EB9B35000C56D3 /* KSCrashMonitor_CPPException.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CB8E564017EB9B35000C56D3 /* KSCrashMonitor_CPPException.cpp */; };
 		CB8E565017EB9B35000C56D3 /* KSCrashMonitor_Deadlock.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8E564117EB9B35000C56D3 /* KSCrashMonitor_Deadlock.h */; settings = {ATTRIBUTES = (Private, ); }; };


### PR DESCRIPTION
KSCrash does not compile as a framework/module with Xcode 8.3.1
Error in KSCrashMonitor_System.h, because it s public and imports a private Header.
Public headers fail to import private headers in general.
As KSCrashFramework.h imports KSCrashMonitor_System.h,
projects that import KSCrashFramework.h do not compile.
This is a fix for it.