### PR TITLE
Add null check to prevent crashes on watchOS.

### DIFF
--- a/Source/KSCrash/Recording/Tools/KSFileUtils.c
+++ b/Source/KSCrash/Recording/Tools/KSFileUtils.c
@@ -437,6 +437,10 @@ bool ksfu_removeFile(const char* path, bool mustExist)
 
 bool ksfu_deleteContentsOfPath(const char* path)
 {
+    if(path == NULL)
+    {
+        return false;
+    }
     if(!canDeletePath(path))
     {
         return false;


### PR DESCRIPTION
`canDeletePath` does not check for null on its own. This adds a null check also to the second of the two places from which this function is called. Adding this check prevents crashes observed on watchOS.