### PR TITLE
[Machine Context] Save suspended threads as local variable to avoid race conditions

### DIFF
--- a/Source/KSCrash/Recording/Monitors/KSCrashMonitor_CPPException.cpp
+++ b/Source/KSCrash/Recording/Monitors/KSCrashMonitor_CPPException.cpp
@@ -99,7 +99,9 @@ extern "C"
 
 static void CPPExceptionTerminate(void)
 {
-    ksmc_suspendEnvironment();
+    thread_act_array_t threads = NULL;
+    mach_msg_type_number_t numThreads = 0;
+    ksmc_suspendEnvironment(&threads, &numThreads);
     KSLOG_DEBUG("Trapped c++ exception");
     const char* name = NULL;
     std::type_info* tinfo = __cxxabiv1::__cxa_current_exception_type();
@@ -173,7 +175,7 @@ catch(TYPE value)\
     {
         KSLOG_DEBUG("Detected NSException. Letting the current NSException handler deal with it.");
     }
-    ksmc_resumeEnvironment();
+    ksmc_resumeEnvironment(threads, numThreads);
 
     KSLOG_DEBUG("Calling original terminate handler.");
     g_originalTerminateHandler();

--- a/Source/KSCrash/Recording/Monitors/KSCrashMonitor_Deadlock.m
+++ b/Source/KSCrash/Recording/Monitors/KSCrashMonitor_Deadlock.m
@@ -107,7 +107,9 @@ static NSTimeInterval g_watchdogInterval = 0;
 
 - (void) handleDeadlock
 {
-    ksmc_suspendEnvironment();
+    thread_act_array_t threads = NULL;
+    mach_msg_type_number_t numThreads = 0;
+    ksmc_suspendEnvironment(&threads, &numThreads);
     kscm_notifyFatalExceptionCaptured(false);
 
     KSMC_NEW_CONTEXT(machineContext);
@@ -127,7 +129,7 @@ static NSTimeInterval g_watchdogInterval = 0;
     crashContext->stackCursor = &stackCursor;
     
     kscm_handleException(crashContext);
-    ksmc_resumeEnvironment();
+    ksmc_resumeEnvironment(threads, numThreads);
 
     KSLOG_DEBUG(@"Calling abort()");
     abort();

--- a/Source/KSCrash/Recording/Monitors/KSCrashMonitor_MachException.c
+++ b/Source/KSCrash/Recording/Monitors/KSCrashMonitor_MachException.c
@@ -303,7 +303,9 @@ static void* handleExceptions(void* const userData)
                 exceptionMessage.code[0], exceptionMessage.code[1]);
     if(g_isEnabled)
     {
-        ksmc_suspendEnvironment();
+        thread_act_array_t threads = NULL;
+        mach_msg_type_number_t numThreads = 0;
+        ksmc_suspendEnvironment(&threads, &numThreads);
         g_isHandlingCrash = true;
         kscm_notifyFatalExceptionCaptured(true);
 
@@ -369,7 +371,7 @@ static void* handleExceptions(void* const userData)
 
         KSLOG_DEBUG("Crash handling complete. Restoring original handlers.");
         g_isHandlingCrash = false;
-        ksmc_resumeEnvironment();
+        ksmc_resumeEnvironment(threads, numThreads);
     }
 
     KSLOG_DEBUG("Replying to mach exception message.");

--- a/Source/KSCrash/Recording/Monitors/KSCrashMonitor_NSException.m
+++ b/Source/KSCrash/Recording/Monitors/KSCrashMonitor_NSException.m
@@ -62,7 +62,9 @@ static void handleException(NSException* exception, BOOL currentSnapshotUserRepo
     KSLOG_DEBUG(@"Trapped exception %@", exception);
     if(g_isEnabled)
     {
-        ksmc_suspendEnvironment();
+        thread_act_array_t threads = NULL;
+        mach_msg_type_number_t numThreads = 0;
+        ksmc_suspendEnvironment(&threads, &numThreads);
         kscm_notifyFatalExceptionCaptured(false);
 
         KSLOG_DEBUG(@"Filling out context.");
@@ -99,7 +101,7 @@ static void handleException(NSException* exception, BOOL currentSnapshotUserRepo
 
         free(callstack);
         if (currentSnapshotUserReported) {
-            ksmc_resumeEnvironment();
+            ksmc_resumeEnvironment(threads, numThreads);
         }
         if (g_previousUncaughtExceptionHandler != NULL)
         {

--- a/Source/KSCrash/Recording/Monitors/KSCrashMonitor_Signal.c
+++ b/Source/KSCrash/Recording/Monitors/KSCrashMonitor_Signal.c
@@ -84,7 +84,9 @@ static void handleSignal(int sigNum, siginfo_t* signalInfo, void* userContext)
     KSLOG_DEBUG("Trapped signal %d", sigNum);
     if(g_isEnabled)
     {
-        ksmc_suspendEnvironment();
+        thread_act_array_t threads = NULL;
+        mach_msg_type_number_t numThreads = 0;
+        ksmc_suspendEnvironment(&threads, &numThreads);
         kscm_notifyFatalExceptionCaptured(false);
 
         KSLOG_DEBUG("Filling out context.");
@@ -105,7 +107,7 @@ static void handleSignal(int sigNum, siginfo_t* signalInfo, void* userContext)
         crashContext->stackCursor = &g_stackCursor;
 
         kscm_handleException(crashContext);
-        ksmc_resumeEnvironment();
+        ksmc_resumeEnvironment(threads, numThreads);
     }
 
     KSLOG_DEBUG("Re-raising signal for regular handlers to catch.");

--- a/Source/KSCrash/Recording/Monitors/KSCrashMonitor_User.c
+++ b/Source/KSCrash/Recording/Monitors/KSCrashMonitor_User.c
@@ -54,9 +54,11 @@ void kscm_reportUserException(const char* name,
     }
     else
     {
+        thread_act_array_t threads = NULL;
+        mach_msg_type_number_t numThreads = 0;
         if(logAllThreads)
         {
-            ksmc_suspendEnvironment();
+            ksmc_suspendEnvironment(&threads, &numThreads);
         }
         if(terminateProgram)
         {
@@ -89,7 +91,7 @@ void kscm_reportUserException(const char* name,
 
         if(logAllThreads)
         {
-            ksmc_resumeEnvironment();
+            ksmc_resumeEnvironment(threads, numThreads);
         }
         if(terminateProgram)
         {

--- a/Source/KSCrash/Recording/Tools/KSMachineContext.c
+++ b/Source/KSCrash/Recording/Tools/KSMachineContext.c
@@ -47,8 +47,6 @@
 static KSThread g_reservedThreads[10];
 static int g_reservedThreadsMaxIndex = sizeof(g_reservedThreads) / sizeof(g_reservedThreads[0]) - 1;
 static int g_reservedThreadsCount = 0;
-static thread_act_array_t g_suspendedThreads = NULL;
-static mach_msg_type_number_t g_suspendedThreadsCount = 0;
 
 
 static inline bool isStackOverflow(const KSMachineContext* const context)
@@ -167,7 +165,7 @@ static inline bool isThreadInList(thread_t thread, KSThread* list, int listCount
 }
 #endif
 
-void ksmc_suspendEnvironment()
+void ksmc_suspendEnvironment(thread_act_array_t *suspendedThreads, mach_msg_type_number_t *numSuspendedThreads)
 {
 #if KSCRASH_HAS_THREADS_API
     KSLOG_DEBUG("Suspending environment.");
@@ -175,15 +173,15 @@ void ksmc_suspendEnvironment()
     const task_t thisTask = mach_task_self();
     const thread_t thisThread = (thread_t)ksthread_self();
     
-    if((kr = task_threads(thisTask, &g_suspendedThreads, &g_suspendedThreadsCount)) != KERN_SUCCESS)
+    if((kr = task_threads(thisTask, suspendedThreads, numSuspendedThreads)) != KERN_SUCCESS)
     {
         KSLOG_ERROR("task_threads: %s", mach_error_string(kr));
         return;
     }
     
-    for(mach_msg_type_number_t i = 0; i < g_suspendedThreadsCount; i++)
+    for(mach_msg_type_number_t i = 0; i < *numSuspendedThreads; i++)
     {
-        thread_t thread = g_suspendedThreads[i];
+        thread_t thread = (*suspendedThreads)[i];
         if(thread != thisThread && !isThreadInList(thread, g_reservedThreads, g_reservedThreadsCount))
         {
             if((kr = thread_suspend(thread)) != KERN_SUCCESS)
@@ -198,7 +196,7 @@ void ksmc_suspendEnvironment()
 #endif
 }
 
-void ksmc_resumeEnvironment()
+void ksmc_resumeEnvironment(thread_act_array_t threads, mach_msg_type_number_t numThreads)
 {
 #if KSCRASH_HAS_THREADS_API
     KSLOG_DEBUG("Resuming environment.");
@@ -206,15 +204,15 @@ void ksmc_resumeEnvironment()
     const task_t thisTask = mach_task_self();
     const thread_t thisThread = (thread_t)ksthread_self();
     
-    if(g_suspendedThreads == NULL || g_suspendedThreadsCount == 0)
+    if(threads == NULL || numThreads == 0)
     {
         KSLOG_ERROR("we should call ksmc_suspendEnvironment() first");
         return;
     }
     
-    for(mach_msg_type_number_t i = 0; i < g_suspendedThreadsCount; i++)
+    for(mach_msg_type_number_t i = 0; i < numThreads; i++)
     {
-        thread_t thread = g_suspendedThreads[i];
+        thread_t thread = threads[i];
         if(thread != thisThread && !isThreadInList(thread, g_reservedThreads, g_reservedThreadsCount))
         {
             if((kr = thread_resume(thread)) != KERN_SUCCESS)
@@ -225,13 +223,11 @@ void ksmc_resumeEnvironment()
         }
     }
     
-    for(mach_msg_type_number_t i = 0; i < g_suspendedThreadsCount; i++)
+    for(mach_msg_type_number_t i = 0; i < numThreads; i++)
     {
-        mach_port_deallocate(thisTask, g_suspendedThreads[i]);
+        mach_port_deallocate(thisTask, threads[i]);
     }
-    vm_deallocate(thisTask, (vm_address_t)g_suspendedThreads, sizeof(thread_t) * g_suspendedThreadsCount);
-    g_suspendedThreads = NULL;
-    g_suspendedThreadsCount = 0;
+    vm_deallocate(thisTask, (vm_address_t)threads, sizeof(thread_t) * numThreads);
     
     KSLOG_DEBUG("Resume complete.");
 #endif

--- a/Source/KSCrash/Recording/Tools/KSMachineContext.h
+++ b/Source/KSCrash/Recording/Tools/KSMachineContext.h
@@ -34,14 +34,15 @@ extern "C" {
 
 #include "KSThread.h"
 #include <stdbool.h>
+#include <mach/mach.h>
 
 /** Suspend the runtime environment.
  */
-void ksmc_suspendEnvironment(void);
+void ksmc_suspendEnvironment(thread_act_array_t *suspendedThreads, mach_msg_type_number_t *numSuspendedThreads);
 
 /** Resume the runtime environment.
  */
-void ksmc_resumeEnvironment(void);
+void ksmc_resumeEnvironment(thread_act_array_t threads, mach_msg_type_number_t numThreads);
 
 /** Create a new machine context on the stack.
  * This macro creates a storage object on the stack, as well as a pointer of type


### PR DESCRIPTION
**Background**
After This change is merged: https://github.com/kstenerud/KSCrash/pull/321 
We started to see crashes inside of ks crash like the following
```
Exception Type:  EXC_BAD_ACCESS (SIGBUS)
Exception Codes: 0x00000000 at 0x0000000113258008
Crashed Thread:  55

Thread 55 Crashed:
0   TestApp                         ksmc_resumeEnvironment +307 (KSMachineContext.c:230)
1   TestApp                         CPPExceptionTerminate() +95 (KSCrashMonitor_CPPException.cpp:193)
2   libc++abi.dylib                 0x00000002034bc838 0x2034af000 + 55352
3   libc++abi.dylib                 0x00000002034bc8c4 0x2034af000 + 55492
4   libdispatch.dylib               _dispatch_client_callout +35
5   libdispatch.dylib               _dispatch_root_queue_drain +635
6   libdispatch.dylib               _dispatch_worker_thread2 +115
7   libsystem_pthread.dylib         _pthread_wqthread +463
```

It seems the cause is a race condition where `g_suspendedThreads` was released while still being accessed https://github.com/kstenerud/KSCrash/blob/master/Source/KSCrash/Recording/Tools/KSMachineContext.c#L230. 

**Change**
Save suspended threads in local variable instead of global variable, Since suspend thread and resume thread are always called in pair