### PR TITLE
Expose uncaughtExceptionHandler as property in KSCrash

### DIFF
--- a/Source/KSCrash/Recording/KSCrash.h
+++ b/Source/KSCrash/Recording/KSCrash.h
@@ -166,6 +166,8 @@ typedef enum
 /** Which languages to demangle when getting stack traces (default KSCrashDemangleLanguageAll) */
 @property(nonatomic,readwrite,assign) KSCrashDemangleLanguage demangleLanguages;
 
+/** Exposes the uncaughtExceptionHandler if set from KSCrash. Is nil if debugger is running. **/
+@property (nonatomic, assign) NSUncaughtExceptionHandler *uncaughtExceptionHandler;
 
 #pragma mark - Information -
 

--- a/Source/KSCrash/Recording/Monitors/KSCrashMonitor_NSException.m
+++ b/Source/KSCrash/Recording/Monitors/KSCrashMonitor_NSException.m
@@ -24,7 +24,7 @@
 // THE SOFTWARE.
 //
 
-
+#import "KSCrash.h"
 #import "KSCrashMonitor_NSException.h"
 #import "KSStackCursor_Backtrace.h"
 #include "KSCrashMonitorContext.h"
@@ -123,6 +123,7 @@ static void setEnabled(bool isEnabled)
             
             KSLOG_DEBUG(@"Setting new handler.");
             NSSetUncaughtExceptionHandler(&handleException);
+            KSCrash.sharedInstance.uncaughtExceptionHandler = &handleException;
         }
         else
         {


### PR DESCRIPTION
This is needed to correctly register and catch uncaught exceptions on macOS.
You need to register a principleClass and overwrite 
`- (void)reportException:(NSException *)exception`

This is the Sentry part of it: https://github.com/getsentry/sentry-cocoa/pull/204