### PR TITLE
Add C API to allow clients to react to the report being finished writing

### DIFF
--- a/Source/KSCrash-Tests/KSCrashReportStore_Tests.m
+++ b/Source/KSCrash-Tests/KSCrashReportStore_Tests.m
@@ -90,7 +90,7 @@
 {
     NSData* crashData = [contents dataUsingEncoding:NSUTF8StringEncoding];
     char crashReportPath[KSCRS_MAX_PATH_LENGTH];
-    kscrs_getNextCrashReportPath(crashReportPath);
+    kscrs_getNextCrashReport(crashReportPath);
     [crashData writeToFile:[NSString stringWithUTF8String:crashReportPath] atomically:YES];
     return [self getReportIDFromPath:[NSString stringWithUTF8String:crashReportPath]];
 }

--- a/Source/KSCrash/Recording/KSCrashC.c
+++ b/Source/KSCrash/Recording/KSCrashC.c
@@ -63,6 +63,7 @@ static bool g_shouldPrintPreviousLog = false;
 char g_consoleLogPath[KSFU_MAX_PATH_LENGTH];
 static KSCrashMonitorType g_monitoring = KSCrashMonitorTypeProductionSafeMinimal;
 static char g_lastCrashReportFilePath[KSFU_MAX_PATH_LENGTH];
+static KSReportWrittenCallback g_reportWrittenCallback;
 
 
 // ============================================================================
@@ -105,9 +106,14 @@ static void onCrash(struct KSCrash_MonitorContext* monitorContext)
     else
     {
         char crashReportFilePath[KSFU_MAX_PATH_LENGTH];
-        kscrs_getNextCrashReport(crashReportFilePath);
+        int64_t reportID = kscrs_getNextCrashReport(crashReportFilePath);
         strncpy(g_lastCrashReportFilePath, crashReportFilePath, sizeof(g_lastCrashReportFilePath));
         kscrashreport_writeStandardReport(monitorContext, crashReportFilePath);
+
+        if(g_reportWrittenCallback)
+        {
+            g_reportWrittenCallback(reportID);
+        }
     }
 }
 
@@ -191,6 +197,11 @@ void kscrash_setDoNotIntrospectClasses(const char** doNotIntrospectClasses, int 
 void kscrash_setCrashNotifyCallback(const KSReportWriteCallback onCrashNotify)
 {
     kscrashreport_setUserSectionWriteCallback(onCrashNotify);
+}
+
+void kscrash_setReportWrittenCallback(const KSReportWrittenCallback onReportWrittenNotify)
+{
+    g_reportWrittenCallback = onReportWrittenNotify;
 }
 
 void kscrash_setAddConsoleLogToReport(bool shouldAddConsoleLogToReport)

--- a/Source/KSCrash/Recording/KSCrashC.c
+++ b/Source/KSCrash/Recording/KSCrashC.c
@@ -105,7 +105,7 @@ static void onCrash(struct KSCrash_MonitorContext* monitorContext)
     else
     {
         char crashReportFilePath[KSFU_MAX_PATH_LENGTH];
-        kscrs_getNextCrashReportPath(crashReportFilePath);
+        kscrs_getNextCrashReport(crashReportFilePath);
         strncpy(g_lastCrashReportFilePath, crashReportFilePath, sizeof(g_lastCrashReportFilePath));
         kscrashreport_writeStandardReport(monitorContext, crashReportFilePath);
     }

--- a/Source/KSCrash/Recording/KSCrashC.h
+++ b/Source/KSCrash/Recording/KSCrashC.h
@@ -119,6 +119,21 @@ void kscrash_setDoNotIntrospectClasses(const char** doNotIntrospectClasses, int 
  */
 void kscrash_setCrashNotifyCallback(const KSReportWriteCallback onCrashNotify);
 
+typedef void (*KSReportWrittenCallback)(int64_t reportID);
+
+/** Set the callback to invoke upon finishing writing a crash report.
+ *
+ * WARNING: Only call async-safe functions from this function! DO NOT call
+ * Objective-C methods!!!
+ *
+ * @param onReportWrittenNotify Function to call after writing a crash report to
+ *                      give the callee an opportunity to react to the report.
+ *                      NULL = ignore.
+ *
+ * Default: NULL
+ */
+void kscrash_setReportWrittenCallback(const KSReportWrittenCallback onReportWrittenNotify);
+
 /** Set if KSLOG console messages should be appended to the report.
  *
  * @param shouldAddConsoleLogToReport If true, add the log to the report.

--- a/Source/KSCrash/Recording/KSCrashReportStore.c
+++ b/Source/KSCrash/Recording/KSCrashReportStore.c
@@ -191,9 +191,14 @@ void kscrs_initialize(const char* appName, const char* reportsPath)
     pthread_mutex_unlock(&g_mutex);
 }
 
-void kscrs_getNextCrashReportPath(char* crashReportPathBuffer)
+int64_t kscrs_getNextCrashReport(char* crashReportPathBuffer)
 {
-    getCrashReportPathByID(getNextUniqueID(), crashReportPathBuffer);
+    int64_t nextID = getNextUniqueID();
+    if(crashReportPathBuffer)
+    {
+        getCrashReportPathByID(nextID, crashReportPathBuffer);
+    }
+    return nextID;
 }
 
 int kscrs_getReportCount()

--- a/Source/KSCrash/Recording/KSCrashReportStore.h
+++ b/Source/KSCrash/Recording/KSCrashReportStore.h
@@ -43,12 +43,14 @@ extern "C" {
  */
 void kscrs_initialize(const char* appName, const char* reportsPath);
 
-/** Get the path to the next crash report to be generated.
+/** Get the next crash report to be generated.
  * Max length for paths is KSCRS_MAX_PATH_LENGTH
  *
  * @param crashReportPathBuffer Buffer to store the crash report path.
+ *
+ * @return the report ID of the next report.
  */
-void kscrs_getNextCrashReportPath(char* crashReportPathBuffer);
+int64_t kscrs_getNextCrashReport(char* crashReportPathBuffer);
 
 /** Get the number of reports on disk.
  */


### PR DESCRIPTION
The existing kscrash_setCrashNotifyCallback() is called during report
writing, and is meant to be used for adding user info to the report.

To be able to e.g. spawn a new process that reads and sends the finished
report, we need a callback that happens after the report has been fully
written.