### PR TITLE
ref: Set default log level to error

### DIFF
--- a/Source/KSCrash/Recording/Tools/KSLogger.h
+++ b/Source/KSCrash/Recording/Tools/KSLogger.h
@@ -46,7 +46,7 @@
  * =====
  *
  * Set the log level in your "Preprocessor Macros" build setting. You may choose
- * TRACE, DEBUG, INFO, WARN, ERROR. If nothing is set, it defaults to INFO.
+ * TRACE, DEBUG, INFO, WARN, ERROR. If nothing is set, it defaults to ERROR.
  *
  * Example: KSLogger_Level=WARN
  *
@@ -229,7 +229,7 @@ void i_kslog_logCBasic(const char* fmt, ...);
 
 
 #ifndef KSLogger_Level
-    #define KSLogger_Level KSLogger_Level_Info
+    #define KSLogger_Level KSLogger_Level_Error
 #endif
 
 #ifndef KSLogger_LocalLevel


### PR DESCRIPTION
ref: https://github.com/getsentry/sentry-cocoa/issues/242

If you are running a Swift project adding a preprocessor macro isn't that simple as it used to be, it also feels very old school way of handling this.
Since I don't want to rewrite too much I think it would be reasonable to set the default log level to error and if people actually want to debug something they should set the bar lower.

Besides that, e.g. Sentry using KSCrash as a dependency it's not possible to configure the log level on the fly and also not once via `#define KSLogger_LocalLevel` since it's already too late.
With this change, you won't miss the important stuff.

I hope this makes sense and gets merged 👍 