### PR TITLE
Fix setSearchQueueNames argument type

### DIFF
--- a/Source/KSCrash/Recording/KSCrash.m
+++ b/Source/KSCrash/Recording/KSCrash.m
@@ -198,7 +198,7 @@ static NSString* getBasePath()
     kscrash_setDeadlockWatchdogInterval(deadlockWatchdogInterval);
 }
 
-- (void) setSearchQueueNames:(bool) searchQueueNames
+- (void) setSearchQueueNames:(BOOL) searchQueueNames
 {
     _searchQueueNames = searchQueueNames;
     kscrash_setSearchQueueNames(searchQueueNames);


### PR DESCRIPTION
Sorry for that, forget about this. A wrong type may produce warnings in Xcode.