### PR TITLE
[FIX] Crash fix due to a space character in "CFBundleName"

### DIFF
--- a/Source/KSCrash/Recording/KSCrash.m
+++ b/Source/KSCrash/Recording/KSCrash.m
@@ -85,7 +85,7 @@ static NSString* getBasePath()
         return nil;
     }
     NSString* pathEnd = [@"KSCrash" stringByAppendingPathComponent:getBundleName()];
-    return [cachePath stringByAppendingPathComponent:pathEnd];
+    return [cachePath stringByAppendingPathComponent:[pathEnd stringByReplacingOccurrencesOfString:@" " withString:@"-"]];
 }
 
 


### PR DESCRIPTION
[FIX] Crash fix: when "CFBundleName" (from info.plist) contains a space character, it affects the base path and causes a crash when trying to access the files in it. Fixed by replacing all spaces with dashes.