### PR TITLE
fix lr causes the call stack inaccurate

### DIFF
--- a/Source/KSCrash/Recording/Tools/KSStackCursor_MachineContext.c
+++ b/Source/KSCrash/Recording/Tools/KSStackCursor_MachineContext.c
@@ -120,17 +120,6 @@ static bool advanceCursor(KSStackCursor *cursor)
         goto successfulExit;
     }
 
-    if(context->linkRegister == 0 && !context->isPastFramePointer)
-    {
-        // Link register, if available, is the second address in the trace.
-        context->linkRegister = kscpu_linkRegister(context->machineContext);
-        if(context->linkRegister != 0)
-        {
-            nextAddress = context->linkRegister;
-            goto successfulExit;
-        }
-    }
-
     if(context->currentFrame.previous == NULL)
     {
         if(context->isPastFramePointer)


### PR DESCRIPTION
lr storage return address,
use lr to get top frame,may cause call stack inaccurate.

```
void test(void) {
   test1();//. <- lr 
   // crash
   // backtrace is wrong, 
}
```