### PR TITLE
Add missing static modifier for internal functions

### DIFF
--- a/Source/KSCrash/Recording/Monitors/KSCrashMonitor_AppState.c
+++ b/Source/KSCrash/Recording/Monitors/KSCrashMonitor_AppState.c
@@ -193,7 +193,7 @@ static double timeSince(double timeInSeconds)
  *
  * @return true if the operation was successful.
  */
-bool loadState(const char* const path)
+static bool loadState(const char* const path)
 {
     // Stop if the file doesn't exist.
     // This is expected on the first run of the app.
@@ -249,7 +249,7 @@ bool loadState(const char* const path)
  *
  * @return true if the operation was successful.
  */
-bool saveState(const char* const path)
+static bool saveState(const char* const path)
 {
     int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
     if(fd < 0)

--- a/Source/KSCrash/Recording/Monitors/KSCrashMonitor_System.m
+++ b/Source/KSCrash/Recording/Monitors/KSCrashMonitor_System.m
@@ -88,7 +88,7 @@ static volatile bool g_isEnabled = false;
 #pragma mark - Utility -
 // ============================================================================
 
-const char* cString(NSString* str)
+static const char* cString(NSString* str)
 {
     return str == NULL ? NULL : strdup(str.UTF8String);
 }

--- a/Source/KSCrash/Recording/Tools/KSObjC.c
+++ b/Source/KSCrash/Recording/Tools/KSObjC.c
@@ -155,13 +155,13 @@ static const char* g_blockBaseClassName = "NSBlock";
 //======================================================================
 
 #if SUPPORT_TAGGED_POINTERS
-bool isTaggedPointer(const void* pointer) {return (((uintptr_t)pointer) & TAG_MASK) != 0; }
-int getTaggedSlot(const void* pointer) { return (int)((((uintptr_t)pointer) >> TAG_SLOT_SHIFT) & TAG_SLOT_MASK); }
-uintptr_t getTaggedPayload(const void* pointer) { return (((uintptr_t)pointer) << TAG_PAYLOAD_LSHIFT) >> TAG_PAYLOAD_RSHIFT; }
+static bool isTaggedPointer(const void* pointer) {return (((uintptr_t)pointer) & TAG_MASK) != 0; }
+static int getTaggedSlot(const void* pointer) { return (int)((((uintptr_t)pointer) >> TAG_SLOT_SHIFT) & TAG_SLOT_MASK); }
+static uintptr_t getTaggedPayload(const void* pointer) { return (((uintptr_t)pointer) << TAG_PAYLOAD_LSHIFT) >> TAG_PAYLOAD_RSHIFT; }
 #else
-bool isTaggedPointer(__unused const void* pointer) { return false; }
-int getTaggedSlot(__unused const void* pointer) { return 0; }
-uintptr_t getTaggedPayload(const void* pointer) { return (uintptr_t)pointer; }
+static bool isTaggedPointer(__unused const void* pointer) { return false; }
+static int getTaggedSlot(__unused const void* pointer) { return 0; }
+static uintptr_t getTaggedPayload(const void* pointer) { return (uintptr_t)pointer; }
 #endif
 
 /** Get class data for a tagged pointer.
@@ -188,7 +188,7 @@ static bool isValidTaggedPointer(const void* object)
     return false;
 }
 
-const struct class_t* decodeIsaPointer(const void* const isaPointer)
+static const struct class_t* decodeIsaPointer(const void* const isaPointer)
 {
 #if ISA_TAG_MASK
     uintptr_t isa = (uintptr_t)isaPointer;
@@ -207,7 +207,7 @@ const struct class_t* decodeIsaPointer(const void* const isaPointer)
     return (const struct class_t*)isaPointer;
 }
 
-const void* getIsaPointer(const void* const objectOrClassPtr)
+static const void* getIsaPointer(const void* const objectOrClassPtr)
 {
     // This is wrong. Should not get class data here.
 //    if(ksobjc_isTaggedPointer(objectOrClassPtr))


### PR DESCRIPTION
To avoid possible symbols collisions these functions should be static. They are not mentioned in any header.