### PR TITLE
Git rid of ARM64e's PAC from return address pointer.

### DIFF
--- a/Source/KSCrash/Recording/Tools/KSCPU.h
+++ b/Source/KSCrash/Recording/Tools/KSCPU.h
@@ -142,6 +142,14 @@ int kscpu_stackGrowDirection(void);
  * @param destinationContext The context to fill.
  */
 void kscpu_getState(struct KSMachineContext* destinationContext);
+
+/** Strip PAC from an instruction pointer.
+ *
+ * @param ip PAC encoded instruction pointer.
+ *
+ * @return Instruction pointer without PAC.
+ */
+uintptr_t kscpu_normaliseInstructionPointer(uintptr_t ip);
     
 #ifdef __cplusplus
 }

--- a/Source/KSCrash/Recording/Tools/KSCPU_arm.c
+++ b/Source/KSCrash/Recording/Tools/KSCPU_arm.c
@@ -158,5 +158,9 @@ int kscpu_stackGrowDirection(void)
     return -1;
 }
 
+uintptr_t kscpu_normaliseInstructionPointer(uintptr_t ip)
+{
+    return ip;
+}
 
 #endif

--- a/Source/KSCrash/Recording/Tools/KSCPU_arm64.c
+++ b/Source/KSCrash/Recording/Tools/KSCPU_arm64.c
@@ -36,6 +36,7 @@
 //#define KSLogger_LocalLevel TRACE
 #include "KSLogger.h"
 
+#define KSPACStrippingMask_ARM64e 0x0000000fffffffff
 
 static const char* g_registerNames[] =
 {
@@ -161,5 +162,9 @@ int kscpu_stackGrowDirection(void)
     return -1;
 }
 
+uintptr_t kscpu_normaliseInstructionPointer(uintptr_t ip)
+{
+    return ip & KSPACStrippingMask_ARM64e;
+}
 
 #endif

--- a/Source/KSCrash/Recording/Tools/KSCPU_x86_32.c
+++ b/Source/KSCrash/Recording/Tools/KSCPU_x86_32.c
@@ -184,4 +184,9 @@ int kscpu_stackGrowDirection(void)
     return -1;
 }
 
+uintptr_t kscpu_normaliseInstructionPointer(uintptr_t ip)
+{
+    return ip;
+}
+
 #endif

--- a/Source/KSCrash/Recording/Tools/KSCPU_x86_64.c
+++ b/Source/KSCrash/Recording/Tools/KSCPU_x86_64.c
@@ -196,4 +196,9 @@ int kscpu_stackGrowDirection(void)
     return -1;
 }
 
+uintptr_t kscpu_normaliseInstructionPointer(uintptr_t ip)
+{
+    return ip;
+}
+
 #endif

--- a/Source/KSCrash/Recording/Tools/KSStackCursor_Backtrace.c
+++ b/Source/KSCrash/Recording/Tools/KSStackCursor_Backtrace.c
@@ -24,6 +24,7 @@
 
 
 #include "KSStackCursor_Backtrace.h"
+#include "KSCPU.h"
 
 //#define KSLogger_LocalLevel TRACE
 #include "KSLogger.h"
@@ -39,7 +40,7 @@ static bool advanceCursor(KSStackCursor *cursor)
         // Bug: The system sometimes gives a backtrace with an extra 0x00000001 at the end.
         if(nextAddress > 1)
         {
-            cursor->stackEntry.address = context->backtrace[currentIndex];
+            cursor->stackEntry.address = kscpu_normaliseInstructionPointer(nextAddress);
             cursor->state.currentDepth++;
             return true;
         }

--- a/Source/KSCrash/Recording/Tools/KSStackCursor_MachineContext.c
+++ b/Source/KSCrash/Recording/Tools/KSStackCursor_MachineContext.c
@@ -114,7 +114,7 @@ static bool advanceCursor(KSStackCursor *cursor)
     nextAddress = context->currentFrame.return_address;
     
 successfulExit:
-    cursor->stackEntry.address = nextAddress;
+    cursor->stackEntry.address = kscpu_normaliseInstructionPointer(nextAddress);
     cursor->state.currentDepth++;
     return true;
 }


### PR DESCRIPTION
Since iPhone XS/XS Max. Apple launched a new CPU A12, which supports ARMv8.3, added Pointer Authentication Codes (PAC) tech for it. PAC will add some authentication codes into link register due to prevent from ROP attack. So, we'll get wrong address when we use original return address as instruction pointer for crash log.

For example:
Thread 0:
0   libsystem_c.dylib               0x000000019f10e318 0x19f0b2000 + 377624
1   libsystem_c.dylib               0x000000019f10e2c4 0x19f0b2000 + 377540
2   (null) 0x003be301a3d4a494 0x0 + 16856619809023124
3   (null) 0x0032b301a3d49b6c 0x0 + 14270568460491628
4   (null) 0x001a0f01a3d49b6c 0x0 + 7334849112480620
...

The solution is using an And Operation between instruction pointer and mask. 