### PR TITLE
Fix rw->ext read failure

### DIFF
--- a/Source/KSCrash/Recording/Tools/KSObjC.c
+++ b/Source/KSCrash/Recording/Tools/KSObjC.c
@@ -540,6 +540,20 @@ static bool isValidIvarType(const char* const type)
     return false;
 }
 
+static bool containsValidExtData(class_rw_t *rw)
+{
+    uintptr_t ext_ptr = rw->ro_or_rw_ext;
+    if (ext_ptr & 0x1UL) {
+        ext_ptr &= ~0x1UL;
+        struct class_rw_ext_t *rw_ext = (struct class_rw_ext_t *)ext_ptr;
+        if (!ksmem_isMemoryReadable(rw_ext, sizeof(*rw_ext))) {
+            return false;
+        }
+    }
+    
+    return true;
+}
+
 static bool containsValidROData(const void* const classPtr)
 {
     const struct class_t* const class = classPtr;
@@ -552,6 +566,11 @@ static bool containsValidROData(const void* const classPtr)
     {
         return false;
     }
+    
+    if (!containsValidExtData(rw)) {
+        return false;
+    }
+    
     const class_ro_t* ro = getClassRO(class);
     if(!ksmem_isMemoryReadable(ro, sizeof(*ro)))
     {
@@ -559,6 +578,7 @@ static bool containsValidROData(const void* const classPtr)
     }
     return true;
 }
+
 
 static bool containsValidIvarData(const void* const classPtr)
 {

--- a/Source/KSCrash/Recording/Tools/KSObjC.c
+++ b/Source/KSCrash/Recording/Tools/KSObjC.c
@@ -550,7 +550,6 @@ static bool containsValidExtData(class_rw_t *rw)
             return false;
         }
     }
-    
     return true;
 }
 
@@ -566,11 +565,9 @@ static bool containsValidROData(const void* const classPtr)
     {
         return false;
     }
-    
     if (!containsValidExtData(rw)) {
         return false;
     }
-    
     const class_ro_t* ro = getClassRO(class);
     if(!ksmem_isMemoryReadable(ro, sizeof(*ro)))
     {
@@ -578,7 +575,6 @@ static bool containsValidROData(const void* const classPtr)
     }
     return true;
 }
-
 
 static bool containsValidIvarData(const void* const classPtr)
 {


### PR DESCRIPTION
Before this, I submitted a pull request: https://github.com/kstenerud/KSCrash/pull/380, but when capturing the crash, I need to judge whether rw->ext is readable. This is my mistake.  So I created a fix。Please review this pull request。@kstenerud