### PR TITLE
Disable queue names searching by default

### DIFF
--- a/Source/KSCrash/Recording/KSCrash.h
+++ b/Source/KSCrash/Recording/KSCrash.h
@@ -107,6 +107,16 @@ typedef enum
  */
 @property(nonatomic,readwrite,assign) double deadlockWatchdogInterval;
 
+/** If YES, attempt to fetch dispatch queue names for each running thread.
+ *
+ * WARNING: There is a chance that this will crash on a ksthread_getQueueName() call!
+ *
+ * Enable at your own risk.
+ *
+ * Default: NO
+ */
+@property(nonatomic,readwrite,assign) BOOL searchQueueNames;
+
 /** If YES, introspect memory contents during a crash.
  * Any Objective-C objects or C strings near the stack pointer or referenced by
  * cpu registers or exceptions will be recorded in the crash report, along with

--- a/Source/KSCrash/Recording/KSCrash.m
+++ b/Source/KSCrash/Recording/KSCrash.m
@@ -100,6 +100,7 @@ static NSString* getBasePath()
 @synthesize deleteBehaviorAfterSendAll = _deleteBehaviorAfterSendAll;
 @synthesize monitoring = _monitoring;
 @synthesize deadlockWatchdogInterval = _deadlockWatchdogInterval;
+@synthesize searchQueueNames = _searchQueueNames;
 @synthesize onCrash = _onCrash;
 @synthesize bundleName = _bundleName;
 @synthesize basePath = _basePath;
@@ -148,6 +149,7 @@ static NSString* getBasePath()
         self.introspectMemory = YES;
         self.catchZombies = NO;
         self.maxReportCount = 5;
+        self.searchQueueNames = NO;
         self.monitoring = KSCrashMonitorTypeProductionSafeMinimal;
     }
     return self;
@@ -195,6 +197,12 @@ static NSString* getBasePath()
 {
     _deadlockWatchdogInterval = deadlockWatchdogInterval;
     kscrash_setDeadlockWatchdogInterval(deadlockWatchdogInterval);
+}
+
+- (void) setSearchQueueNames:(bool) searchQueueNames
+{
+    _searchQueueNames = searchQueueNames;
+    kscrash_setSearchQueueNames(searchQueueNames);
 }
 
 - (void) setOnCrash:(KSReportWriteCallback) onCrash

--- a/Source/KSCrash/Recording/KSCrash.m
+++ b/Source/KSCrash/Recording/KSCrash.m
@@ -105,7 +105,6 @@ static NSString* getBasePath()
 @synthesize bundleName = _bundleName;
 @synthesize basePath = _basePath;
 @synthesize introspectMemory = _introspectMemory;
-@synthesize catchZombies = _catchZombies;
 @synthesize doNotIntrospectClasses = _doNotIntrospectClasses;
 @synthesize demangleLanguages = _demangleLanguages;
 @synthesize addConsoleLogToReport = _addConsoleLogToReport;
@@ -217,10 +216,21 @@ static NSString* getBasePath()
     kscrash_setIntrospectMemory(introspectMemory);
 }
 
+- (BOOL) catchZombies
+{
+    return (self.monitoring & KSCrashMonitorTypeZombie) != 0;
+}
+
 - (void) setCatchZombies:(BOOL)catchZombies
 {
-    _catchZombies = catchZombies;
-    self.monitoring |= KSCrashMonitorTypeZombie;
+    if(catchZombies)
+    {
+        self.monitoring |= KSCrashMonitorTypeZombie;
+    }
+    else
+    {
+        self.monitoring &= (KSCrashMonitorType)~KSCrashMonitorTypeZombie;
+    }
 }
 
 - (void) setDoNotIntrospectClasses:(NSArray *)doNotIntrospectClasses

--- a/Source/KSCrash/Recording/KSCrashC.c
+++ b/Source/KSCrash/Recording/KSCrashC.c
@@ -179,6 +179,11 @@ void kscrash_setDeadlockWatchdogInterval(double deadlockWatchdogInterval)
 #endif
 }
 
+void kscrash_setSearchQueueNames(bool searchQueueNames)
+{
+    ksccd_setSearchQueueNames(searchQueueNames);
+}
+
 void kscrash_setIntrospectMemory(bool introspectMemory)
 {
     kscrashreport_setIntrospectMemory(introspectMemory);

--- a/Source/KSCrash/Recording/KSCrashC.h
+++ b/Source/KSCrash/Recording/KSCrashC.h
@@ -89,6 +89,16 @@ void kscrash_setUserInfoJSON(const char* const userInfoJSON);
  */
 void kscrash_setDeadlockWatchdogInterval(double deadlockWatchdogInterval);
 
+/** If true, attempt to fetch dispatch queue names for each running thread.
+ *
+ * WARNING: There is a chance that this will crash on a ksthread_getQueueName() call!
+ *
+ * Enable at your own risk.
+ *
+ * Default: false
+ */
+void kscrash_setSearchQueueNames(bool searchQueueNames);
+
 /** If true, introspect memory contents during a crash.
  * Any Objective-C objects or C strings near the stack pointer or referenced by
  * cpu registers or exceptions will be recorded in the crash report, along with

--- a/Source/KSCrash/Recording/KSCrashCachedData.c
+++ b/Source/KSCrash/Recording/KSCrashCachedData.c
@@ -52,6 +52,7 @@ static const char** g_allThreadNames;
 static const char** g_allQueueNames;
 static int g_allThreadsCount;
 static _Atomic(int) g_semaphoreCount;
+static bool g_searchQueueNames = false;
 
 static void updateThreadList()
 {
@@ -81,7 +82,7 @@ static void updateThreadList()
         {
             allThreadNames[i] = strdup(buffer);
         }
-        if(ksthread_getQueueName((KSThread)thread, buffer, sizeof(buffer)) && buffer[0] != 0)
+        if(g_searchQueueNames && ksthread_getQueueName((KSThread)thread, buffer, sizeof(buffer)) && buffer[0] != 0)
         {
             allQueueNames[i] = strdup(buffer);
         }
@@ -183,6 +184,11 @@ void ksccd_unfreeze()
         // Handle extra calls to unfreeze somewhat gracefully.
         g_semaphoreCount++;
     }
+}
+
+void ksccd_setSearchQueueNames(bool searchQueueNames)
+{
+    g_searchQueueNames = searchQueueNames;
 }
 
 KSThread* ksccd_getAllThreads(int* threadCount)

--- a/Source/KSCrash/Recording/KSCrashCachedData.h
+++ b/Source/KSCrash/Recording/KSCrashCachedData.h
@@ -34,6 +34,8 @@ void ksccd_init(int pollingIntervalInSeconds);
 void ksccd_freeze(void);
 void ksccd_unfreeze(void);
 
+void ksccd_setSearchQueueNames(bool searchQueueNames);
+
 KSThread* ksccd_getAllThreads(int* threadCount);
 
 const char* ksccd_getThreadName(KSThread thread);


### PR DESCRIPTION
An alternative to #281 fix.
Fixes #207 by disabling crashing functionality by default(until no other ways to solve the problem are found).