### PR TITLE
Temporally Fixing dispatch-Queues names crash

### DIFF
--- a/Source/KSCrash/Recording/Tools/KSThread.c
+++ b/Source/KSCrash/Recording/Tools/KSThread.c
@@ -91,7 +91,12 @@ bool ksthread_getQueueName(const KSThread thread, char* const buffer, int bufLen
     }
     
     dispatch_queue_t dispatch_queue = *dispatch_queue_ptr;
-    const char* queue_name = dispatch_queue_get_label(dispatch_queue);
+    
+    const char* queue_name = NULL;
+    if (dispatch_queue == dispatch_get_main_queue()) {
+        queue_name = dispatch_queue_get_label(dispatch_get_main_queue());
+    }
+    
     if(queue_name == NULL)
     {
         KSLOG_TRACE("Error while getting dispatch queue name : %p", dispatch_queue);


### PR DESCRIPTION
I do not know actually how to reproduce the crash and why for some reason the dispatch_queue address is outside the memory bounds of the application.
But I think this a good compromise with this PR can only show the name of main-thread only and will stop the app from crash.
https://github.com/kstenerud/KSCrash/issues/207