### PR TITLE
Fix syntax errors

### DIFF
--- a/Mac/Example-Apps-Mac.xcodeproj/project.pbxproj
+++ b/Mac/Example-Apps-Mac.xcodeproj/project.pbxproj
@@ -465,10 +465,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/Mac-beusbddefllzqoanxuparffwsspt/Build/Products/Debug",
-				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Simple-Example/Simple-Example-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -488,10 +484,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/Mac-beusbddefllzqoanxuparffwsspt/Build/Products/Debug",
-				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Simple-Example/Simple-Example-Prefix.pch";
 				INFOPLIST_FILE = "Simple-Example/Simple-Example-Info.plist";

--- a/Source/KSCrash/Recording/Monitors/KSCrashMonitor_System.m
+++ b/Source/KSCrash/Recording/Monitors/KSCrashMonitor_System.m
@@ -499,8 +499,11 @@ static void initialize()
 #if KSCRASH_HOST_WATCH
         g_systemData.systemName = "watchOS";
 #endif
-        NSOperatingSystemVersion version = {0};
-        @available(macOS 10.10, *) version = [NSProcessInfo processInfo].operatingSystemVersion;
+        NSOperatingSystemVersion version = {0, 0, 0};
+        if(@available(macOS 10.10, *))
+        {
+            version = [NSProcessInfo processInfo].operatingSystemVersion;
+        }
         NSString* systemVersion;
         if(version.patchVersion == 0)
         {

--- a/Source/KSCrash/Reporting/Tools/KSReachabilityKSCrash.m
+++ b/Source/KSCrash/Reporting/Tools/KSReachabilityKSCrash.m
@@ -365,7 +365,7 @@ static void onReachabilityChanged(__unused SCNetworkReachabilityRef target,
 
 @implementation KSReachableOperationKSCrash
 
-+ (KSReachableOperationKSCrash*) operationWithHost:(NSString*) hostname
++ (KSReachableOperationKSCrash*) operationWithHost:(NSString*) host
                                          allowWWAN:(BOOL) allowWWAN
                                              block:(void(^)(void)) block;
 {


### PR DESCRIPTION
This fixes minor syntax errors I found using `pod lib lint KSCrash.podspec`. Also, removed an unnecessary framework path in the Mac workspace.