### PR TITLE
fix ISA_MASK

### DIFF
--- a/Source/KSCrash/Recording/Tools/KSObjCApple.h
+++ b/Source/KSCrash/Recording/Tools/KSObjCApple.h
@@ -51,7 +51,7 @@ NAME { \
 #   define ISA_MASK     0x00007ffffffffff8UL
 #elif defined(__arm64__)
 #   define ISA_TAG_MASK 1UL
-#   define ISA_MASK     0x00000001fffffff8UL
+#   define ISA_MASK     0x0000000ffffffff8UL
 #else
 #   define ISA_TAG_MASK 0UL
 #   define ISA_MASK     ~1UL


### PR DESCRIPTION
Fix crash in `getClassRW` described in this issue: [crash caused by wrong ISA_MASK](https://github.com/kstenerud/KSCrash/issues/292#issue-368233441).

`ISA_MASK` should be `0x0000000ffffffff8UL` in arm64, see  [objc-private.h](https://opensource.apple.com/source/objc4/objc4-723/runtime/objc-private.h.auto.html).