### PR TITLE
Core subspec

### DIFF
--- a/KSCrash.podspec
+++ b/KSCrash.podspec
@@ -123,4 +123,12 @@ Pod::Spec.new do |s|
     installations.source_files = 'Source/KSCrash/Installations/**/*.{h,m,mm,c,cpp}'
   end
 
+  s.subspec 'Core' do |core|
+    core.dependency 'KSCrash/Reporting/Filters/Basic'
+    core.source_files = 'Source/KSCrash/Installations/KSCrashInstallation.h',
+                        'Source/KSCrash/Installations/KSCrashInstallation.m',
+                        'Source/KSCrash/Installations/KSCrashInstallation+Private.h',
+                        'Source/KSCrash/Reporting/Tools/KSCString.{h,m}'
+  end
+
 end


### PR DESCRIPTION
This adds a `Core` subspec which should be the minimum requirement for crash handling.
This would require a Cocoapod release in order for Sentry to take advantage of.

A quick local test with the `Core` subspec files was successful, I cannot guarantee that I have to add more files after this is released and I tested everything.

But in order to test it, there must be a new CocoaPod release first 😅 