### PR TITLE
Remove sencondary thread

### DIFF
--- a/iOS/Example-Apps-iOS.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/iOS/Example-Apps-iOS.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/iOS/KSCrash-iOS.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/iOS/KSCrash-iOS.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
1. Xcode 9.3 adds a new IDEWorkspaceChecks.plist file to a workspace's shared data, to store the state of necessary workspace checks. Committing this file to source control will prevent unnecessary rerunning of those checks for each user opening the workspace. (ref: [Xcode Release Notes](https://developer.apple.com/library/archive/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html));
2. Remove secondary thread in mach exception monitor. I will explain why I do this blow.

Let's focus on KSCrashMonitor_MachException.c. 

First, line 321 we call `restoreExceptionPorts()` in which we set exception port to `g_previousExceptionPorts`. From now all exception message will be sent to `g_previousExceptionPorts `.

Then, we resume `g_secondaryMachThread` on line 322 in case of the crash handling code itself crashes. However, `g_secondaryMachThread` listens on `g_exceptionPort` which no longer receive any exception message.