### PR TITLE
Fix ISA_MASK after iOS 9

### DIFF
--- a/Source/KSCrash/Recording/Tools/KSObjC.c
+++ b/Source/KSCrash/Recording/Tools/KSObjC.c
@@ -194,7 +194,14 @@ const struct class_t* decodeIsaPointer(const void* const isaPointer)
     uintptr_t isa = (uintptr_t)isaPointer;
     if(isa & ISA_TAG_MASK)
     {
+#if defined(__arm64__)
+        if (floor(kCFCoreFoundationVersionNumber) <= kCFCoreFoundationVersionNumber_iOS_8_x_Max) {
+            return (const struct class_t*)(isa & ISA_MASK_OLD);
+        }
         return (const struct class_t*)(isa & ISA_MASK);
+#else
+        return (const struct class_t*)(isa & ISA_MASK);
+#endif
     }
 #endif
     return (const struct class_t*)isaPointer;

--- a/Source/KSCrash/Recording/Tools/KSObjCApple.h
+++ b/Source/KSCrash/Recording/Tools/KSObjCApple.h
@@ -46,11 +46,13 @@ NAME { \
 // and objc4-680/runtime/objc-msg-arm64.s
 // ======================================================================
 
+// Use ISA_MASK_OLD before iOS 9, in and after iOS 9, use ISA_MASK
 #if __x86_64__
 #   define ISA_TAG_MASK 1UL
 #   define ISA_MASK     0x00007ffffffffff8UL
 #elif defined(__arm64__)
 #   define ISA_TAG_MASK 1UL
+#   define ISA_MASK_OLD 0x00000001fffffff8UL
 #   define ISA_MASK     0x0000000ffffffff8UL
 #else
 #   define ISA_TAG_MASK 0UL

--- a/Source/KSCrash/Recording/Tools/KSObjCApple.h
+++ b/Source/KSCrash/Recording/Tools/KSObjCApple.h
@@ -51,7 +51,7 @@ NAME { \
 #   define ISA_MASK     0x00007ffffffffff8UL
 #elif defined(__arm64__)
 #   define ISA_TAG_MASK 1UL
-#   define ISA_MASK     0x00000001fffffff8UL
+#   define ISA_MASK     0x0000000ffffffff8UL
 #else
 #   define ISA_TAG_MASK 0UL
 #   define ISA_MASK     ~1UL


### PR DESCRIPTION
Fix crash in `getClassRW` described in this issue: [crash caused by wrong ISA_MASK](https://github.com/kstenerud/KSCrash/issues/292#issue-368233441).

`ISA_MASK` before iOS 9 is `0x00000001fffffff8UL`, in and after iOS 9, it's changed to `0x0000000ffffffff8UL`, see  [objc-private.h](https://opensource.apple.com/source/objc4/objc4-723/runtime/objc-private.h.auto.html).
This can be confirmed from `objc_getMetaClass` in `libobjc.A.dylib` in system frameworks: [iOS-System-Symbols](https://github.com/Zuikyo/iOS-System-Symbols).

So we should use different  `ISA_MASK` in different iOS system version.