### PR TITLE
C++ crash hook fixes

### DIFF
--- a/KSCrash.podspec
+++ b/KSCrash.podspec
@@ -15,8 +15,9 @@ Pod::Spec.new do |s|
   s.libraries = 'c++', 'z'
   s.xcconfig = { 'GCC_ENABLE_CPP_EXCEPTIONS' => 'YES' }
   s.default_subspecs = 'Installations'
-
+  
   s.subspec 'Recording' do |recording|
+    recording.compiler_flags = '-fno-optimize-sibling-calls'
     recording.source_files   = 'Source/KSCrash/Recording/**/*.{h,m,mm,c,cpp}',
                                'Source/KSCrash/llvm/**/*.{h,m,mm,c,cpp}',
                                'Source/KSCrash/swift/**/*.{h,m,mm,c,cpp}',
@@ -30,6 +31,7 @@ Pod::Spec.new do |s|
 
     recording.subspec 'Tools' do |tools|
       tools.source_files = 'Source/KSCrash/Recording/Tools/*.h'
+      tools.compiler_flags = '-fno-optimize-sibling-calls'
     end
   end
 

--- a/KSCrash.podspec
+++ b/KSCrash.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.libraries = 'c++', 'z'
   s.xcconfig = { 'GCC_ENABLE_CPP_EXCEPTIONS' => 'YES' }
   s.default_subspecs = 'Installations'
-  
+
   s.subspec 'Recording' do |recording|
     recording.compiler_flags = '-fno-optimize-sibling-calls'
     recording.source_files   = 'Source/KSCrash/Recording/**/*.{h,m,mm,c,cpp}',

--- a/Source/KSCrash/Recording/Monitors/KSCrashMonitor_CPPException.cpp
+++ b/Source/KSCrash/Recording/Monitors/KSCrashMonitor_CPPException.cpp
@@ -77,20 +77,12 @@ static KSStackCursor g_stackCursor;
 #pragma mark - Callbacks -
 // ============================================================================
 
-static void captureStackTrace()
+static void captureStackTrace(void* thrown_exception, std::type_info* tinfo, void (*dest)(void*))
 {
     if(g_captureNextStackTrace)
     {
-        // TODO: Meant to be `3` (captureStackTrace, __cxa_throw_decorator), but sometimes one of the frames lost.
-        // Temporary fix with `2`.
-        const int skip_entries = 2;
-        kssc_initSelfThread(&g_stackCursor, skip_entries);
+        kssc_initSelfThread(&g_stackCursor, 2);
     }
-}
-
-static void captureStackTrace(void* thrown_exception, std::type_info* tinfo, void (*dest)(void*))
-{
-    captureStackTrace();
 }
 
 typedef void (*cxa_throw_type)(void*, std::type_info*, void (*)(void*));
@@ -104,7 +96,7 @@ extern "C"
         static cxa_throw_type orig_cxa_throw = NULL;
         if (g_cxaSwapEnabled == false)
         {
-            captureStackTrace();
+            captureStackTrace(NULL, NULL, NULL);
         }
         unlikely_if(orig_cxa_throw == NULL)
         {

--- a/Source/KSCrash/Recording/Tools/KSCxaThrowSwapper.c
+++ b/Source/KSCrash/Recording/Tools/KSCxaThrowSwapper.c
@@ -342,7 +342,7 @@ static void rebind_symbols_for_image(const struct mach_header *header, intptr_t 
     const segment_command_t *data_const_seg = ksgs_getsegbynamefromheader((mach_header_t *) header, SEG_DATA_CONST);
     if (data_const_seg != NULL)
     {
-        if (get_sections(data_seg, &lazy_sym_sect, &non_lazy_sym_sect))
+        if (get_sections(data_const_seg, &lazy_sym_sect, &non_lazy_sym_sect))
         {
             perform_rebinding_with_section(lazy_sym_sect, slide, symtab, strtab, indirect_symtab);
             perform_rebinding_with_section(non_lazy_sym_sect, slide, symtab, strtab, indirect_symtab);

--- a/Source/KSCrash/Recording/Tools/KSgetsect.c
+++ b/Source/KSCrash/Recording/Tools/KSgetsect.c
@@ -48,44 +48,19 @@
 #include "KSgetsect.h"
 #include <string.h>
 
-#ifndef __LP64__
-const struct segment_command *ksgs_getsegbynamefromheader(const struct mach_header *mhp, char *segname)
+const segment_command_t *ksgs_getsegbynamefromheader(const mach_header_t *header, const char *seg_name)
 {
-    struct segment_command *sgp;
-    uint32_t i;
+    segment_command_t *sgp;
+    unsigned long i;
 
-    sgp = (struct segment_command *) ((char *) mhp + sizeof(struct mach_header));
-    for (i = 0; i < mhp->ncmds; i++)
+    sgp = (segment_command_t *) ((uintptr_t) header + sizeof(mach_header_t));
+    for (i = 0; i < header->ncmds; i++)
     {
-        if (sgp->cmd == LC_SEGMENT)
+        if (sgp->cmd == LC_SEGMENT_ARCH_DEPENDENT && strncmp(sgp->segname, seg_name, sizeof(sgp->segname)) == 0)
         {
-            if (strncmp(sgp->segname, segname, sizeof(sgp->segname)) == 0)
-            {
-                return sgp;
-            }
+            return sgp;
         }
-        sgp = (struct segment_command *) ((char *) sgp + sgp->cmdsize);
+        sgp = (segment_command_t *) ((uintptr_t) sgp + sgp->cmdsize);
     }
-    return NULL;
+    return (segment_command_t *) NULL;
 }
-#else /* defined(__LP64__) */
-const struct segment_command_64 *ksgs_getsegbynamefromheader(const struct mach_header_64 *mhp, char *segname)
-{
-    struct segment_command_64 *sgp;
-    uint32_t i;
-
-    sgp = (struct segment_command_64 *) ((char *) mhp + sizeof(struct mach_header_64));
-    for (i = 0; i < mhp->ncmds; i++)
-    {
-        if (sgp->cmd == LC_SEGMENT_64)
-        {
-            if (strncmp(sgp->segname, segname, sizeof(sgp->segname)) == 0)
-            {
-                return sgp;
-            }
-        }
-        sgp = (struct segment_command_64 *) ((char *) sgp + sgp->cmdsize);
-    }
-    return NULL;
-}
-#endif /* defined(__LP64__) */

--- a/Source/KSCrash/Recording/Tools/KSgetsect.h
+++ b/Source/KSCrash/Recording/Tools/KSgetsect.h
@@ -25,22 +25,20 @@
 #ifndef KSgetsect_h
 #define KSgetsect_h
 
-#include <mach-o/loader.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
+
+#include <mach-o/loader.h>
+#include "KSPlatformSpecificDefines.h"
+
 /**
  * This routine returns the segment_command structure for the named segment
  * if it exist in the passed mach header. Otherwise it returns zero.
  * It just looks through the load commands. Since these are mapped into the text
  * segment they are read only and thus const.
  */
-#ifndef __LP64__
-const struct segment_command *ksgs_getsegbynamefromheader(const struct mach_header *mhp, char *segname);
-#else /* defined(__LP64__) */
-const struct segment_command_64 *ksgs_getsegbynamefromheader(const struct mach_header_64 *mhp, char *segname);
-#endif /* defined(__LP64__) */
+const segment_command_t *ksgs_getsegbynamefromheader(const mach_header_t *header, const char *seg_name);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Prevented tail call optimisation to gain constant stack frames number in backtrace.