### PR TITLE
Increase decodebuffer of JSONElement

### DIFF
--- a/Source/KSCrash/Recording/Tools/KSJSONCodec.c
+++ b/Source/KSCrash/Recording/Tools/KSJSONCodec.c
@@ -1358,7 +1358,7 @@ int ksjson_addJSONElement(KSJSONEncodeContext* const encodeContext,
         .onStringElement = addJSONFromFile_onStringElement,
     };
     char nameBuffer[100] = {0};
-    char stringBuffer[500] = {0};
+    char stringBuffer[5000] = {0};
     KSJSONDecodeContext decodeContext =
     {
         .bufferPtr = jsonData,


### PR DESCRIPTION
@kstenerud I am not 100% confident with the change, you be the judge. There should be a reason why this is so low, right?

Background story:
We are writing a whole dump of a Javascript stacktrace in the report whenever we crash on react-native. It sometimes happens that this dump is > 500.
Increasing the limit fixes the `KSJSON_ERROR_DATA_TOO_LONG` issue we are getting.

If this change is fine, please merge it so we can upgrade it, thx man 👍 