### PR TITLE
fix invalid upper 32 bits in MachExceptionMessage exception codes for 32-bit systems

### DIFF
--- a/Source/KSCrash/Recording/Monitors/KSCrashMonitor_MachException.c
+++ b/Source/KSCrash/Recording/Monitors/KSCrashMonitor_MachException.c
@@ -50,10 +50,10 @@
 #define kThreadPrimary "KSCrash Exception Handler (Primary)"
 #define kThreadSecondary "KSCrash Exception Handler (Secondary)"
 
-#if defined __arm__ || defined __i386__
-    #define MACH_ERROR_CODE_MASK 0xFFFFFFFF
-#elif defined __arm64__ || defined __x86_64__
+#if __LP64__
     #define MACH_ERROR_CODE_MASK 0xFFFFFFFFFFFFFFFF
+#else
+    #define MACH_ERROR_CODE_MASK 0xFFFFFFFF
 #endif
 
 // ============================================================================

--- a/Source/KSCrash/Recording/Monitors/KSCrashMonitor_MachException.c
+++ b/Source/KSCrash/Recording/Monitors/KSCrashMonitor_MachException.c
@@ -50,6 +50,11 @@
 #define kThreadPrimary "KSCrash Exception Handler (Primary)"
 #define kThreadSecondary "KSCrash Exception Handler (Secondary)"
 
+#if defined __arm__ || defined __i386__
+    #define MACH_ERROR_CODE_MASK 0xFFFFFFFF
+#elif defined __arm64__ || defined __x86_64__
+    #define MACH_ERROR_CODE_MASK 0xFFFFFFFFFFFFFFFF
+#endif
 
 // ============================================================================
 #pragma mark - Types -
@@ -348,8 +353,8 @@ static void* handleExceptions(void* const userData)
         crashContext->eventID = eventID;
         crashContext->registersAreValid = true;
         crashContext->mach.type = exceptionMessage.exception;
-        crashContext->mach.code = exceptionMessage.code[0];
-        crashContext->mach.subcode = exceptionMessage.code[1];
+        crashContext->mach.code = exceptionMessage.code[0] & MACH_ERROR_CODE_MASK;
+        crashContext->mach.subcode = exceptionMessage.code[1] & MACH_ERROR_CODE_MASK;
         if(crashContext->mach.code == KERN_PROTECTION_FAILURE && crashContext->isStackOverflow)
         {
             // A stack overflow should return KERN_INVALID_ADDRESS, but


### PR DESCRIPTION
In 32-bit systems `MachExceptionMessage.code` had only the lower 32 bits valid. This produced an invalid comparison of error code and `KERN_INVALID_ADDRESS`. As a result, the UNIX signal code was always `SIGBUS`.