### PR TITLE
Fix iOS 13.4 runtime crash

### DIFF
--- a/Source/KSCrash/Recording/Tools/KSObjC.c
+++ b/Source/KSCrash/Recording/Tools/KSObjC.c
@@ -227,7 +227,25 @@ static inline struct class_rw_t* getClassRW(const struct class_t* const class)
 
 static inline const struct class_ro_t* getClassRO(const struct class_t* const class)
 {
+#ifdef KS_OBJC_CLASS_ABI_VERSION_MAX
+    class_rw_t *rw = getClassRW(class);
+    uintptr_t ext_ptr = rw->ro_or_rw_ext;
+    /* When objc_class_abi_version >= 1, it's a tagged union based on the low bit:
+    * 0: class_ro_t  1: class_rw_ext_t
+    * @see https://opensource.apple.com/source/objc4/objc4-781/runtime/objc-runtime-new.h */
+    if (ext_ptr & 0x1UL) {
+        ext_ptr &= ~0x1UL;
+        struct class_rw_ext_t *rw_ext = (struct class_rw_ext_t *)ext_ptr;
+        return rw_ext->ro;
+    } else {
+        ext_ptr &= ~0x1UL;
+        struct class_ro_t *ro = (struct class_ro_t *)ext_ptr;
+        return ro;
+    }
+
+#else
     return getClassRW(class)->ro;
+#endif
 }
 
 static inline const void* getSuperClass(const void* const classPtr)

--- a/Source/KSCrash/Recording/Tools/KSObjC.c
+++ b/Source/KSCrash/Recording/Tools/KSObjC.c
@@ -227,7 +227,6 @@ static inline struct class_rw_t* getClassRW(const struct class_t* const class)
 
 static inline const struct class_ro_t* getClassRO(const struct class_t* const class)
 {
-#ifdef KS_OBJC_CLASS_ABI_VERSION_MAX
     class_rw_t *rw = getClassRW(class);
     uintptr_t ext_ptr = rw->ro_or_rw_ext;
     /* When objc_class_abi_version >= 1, it's a tagged union based on the low bit:
@@ -238,14 +237,9 @@ static inline const struct class_ro_t* getClassRO(const struct class_t* const cl
         struct class_rw_ext_t *rw_ext = (struct class_rw_ext_t *)ext_ptr;
         return rw_ext->ro;
     } else {
-        ext_ptr &= ~0x1UL;
         struct class_ro_t *ro = (struct class_ro_t *)ext_ptr;
         return ro;
     }
-
-#else
-    return getClassRW(class)->ro;
-#endif
 }
 
 static inline const void* getSuperClass(const void* const classPtr)

--- a/Source/KSCrash/Recording/Tools/KSObjCApple.h
+++ b/Source/KSCrash/Recording/Tools/KSObjCApple.h
@@ -230,8 +230,32 @@ typedef struct class_ro_t {
     property_list_t *baseProperties;
 } class_ro_t;
 
+#if (defined __MAC_10_15_4) || (defined __IPHONE_13_4)
+// @see https://opensource.apple.com/source/objc4/objc4-781/runtime/objc-gdb.h
+#define KS_OBJC_CLASS_ABI_VERSION_MAX 1
+#endif
+
+struct class_rw_ext_t {
+    const class_ro_t *ro;
+    method_array_t methods;
+    property_array_t properties;
+    protocol_array_t protocols;
+    char *demangledName;
+    uint32_t version;
+};
+
 typedef struct class_rw_t {
     uint32_t flags;
+#ifdef KS_OBJC_CLASS_ABI_VERSION_MAX
+    uint16_t witness;
+    uint16_t index;
+    
+    uintptr_t ro_or_rw_ext;
+    
+    Class firstSubclass;
+    Class nextSiblingClass;
+    
+#else
     uint32_t version;
     
     const class_ro_t *ro;
@@ -244,6 +268,8 @@ typedef struct class_rw_t {
     Class nextSiblingClass;
     
     char *demangledName;
+#endif
+    
 } class_rw_t;
 
 typedef struct class_t {

--- a/Source/KSCrash/Recording/Tools/KSObjCApple.h
+++ b/Source/KSCrash/Recording/Tools/KSObjCApple.h
@@ -110,6 +110,15 @@ NAME { \
 #endif
 
 // ======================================================================
+#pragma mark - objc4-781/runtime/objc-internal.h -
+// ======================================================================
+#if __ARM_ARCH_7K__ >= 2  ||  (__arm64__ && !__LP64__)
+#   define SUPPORT_INDEXED_ISA 1
+#else
+#   define SUPPORT_INDEXED_ISA 0
+#endif
+
+// ======================================================================
 #pragma mark - objc4-680/runtime/objc-internal.h -
 // ======================================================================
 
@@ -230,11 +239,6 @@ typedef struct class_ro_t {
     property_list_t *baseProperties;
 } class_ro_t;
 
-#if (defined __MAC_10_15_4) || (defined __IPHONE_13_4)
-// @see https://opensource.apple.com/source/objc4/objc4-781/runtime/objc-gdb.h
-#define KS_OBJC_CLASS_ABI_VERSION_MAX 1
-#endif
-
 struct class_rw_ext_t {
     const class_ro_t *ro;
     method_array_t methods;
@@ -246,30 +250,15 @@ struct class_rw_ext_t {
 
 typedef struct class_rw_t {
     uint32_t flags;
-#ifdef KS_OBJC_CLASS_ABI_VERSION_MAX
     uint16_t witness;
+#if SUPPORT_INDEXED_ISA
     uint16_t index;
-    
-    uintptr_t ro_or_rw_ext;
-    
-    Class firstSubclass;
-    Class nextSiblingClass;
-    
-#else
-    uint32_t version;
-    
-    const class_ro_t *ro;
-    
-    method_array_t methods;
-    property_array_t properties;
-    protocol_array_t protocols;
-    
-    Class firstSubclass;
-    Class nextSiblingClass;
-    
-    char *demangledName;
 #endif
     
+    uintptr_t ro_or_rw_ext;
+    Class firstSubclass;
+    Class nextSiblingClass;
+
 } class_rw_t;
 
 typedef struct class_t {


### PR DESCRIPTION
on iOS 13.4, Apple changed objective-c runtime code (objc4-781),  The structure `class_rw_t` ro pointer has changed.
This should fix this bug：https://github.com/kstenerud/KSCrash/issues/371.
I have passed the test on my iphone iOS 13.4 and macbook pro macOS 10.15.5.