### PR TITLE
Fix app versions order in Apple-like formatted crash log

### DIFF
--- a/Source/KSCrash/Reporting/Filters/KSCrashReportFilterAppleFmt.m
+++ b/Source/KSCrash/Reporting/Filters/KSCrashReportFilterAppleFmt.m
@@ -439,8 +439,8 @@ static NSDictionary* g_registerOrders;
     [str appendFormat:@"Path:            %@\n", executablePath];
     [str appendFormat:@"Identifier:      %@\n", [system objectForKey:@KSCrashField_BundleID]];
     [str appendFormat:@"Version:         %@ (%@)\n",
-     [system objectForKey:@KSCrashField_BundleShortVersion],
-     [system objectForKey:@KSCrashField_BundleVersion]];
+     [system objectForKey:@KSCrashField_BundleVersion],
+     [system objectForKey:@KSCrashField_BundleShortVersion]];
     [str appendFormat:@"Code Type:       %@\n", cpuArchType];
     [str appendFormat:@"Parent Process:  ? [%@]\n",
      [system objectForKey:@KSCrashField_ParentProcessID]];


### PR DESCRIPTION
I'm not quite sure about this change. It is kinda breaking one. But according to Apple documentation of crash logs, versions should be in this order. I've checked logs generated by devices in `~/Library/Logs/CrashReporter/MobileDevice` and they have such format.

Here is a reference: https://developer.apple.com/library/content/technotes/tn2151/_index.html
> Version: The version of the process that crashed. The value for this field is a concatenation of the crashed application's CFBundleVersion and CFBundleVersionString.

![2018-03-23_20-19-13](https://user-images.githubusercontent.com/443972/37843979-7ad2ae78-2ed7-11e8-97ba-4484adb8101f.png)