### PR TITLE
Add missing header file KSSystemCapabilities.h for KSCrash.m

### DIFF
--- a/Source/KSCrash/Recording/KSCrash.m
+++ b/Source/KSCrash/Recording/KSCrash.m
@@ -35,6 +35,7 @@
 #import "NSError+SimpleConstructor.h"
 #import "KSCrashMonitorContext.h"
 #import "KSCrashMonitor_System.h"
+#import "KSSystemCapabilities.h"
 
 //#define KSLogger_LocalLevel TRACE
 #import "KSLogger.h"


### PR DESCRIPTION
The Application States within crash log does not work fine, it seems that KSCrash.m forgot import KSSystemCapabilities.h. Therefore, notification observer can not work within KSCRASH_HAS_UIAPPLICATION macro.