### PR TITLE
Fix recrash report format for apple format report

### DIFF
--- a/Source/KSCrash/Reporting/Filters/KSCrashReportFilterAppleFmt.m
+++ b/Source/KSCrash/Reporting/Filters/KSCrashReportFilterAppleFmt.m
@@ -847,25 +847,20 @@ static NSDictionary* g_registerOrders;
 
 - (NSString*) recrashReportString:(NSDictionary*) report
 {
-    NSDictionary* recrashReport = [self recrashReport:report];
-    if(recrashReport == nil)
-    {
-        return @"";
-    }
-
     NSMutableString* str = [NSMutableString string];
-
-    NSDictionary* system = [self systemReport:report];
+    
+    NSDictionary* recrashReport = [self recrashReport:report];
+    NSDictionary* system = [self systemReport:recrashReport];
     NSString* executablePath = [system objectForKey:@KSCrashField_ExecutablePath];
     NSString* executableName = [executablePath lastPathComponent];
-    NSDictionary* crash = [self crashReport:recrashReport];
+    NSDictionary* crash = [self crashReport:report];
     NSDictionary* thread = [crash objectForKey:@KSCrashField_CrashedThread];
 
     [str appendString:@"\nHandler crashed while reporting:\n"];
-    [str appendString:[self errorInfoStringForReport:recrashReport]];
+    [str appendString:[self errorInfoStringForReport:report]];
     [str appendString:[self threadStringForThread:thread mainExecutableName:executableName]];
-    [str appendString:[self crashedThreadCPUStateStringForReport:recrashReport
-                                                         cpuArch:[self cpuArchForReport:report]]];
+    [str appendString:[self crashedThreadCPUStateStringForReport:report
+                                                         cpuArch:[self cpuArchForReport:recrashReport]]];
     NSString* diagnosis = [crash objectForKey:@KSCrashField_Diagnosis];
     if(diagnosis != nil)
     {
@@ -879,9 +874,14 @@ static NSDictionary* g_registerOrders;
 - (NSString*) toAppleFormat:(NSDictionary*) report
 {
     NSMutableString* str = [NSMutableString string];
-
-    [str appendString:[self crashReportString:report]];
-    [str appendString:[self recrashReportString:report]];
+    
+    NSDictionary* recrashReport = report[@KSCrashField_RecrashReport];
+    if (recrashReport) {
+        [str appendString:[self crashReportString:recrashReport]];
+        [str appendString:[self recrashReportString:report]];
+    } else {
+        [str appendString:[self crashReportString:report]];
+    }
 
     return str;
 }


### PR DESCRIPTION
This is a fix for the apple format report when a recrash happened. The report and recrash report are mistaken when generating the recrash report string.