### PR TITLE
Initialization with custom base path

### DIFF
--- a/Source/KSCrash/Recording/KSCrash.h
+++ b/Source/KSCrash/Recording/KSCrash.h
@@ -55,6 +55,9 @@ typedef enum
 
 #pragma mark - Configuration -
 
+/** Init KSCrash instance with custom base path. */
+- (id) initWithBasePath:(NSString *)basePath;
+
 /** A dictionary containing any info you'd like to appear in crash reports. Must
  * contain only JSON-safe data: NSString for keys, and NSDictionary, NSArray,
  * NSString, NSDate, and NSNumber for values.

--- a/Source/KSCrash/Recording/KSCrash.m
+++ b/Source/KSCrash/Recording/KSCrash.m
@@ -128,10 +128,15 @@ static NSString* getBasePath()
 
 - (id) init
 {
+    return [self initWithBasePath:getBasePath()];
+}
+
+- (id) initWithBasePath:(NSString *)basePath
+{
     if((self = [super init]))
     {
         self.bundleName = getBundleName();
-        self.basePath = getBasePath();
+        self.basePath = basePath;
         if(self.basePath == nil)
         {
             KSLOG_ERROR(@"Failed to initialize crash handler. Crash reporting disabled.");


### PR DESCRIPTION
Migration from 1.8.6 is not so easy. It's possible, that I am the only user of a custom-reports-and-stuff-path, but I need this kind of constructor.