### PR TITLE
fix code and subcode in mach exceptions 

### DIFF
--- a/Source/KSCrash/Recording/KSCrashReport.c
+++ b/Source/KSCrash/Recording/KSCrashReport.c
@@ -135,7 +135,7 @@ static void addIntegerElement(const KSCrashReportWriter* const writer, const cha
 
 static void addUIntegerElement(const KSCrashReportWriter* const writer, const char* const key, const uint64_t value)
 {
-    ksjson_addIntegerElement(getJsonContext(writer), key, (int64_t)value);
+    ksjson_addUIntegerElement(getJsonContext(writer), key, value);
 }
 
 static void addStringElement(const KSCrashReportWriter* const writer, const char* const key, const char* const value)

--- a/Source/KSCrash/Recording/KSCrashReport.c
+++ b/Source/KSCrash/Recording/KSCrashReport.c
@@ -1360,7 +1360,7 @@ static void writeError(const KSCrashReportWriter* const writer,
             {
                 writer->addStringElement(writer, KSCrashField_CodeName, machCodeName);
             }
-            writer->addUIntegerElement(writer, KSCrashField_Subcode, (unsigned)crash->mach.subcode);
+            writer->addUIntegerElement(writer, KSCrashField_Subcode, (size_t)crash->mach.subcode);
         }
         writer->endContainer(writer);
 #endif

--- a/Source/KSCrash/Recording/Monitors/KSCrashMonitor_MachException.c
+++ b/Source/KSCrash/Recording/Monitors/KSCrashMonitor_MachException.c
@@ -324,7 +324,7 @@ static void* handleExceptions(void* const userData)
         }
         else
         {
-            KSLOG_DEBUG("This is the secondary exception thread. Restoring original exception ports.");
+            KSLOG_DEBUG("This is the secondary exception thread.");// Restoring original exception ports.");
 //            restoreExceptionPorts();
         }
 
@@ -337,7 +337,8 @@ static void* handleExceptions(void* const userData)
         if(ksmc_getContextForThread(exceptionMessage.thread.name, machineContext, true))
         {
             kssc_initWithMachineContext(&g_stackCursor, 100, machineContext);
-            KSLOG_TRACE("Fault address 0x%x, instruction address 0x%x", kscpu_faultAddress(machineContext), kscpu_instructionAddress(machineContext));
+            KSLOG_TRACE("Fault address %p, instruction address %p",
+                        kscpu_faultAddress(machineContext), kscpu_instructionAddress(machineContext));
             if(exceptionMessage.exception == EXC_BAD_ACCESS)
             {
                 crashContext->faultAddress = kscpu_faultAddress(machineContext);

--- a/Source/KSCrash/Recording/Monitors/KSCrashMonitor_MachException.c
+++ b/Source/KSCrash/Recording/Monitors/KSCrashMonitor_MachException.c
@@ -62,6 +62,7 @@
 
 /** A mach exception message (according to ux_exception.c, xnu-1699.22.81).
  */
+#pragma pack(4)
 typedef struct
 {
     /** Mach header. */
@@ -99,9 +100,11 @@ typedef struct
     /** Padding to avoid RCV_TOO_LARGE. */
     char                       padding[512];
 } MachExceptionMessage;
+#pragma pack()
 
 /** A mach reply message (according to ux_exception.c, xnu-1699.22.81).
  */
+#pragma pack(4)
 typedef struct
 {
     /** Mach header. */
@@ -113,7 +116,7 @@ typedef struct
     /** Return code. */
     kern_return_t     returnCode;
 } MachReplyMessage;
-
+#pragma pack()
 
 // ============================================================================
 #pragma mark - Globals -
@@ -299,7 +302,7 @@ static void* handleExceptions(void* const userData)
         KSLOG_ERROR("mach_msg: %s", mach_error_string(kr));
     }
 
-    KSLOG_DEBUG("Trapped mach exception code 0x%x, subcode 0x%x",
+    KSLOG_DEBUG("Trapped mach exception code 0x%llx, subcode 0x%llx",
                 exceptionMessage.code[0], exceptionMessage.code[1]);
     if(g_isEnabled)
     {
@@ -498,7 +501,7 @@ static bool installExceptionHandler()
     kr = task_set_exception_ports(thisTask,
                                   mask,
                                   g_exceptionPort,
-                                  EXCEPTION_DEFAULT,
+                                  EXCEPTION_DEFAULT | MACH_EXCEPTION_CODES,
                                   THREAD_STATE_NONE);
     if(kr != KERN_SUCCESS)
     {

--- a/Source/KSCrash/Recording/Monitors/KSCrashMonitor_MachException.c
+++ b/Source/KSCrash/Recording/Monitors/KSCrashMonitor_MachException.c
@@ -357,8 +357,8 @@ static void* handleExceptions(void* const userData)
         crashContext->eventID = eventID;
         crashContext->registersAreValid = true;
         crashContext->mach.type = exceptionMessage.exception;
-        crashContext->mach.code = exceptionMessage.code[0] & MACH_ERROR_CODE_MASK;
-        crashContext->mach.subcode = exceptionMessage.code[1] & MACH_ERROR_CODE_MASK;
+        crashContext->mach.code = exceptionMessage.code[0] & (int64_t)MACH_ERROR_CODE_MASK;
+        crashContext->mach.subcode = exceptionMessage.code[1] & (int64_t)MACH_ERROR_CODE_MASK;
         if(crashContext->mach.code == KERN_PROTECTION_FAILURE && crashContext->isStackOverflow)
         {
             // A stack overflow should return KERN_INVALID_ADDRESS, but
@@ -501,7 +501,7 @@ static bool installExceptionHandler()
     kr = task_set_exception_ports(thisTask,
                                   mask,
                                   g_exceptionPort,
-                                  EXCEPTION_DEFAULT | MACH_EXCEPTION_CODES,
+                                  (int)(EXCEPTION_DEFAULT | MACH_EXCEPTION_CODES),
                                   THREAD_STATE_NONE);
     if(kr != KERN_SUCCESS)
     {

--- a/Source/KSCrash/Recording/Tools/KSJSONCodec.c
+++ b/Source/KSCrash/Recording/Tools/KSJSONCodec.c
@@ -365,6 +365,20 @@ int ksjson_addIntegerElement(KSJSONEncodeContext* const context,
     return addJSONData(context, buff, (int)strlen(buff));
 }
 
+int ksjson_addUIntegerElement(KSJSONEncodeContext* const context,
+                             const char* const name,
+                             uint64_t value)
+{
+    int result = ksjson_beginElement(context, name);
+    unlikely_if(result != KSJSON_OK)
+    {
+        return result;
+    }
+    char buff[30];
+    sprintf(buff, "%" PRIu64, value);
+    return addJSONData(context, buff, (int)strlen(buff));
+}
+
 int ksjson_addNullElement(KSJSONEncodeContext* const context,
                           const char* const name)
 {

--- a/Source/KSCrash/Recording/Tools/KSJSONCodec.h
+++ b/Source/KSCrash/Recording/Tools/KSJSONCodec.h
@@ -170,6 +170,20 @@ int ksjson_addIntegerElement(KSJSONEncodeContext* context,
                              const char* name,
                              int64_t value);
 
+/** Add an unsigned integer element.
+ *
+ * @param context The encoding context.
+ *
+ * @param name The element's name.
+ *
+ * @param value The element's value.
+ *
+ * @return KSJSON_OK if the process was successful.
+ */
+int ksjson_addUIntegerElement(KSJSONEncodeContext* const context,
+                              const char* const name,
+                              uint64_t value);
+    
 /** Add a floating point element.
  *
  * @param context The encoding context.


### PR DESCRIPTION
The reason for the problem was in the incorrect configuration of exception port and later the wrong interpretation of struct returned from the kernel. 
`kern_return_t task_set_exception_ports`  function has a `exception_behavior_t behavior` parameter that allows to configure messages received later. By default, it returns 32-bit `code` and `subcode` . But there is a 64-bit "array" `mach_exception_data_type_t code[0];` in the `MachReplyMessage` struct. So we added `MACH_EXCEPTION_CODES` flag, that enables sending "`64-bit code and subcode in the exception header`".
Also, we experienced the wrong memory alignment of this struct on 64-bit systems, that caused additional 4-byte shifting before array and incorrect reading of `code` and `subcode`.