### PR TITLE
Fix timestamp migration

### DIFF
--- a/Source/KSCrash/Recording/KSCrashReportFixer.c
+++ b/Source/KSCrash/Recording/KSCrashReportFixer.c
@@ -138,19 +138,12 @@ static bool matchesAPath(FixupContext* context, const char* name, char* paths[][
 static bool matchesMinVersion(FixupContext* context, int major, int minor, int patch)
 {
     // Works only for report version 3.1.0 and above. See KSCrashReportVersion.h
-    if(context->reportVersionComponents[0] < major)
-    {
-        return false;
-    }
-    if(context->reportVersionComponents[1] < minor)
-    {
-        return false;
-    }
-    if(context->reportVersionComponents[2] < patch)
-    {
-        return false;
-    }
-    return true;
+    bool result = false;
+    int *parts = context->reportVersionComponents;
+    result = result || (parts[0] > major);
+    result = result || (parts[0] == major && parts[1] > minor);
+    result = result || (parts[0] == major && parts[1] == minor && parts[2] >= patch);
+    return result;
 }
 
 static bool shouldDemangle(FixupContext* context, const char* name)

--- a/Source/KSCrash/Recording/KSCrashReportFixer.c
+++ b/Source/KSCrash/Recording/KSCrashReportFixer.c
@@ -240,8 +240,7 @@ static int onStringElement(const char* const name,
     }
     if(shouldSaveVersion(context, name))
     {
-        memset(&(context->reportVersionComponents), 0,
-               sizeof(*context->reportVersionComponents) * REPORT_VERSION_COMPONENTS_COUNT);
+        memset(context->reportVersionComponents, 0, sizeof(context->reportVersionComponents));
         int versionPartsIndex = 0;
         char* mutableValue = strdup(value);
         char* versionPart = strtok(mutableValue, ".");

--- a/Source/KSCrash/Recording/KSCrashReportVersion.h
+++ b/Source/KSCrash/Recording/KSCrashReportVersion.h
@@ -27,6 +27,6 @@
 #ifndef HDR_KSCrashReportVersion_h
 #define HDR_KSCrashReportVersion_h
 
-#define KSCRASH_REPORT_VERSION "3.2.0"
+#define KSCRASH_REPORT_VERSION "3.3.0"
 
 #endif /* HDR_KSCrashReportVersion_h */


### PR DESCRIPTION
After #326 there has been a migration problem. Reports from previous versions would not be parsed(fixed in KSCrashReportFixer) properly.