### PR TITLE
Fix regression for non-unique crash IDs

### DIFF
--- a/Source/KSCrash/Recording/KSCrashReportStore.c
+++ b/Source/KSCrash/Recording/KSCrashReportStore.c
@@ -166,7 +166,7 @@ static void initializeIDs()
                    + (int64_t)time.tm_year * 61 * 60 * 24 * 366;
     baseID <<= 23;
 
-    g_nextUniqueIDHigh = baseID & ~0xffffffff;
+    g_nextUniqueIDHigh = baseID & ~(int64_t)0xffffffff;
     g_nextUniqueIDLow = (uint32_t)(baseID & 0xffffffff);
 }
 


### PR DESCRIPTION
Fix regression introduced in 3409913f78837a955c081df6cc237673db5c7bab, which made crash report IDs non-unique, as the 32 MSB's were zeroed out (`(int64_t)foo & ~0xffffffff` is always `0`), leading to only 9 bits of entropy