### PR TITLE
[Stack Cursor] add back link register, do stack walk based on linked register when pc is null

### DIFF
--- a/Source/KSCrash/Recording/Tools/KSStackCursor_MachineContext.c
+++ b/Source/KSCrash/Recording/Tools/KSStackCursor_MachineContext.c
@@ -109,15 +109,22 @@ static bool advanceCursor(KSStackCursor *cursor)
         return false;
     }
     
-    if(context->instructionAddress == 0)
+    if(context->instructionAddress == 0 && cursor->state.currentDepth == 0)
     {
         context->instructionAddress = kscpu_instructionAddress(context->machineContext);
-        if(context->instructionAddress == 0)
-        {
-            return false;
-        }
         nextAddress = context->instructionAddress;
         goto successfulExit;
+    }
+    
+    if(context->linkRegister == 0 && !context->isPastFramePointer)
+    {
+        // Link register, if available, is the second address in the trace.
+        context->linkRegister = kscpu_linkRegister(context->machineContext);
+        if(context->linkRegister != 0)
+        {
+            nextAddress = context->linkRegister;
+            goto successfulExit;
+        }
     }
 
     if(context->currentFrame.previous == NULL)


### PR DESCRIPTION
**Background**
When a crash happened due null ptr function, current logic will produce an empty stack trace. However, we can still walk from link register to get the rest of the stack trace.

Also, after this change: https://github.com/kstenerud/KSCrash/pull/327/files, We started to see missing frames in the stack trace. Seems in c++ world sometimes there  is a compiler optimization which skips pushing return address to the stack and we have to retrieve it from link register.

**Change**
1. Revert this change: https://github.com/kstenerud/KSCrash/pull/327/files
2. Don't return yet when pc is zero, we can still walk the stack by value in link register

**Test Plan**
Example crash stack trace caught after this change (which was previously empty):
```
...
Thread 32 Crashed:
0   (null) 0x0000000000000000 0x0 + 0
1   MYAPP                        0x00000001073187b8 <Some Function> + 164
2   MYAPP                        0x00000001072b4818 <Some other Function> + 52
3 ...

Thread 32 crashed with ARM-64 Thread State:
  cpsr: 0x0000000060000000     fp: 0x000000016c142710     lr: 0x00000001073187b8     pc: 0x0000000000000000 
    sp: 0x000000016c1426d0     x0: 0x000000011ea10c88     x1: 0x000000011ca94a00    x10: 0x00000000000bdff0 
   x11: 0x0000000000179f41    x12: 0x000000011ea10000    x13: 0x0000000000003fff    x14: 0x00000000ec3f6083 
   x15: 0x00000000000013ca    x16: 0x00000000ec3f6083    x17: 0x00000000000013ca    x18: 0x0000000000000000 
   x19: 0x000000011ea10c88     x2: 0x000000011ea10c70    x20: 0x0000000000000003    x21: 0x000000011e916118 
   x22: 0x000000011e916228    x23: 0x000000016c142d80    x24: 0x0000000000000066    x25: 0x000000000000010c 
   x26: 0x0000000000000000    x27: 0x000000016c143180    x28: 0x00000000000003ff    x29: 0x000000016c142710 
    x3: 0x0000000000000035     x4: 0x000000011ea10c70     x5: 0x0000000000000028     x6: 0x0000000000000000 
    x7: 0x0000000110221f40     x8: 0x0000000000000000     x9: 0x0000000000012503 
```
