### PR TITLE
modify GZip category name,avoid duplicate name with GZip library

### DIFF
--- a/Source/Framework/KSCrashFramework.h
+++ b/Source/Framework/KSCrashFramework.h
@@ -37,6 +37,6 @@
 #import "KSCrashReportSinkVictory.h"
 #import "KSCrashReportWriter.h"
 #import "KSJSONCodecObjC.h"
-#import "NSData+GZip.h"
+#import "NSData+KSGZip.h"
 
 #endif /* KSCrashFramework_h */

--- a/Source/KSCrash-Tests/KSCrashReportFilterGZip_Tests.m
+++ b/Source/KSCrash-Tests/KSCrashReportFilterGZip_Tests.m
@@ -28,7 +28,7 @@
 #import <XCTest/XCTest.h>
 
 #import "KSCrashReportFilterGZip.h"
-#import "NSData+GZip.h"
+#import "NSData+KSGZip.h"
 
 
 @interface KSCrashReportFilterGZip_Tests : XCTestCase @end

--- a/Source/KSCrash-Tests/KSCrashReportFilter_Tests.m
+++ b/Source/KSCrash-Tests/KSCrashReportFilter_Tests.m
@@ -31,7 +31,7 @@
 #import "KSCrashReportFilterBasic.h"
 #import "KSCrashReportFilterGZip.h"
 #import "KSCrashReportFilterJSON.h"
-#import "NSData+GZip.h"
+#import "NSData+KSGZip.h"
 #import "NSError+SimpleConstructor.h"
 
 

--- a/Source/KSCrash-Tests/NSData+Gzip_Tests.m
+++ b/Source/KSCrash-Tests/NSData+Gzip_Tests.m
@@ -26,7 +26,7 @@
 
 
 #import <XCTest/XCTest.h>
-#import "NSData+GZip.h"
+#import "NSData+KSGZip.h"
 
 
 @interface NSData_Gzip_Tests : XCTestCase @end

--- a/Source/KSCrash/Reporting/Filters/KSCrashReportFilterGZip.m
+++ b/Source/KSCrash/Reporting/Filters/KSCrashReportFilterGZip.m
@@ -26,7 +26,7 @@
 
 
 #import "KSCrashReportFilterGZip.h"
-#import "NSData+GZip.h"
+#import "NSData+KSGZip.h"
 
 
 @interface KSCrashReportFilterGZipCompress ()

--- a/Source/KSCrash/Reporting/Filters/Tools/NSData+KSGZip.h
+++ b/Source/KSCrash/Reporting/Filters/Tools/NSData+KSGZip.h
@@ -31,7 +31,7 @@
 /**
  * GNU zip/unzip support for NSData.
  */
-@interface NSData (GZip)
+@interface NSData (KSGZip)
 
 /**
  * Gzip the data in this object (no header).

--- a/Source/KSCrash/Reporting/Filters/Tools/NSData+KSGZip.m
+++ b/Source/KSCrash/Reporting/Filters/Tools/NSData+KSGZip.m
@@ -25,7 +25,7 @@
 //
 
 
-#import "NSData+GZip.h"
+#import "NSData+KSGZip.h"
 
 #import "NSError+SimpleConstructor.h"
 #import <zlib.h>
@@ -60,7 +60,7 @@ static NSString* zlibError(int errorCode)
     return [NSString stringWithFormat:@"Unknown error: %d", errorCode];
 }
 
-@implementation NSData (GZip)
+@implementation NSData (KSGZip)
 
 - (NSData*) gzippedWithCompressionLevel:(int) compressionLevel
                                   error:(NSError* __autoreleasing *) error

--- a/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkEMail.m
+++ b/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkEMail.m
@@ -296,7 +296,7 @@
 
 #else
 
-#import "NSData+GZip.h"
+#import "NSData+KSGZip.h"
 
 @implementation KSCrashReportSinkEMail
 

--- a/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkQuincyHockey.m
+++ b/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkQuincyHockey.m
@@ -30,7 +30,7 @@
 #import "KSCrashReportFields.h"
 #import "KSHTTPMultipartPostBody.h"
 #import "KSHTTPRequestSender.h"
-#import "NSData+GZip.h"
+#import "NSData+KSGZip.h"
 #import "KSCrashReportFilterAppleFmt.h"
 #import "KSCrashReportFilterBasic.h"
 #import "KSJSONCodecObjC.h"

--- a/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkStandard.m
+++ b/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkStandard.m
@@ -29,7 +29,7 @@
 
 #import "KSHTTPMultipartPostBody.h"
 #import "KSHTTPRequestSender.h"
-#import "NSData+GZip.h"
+#import "NSData+KSGZip.h"
 #import "KSJSONCodecObjC.h"
 #import "KSReachabilityKSCrash.h"
 #import "NSError+SimpleConstructor.h"

--- a/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkVictory.m
+++ b/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkVictory.m
@@ -33,7 +33,7 @@
 
 #import "KSHTTPMultipartPostBody.h"
 #import "KSHTTPRequestSender.h"
-#import "NSData+GZip.h"
+#import "NSData+KSGZip.h"
 #import "KSJSONCodecObjC.h"
 #import "KSReachabilityKSCrash.h"
 #import "NSError+SimpleConstructor.h"

--- a/iOS/KSCrash-iOS.xcodeproj/project.pbxproj
+++ b/iOS/KSCrash-iOS.xcodeproj/project.pbxproj
@@ -107,8 +107,8 @@
 		03DE7CB81C84DFBC00F789BA /* Container+DeepSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D1317EB765C0056DA83 /* Container+DeepSearch.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		03DE7CB91C84DFBC00F789BA /* Container+DeepSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D1417EB765C0056DA83 /* Container+DeepSearch.m */; };
 		03DE7CBA1C84DFBC00F789BA /* KSVarArgs.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8617EB765C0056DA83 /* KSVarArgs.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		03DE7CBB1C84DFBC00F789BA /* NSData+GZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+GZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		03DE7CBC1C84DFBC00F789BA /* NSData+GZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8A17EB765C0056DA83 /* NSData+GZip.m */; };
+		03DE7CBB1C84DFBC00F789BA /* NSData+KSGZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+KSGZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		03DE7CBC1C84DFBC00F789BA /* NSData+KSGZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8A17EB765C0056DA83 /* NSData+KSGZip.m */; };
 		03DE7CBD1C84DFC100F789BA /* KSCString.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D6117EB765C0056DA83 /* KSCString.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		03DE7CBE1C84DFC100F789BA /* KSCString.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D6217EB765C0056DA83 /* KSCString.m */; };
 		03DE7CBF1C84DFC100F789BA /* KSHTTPMultipartPostBody.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D6517EB765C0056DA83 /* KSHTTPMultipartPostBody.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -210,7 +210,7 @@
 		632D8DF51EDFFA6700A9A62E /* KSCrashReportFilterStringify.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CB94D3611CAC190900806679 /* KSCrashReportFilterStringify.h */; };
 		632D8DF61EDFFA6700A9A62E /* Container+DeepSearch.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D1317EB765C0056DA83 /* Container+DeepSearch.h */; };
 		632D8DF71EDFFA6700A9A62E /* KSVarArgs.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8617EB765C0056DA83 /* KSVarArgs.h */; };
-		632D8DF81EDFFA6700A9A62E /* NSData+GZip.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+GZip.h */; };
+		632D8DF81EDFFA6700A9A62E /* NSData+KSGZip.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+KSGZip.h */; };
 		632D8DF91EDFFA6700A9A62E /* KSCrashReportSinkConsole.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D4117EB765C0056DA83 /* KSCrashReportSinkConsole.h */; };
 		632D8DFA1EDFFA6700A9A62E /* KSCrashReportSinkEMail.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D4317EB765C0056DA83 /* KSCrashReportSinkEMail.h */; };
 		632D8DFB1EDFFA6700A9A62E /* KSCrashReportSinkQuincyHockey.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CBF53D4517EB765C0056DA83 /* KSCrashReportSinkQuincyHockey.h */; };
@@ -490,7 +490,7 @@
 		CBF53E3517EB765C0056DA83 /* KSSysCtl.c in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8117EB765C0056DA83 /* KSSysCtl.c */; };
 		CBF53E3917EB765C0056DA83 /* KSCrashMonitor_System.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8417EB765C0056DA83 /* KSCrashMonitor_System.m */; };
 		CBF53E3E17EB765C0056DA83 /* KSCrashMonitor_Zombie.c in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8817EB765C0056DA83 /* KSCrashMonitor_Zombie.c */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		CBF53E4117EB765C0056DA83 /* NSData+GZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8A17EB765C0056DA83 /* NSData+GZip.m */; };
+		CBF53E4117EB765C0056DA83 /* NSData+KSGZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8A17EB765C0056DA83 /* NSData+KSGZip.m */; };
 		CBF53E4717EB765C0056DA83 /* NSError+SimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8E17EB765C0056DA83 /* NSError+SimpleConstructor.m */; };
 		CBF53E4A17EB765C0056DA83 /* NSMutableData+AppendUTF8.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D9017EB765C0056DA83 /* NSMutableData+AppendUTF8.m */; };
 		CBF53E5617EB7EA80056DA83 /* KSCrashC.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D1F17EB765C0056DA83 /* KSCrashC.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -536,7 +536,7 @@
 		CBF53E8B17EB7EA80056DA83 /* KSHTTPRequestSender.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D6717EB765C0056DA83 /* KSHTTPRequestSender.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBF53E8C17EB7EA80056DA83 /* KSReachabilityKSCrash.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D7817EB765C0056DA83 /* KSReachabilityKSCrash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBF53E8E17EB7EA80056DA83 /* KSVarArgs.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8617EB765C0056DA83 /* KSVarArgs.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CBF53E8F17EB7EA80056DA83 /* NSData+GZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+GZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CBF53E8F17EB7EA80056DA83 /* NSData+KSGZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+KSGZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBF53E9117EB7EA80056DA83 /* NSError+SimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8D17EB765C0056DA83 /* NSError+SimpleConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBF53E9217EB7EA80056DA83 /* NSMutableData+AppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8F17EB765C0056DA83 /* NSMutableData+AppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CBF53E9317EB7EA80056DA83 /* KSCrashInstallation+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D2717EB765C0056DA83 /* KSCrashInstallation+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -592,7 +592,7 @@
 		EDF2BEAB1CCF15AD004BADF4 /* KSCrashInstallationVictory.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D2F17EB765C0056DA83 /* KSCrashInstallationVictory.m */; };
 		EDF2BEAC1CCF15AD004BADF4 /* KSCrashReportSinkStandard.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D4817EB765C0056DA83 /* KSCrashReportSinkStandard.m */; };
 		EDF2BEAD1CCF15AD004BADF4 /* KSCString.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D6217EB765C0056DA83 /* KSCString.m */; };
-		EDF2BEAE1CCF15AD004BADF4 /* NSData+GZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8A17EB765C0056DA83 /* NSData+GZip.m */; };
+		EDF2BEAE1CCF15AD004BADF4 /* NSData+KSGZip.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D8A17EB765C0056DA83 /* NSData+KSGZip.m */; };
 		EDF2BEB01CCF15AD004BADF4 /* KSObjC.c in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D7517EB765C0056DA83 /* KSObjC.c */; };
 		EDF2BEB11CCF15AD004BADF4 /* KSCrashReportFilterJSON.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D3E17EB765C0056DA83 /* KSCrashReportFilterJSON.m */; };
 		EDF2BEB21CCF15AD004BADF4 /* KSCrashInstallation.m in Sources */ = {isa = PBXBuildFile; fileRef = CBF53D2617EB765C0056DA83 /* KSCrashInstallation.m */; };
@@ -643,7 +643,7 @@
 		EDF2BEE91CCF15AD004BADF4 /* KSCrashReportFields.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D3217EB765C0056DA83 /* KSCrashReportFields.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BEEA1CCF15AD004BADF4 /* KSCrashMonitor_NSException.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D5417EB765C0056DA83 /* KSCrashMonitor_NSException.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BEEB1CCF15AD004BADF4 /* AlignOf.h in Headers */ = {isa = PBXBuildFile; fileRef = CBC43F0F1C5AF2B10083A11B /* AlignOf.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		EDF2BEEC1CCF15AD004BADF4 /* NSData+GZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+GZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EDF2BEEC1CCF15AD004BADF4 /* NSData+KSGZip.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8917EB765C0056DA83 /* NSData+KSGZip.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EDF2BEED1CCF15AD004BADF4 /* KSCrashMonitor_User.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D5A17EB765C0056DA83 /* KSCrashMonitor_User.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BEEE1CCF15AD004BADF4 /* StringRef.h in Headers */ = {isa = PBXBuildFile; fileRef = CBC43F0B1C5AF2B10083A11B /* StringRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDF2BEEF1CCF15AD004BADF4 /* NSMutableData+AppendUTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF53D8F17EB765C0056DA83 /* NSMutableData+AppendUTF8.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -778,7 +778,7 @@
 				632D8DF51EDFFA6700A9A62E /* KSCrashReportFilterStringify.h in Copy Headers */,
 				632D8DF61EDFFA6700A9A62E /* Container+DeepSearch.h in Copy Headers */,
 				632D8DF71EDFFA6700A9A62E /* KSVarArgs.h in Copy Headers */,
-				632D8DF81EDFFA6700A9A62E /* NSData+GZip.h in Copy Headers */,
+				632D8DF81EDFFA6700A9A62E /* NSData+KSGZip.h in Copy Headers */,
 				632D8DF91EDFFA6700A9A62E /* KSCrashReportSinkConsole.h in Copy Headers */,
 				632D8DFA1EDFFA6700A9A62E /* KSCrashReportSinkEMail.h in Copy Headers */,
 				632D8DFB1EDFFA6700A9A62E /* KSCrashReportSinkQuincyHockey.h in Copy Headers */,
@@ -1039,8 +1039,8 @@
 		CBF53D8617EB765C0056DA83 /* KSVarArgs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSVarArgs.h; path = ../../Source/KSCrash/Reporting/Filters/Tools/KSVarArgs.h; sourceTree = "<group>"; };
 		CBF53D8717EB765C0056DA83 /* KSCrashMonitor_Zombie.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KSCrashMonitor_Zombie.h; path = ../../Source/KSCrash/Recording/Monitors/KSCrashMonitor_Zombie.h; sourceTree = "<group>"; };
 		CBF53D8817EB765C0056DA83 /* KSCrashMonitor_Zombie.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = KSCrashMonitor_Zombie.c; path = ../../Source/KSCrash/Recording/Monitors/KSCrashMonitor_Zombie.c; sourceTree = "<group>"; };
-		CBF53D8917EB765C0056DA83 /* NSData+GZip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSData+GZip.h"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+GZip.h"; sourceTree = "<group>"; };
-		CBF53D8A17EB765C0056DA83 /* NSData+GZip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+GZip.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+GZip.m"; sourceTree = "<group>"; };
+		CBF53D8917EB765C0056DA83 /* NSData+KSGZip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSData+KSGZip.h"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+KSGZip.h"; sourceTree = "<group>"; };
+		CBF53D8A17EB765C0056DA83 /* NSData+KSGZip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSData+KSGZip.m"; path = "../../Source/KSCrash/Reporting/Filters/Tools/NSData+KSGZip.m"; sourceTree = "<group>"; };
 		CBF53D8D17EB765C0056DA83 /* NSError+SimpleConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSError+SimpleConstructor.h"; path = "../../Source/KSCrash/Recording/Tools/NSError+SimpleConstructor.h"; sourceTree = "<group>"; };
 		CBF53D8E17EB765C0056DA83 /* NSError+SimpleConstructor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+SimpleConstructor.m"; path = "../../Source/KSCrash/Recording/Tools/NSError+SimpleConstructor.m"; sourceTree = "<group>"; };
 		CBF53D8F17EB765C0056DA83 /* NSMutableData+AppendUTF8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSMutableData+AppendUTF8.h"; path = "../../Source/KSCrash/Reporting/Tools/NSMutableData+AppendUTF8.h"; sourceTree = "<group>"; };
@@ -1499,8 +1499,8 @@
 				CBF53D1317EB765C0056DA83 /* Container+DeepSearch.h */,
 				CBF53D1417EB765C0056DA83 /* Container+DeepSearch.m */,
 				CBF53D8617EB765C0056DA83 /* KSVarArgs.h */,
-				CBF53D8917EB765C0056DA83 /* NSData+GZip.h */,
-				CBF53D8A17EB765C0056DA83 /* NSData+GZip.m */,
+				CBF53D8917EB765C0056DA83 /* NSData+KSGZip.h */,
+				CBF53D8A17EB765C0056DA83 /* NSData+KSGZip.m */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -1533,7 +1533,7 @@
 				03DE7CC71C84DFCD00F789BA /* KSCrashInstallation+Private.h in Headers */,
 				03DE7DAA1C879A0200F789BA /* KSCrashFramework.h in Headers */,
 				CB5657EF1E1D8A71005A8302 /* KSStackCursor_SelfThread.h in Headers */,
-				03DE7CBB1C84DFBC00F789BA /* NSData+GZip.h in Headers */,
+				03DE7CBB1C84DFBC00F789BA /* NSData+KSGZip.h in Headers */,
 				03DE7CD21C84DFD000F789BA /* KSCrash.h in Headers */,
 				03DE7C421C84DF8100F789BA /* KSCrashC.h in Headers */,
 				CB5633CD1DD5392A0023CEB6 /* KSCrashMonitorContext.h in Headers */,
@@ -1701,7 +1701,7 @@
 				CBF53E7117EB7EA80056DA83 /* KSObjC.h in Headers */,
 				CBF53E6C17EB7EA80056DA83 /* KSJSONCodec.h in Headers */,
 				CBF53E5F17EB7EA80056DA83 /* KSCrashMonitor.h in Headers */,
-				CBF53E8F17EB7EA80056DA83 /* NSData+GZip.h in Headers */,
+				CBF53E8F17EB7EA80056DA83 /* NSData+KSGZip.h in Headers */,
 				CBF53E5D17EB7EA80056DA83 /* KSCrashMonitor_System.h in Headers */,
 				CBF53E7417EB7EA80056DA83 /* KSSignalInfo.h in Headers */,
 				CB25A5BA1DF2182A00EC2B02 /* KSCPU.h in Headers */,
@@ -1785,7 +1785,7 @@
 				EDF2BEE91CCF15AD004BADF4 /* KSCrashReportFields.h in Headers */,
 				EDF2BEEA1CCF15AD004BADF4 /* KSCrashMonitor_NSException.h in Headers */,
 				EDF2BEEB1CCF15AD004BADF4 /* AlignOf.h in Headers */,
-				EDF2BEEC1CCF15AD004BADF4 /* NSData+GZip.h in Headers */,
+				EDF2BEEC1CCF15AD004BADF4 /* NSData+KSGZip.h in Headers */,
 				EDF2BEED1CCF15AD004BADF4 /* KSCrashMonitor_User.h in Headers */,
 				EDF2BEEE1CCF15AD004BADF4 /* StringRef.h in Headers */,
 				EDF2BEEF1CCF15AD004BADF4 /* NSMutableData+AppendUTF8.h in Headers */,
@@ -1936,6 +1936,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -2040,7 +2041,7 @@
 				03DE7CA71C84DFB100F789BA /* KSCrashReportSinkStandard.m in Sources */,
 				CBA8A0C61E2561210019B5B9 /* KSCrashCachedData.c in Sources */,
 				03DE7CBE1C84DFC100F789BA /* KSCString.m in Sources */,
-				03DE7CBC1C84DFBC00F789BA /* NSData+GZip.m in Sources */,
+				03DE7CBC1C84DFBC00F789BA /* NSData+KSGZip.m in Sources */,
 				03DE7C8A1C84DFAB00F789BA /* KSObjC.c in Sources */,
 				03DE7CB51C84DFB700F789BA /* KSCrashReportFilterJSON.m in Sources */,
 				03DE7CC91C84DFCD00F789BA /* KSCrashInstallation.m in Sources */,
@@ -2122,7 +2123,7 @@
 				CBF53DA317EB765C0056DA83 /* KSCrashC.c in Sources */,
 				CBF53E1117EB765C0056DA83 /* KSJSONCodec.c in Sources */,
 				CBB61CC11E0035E4000C24A6 /* KSID.c in Sources */,
-				CBF53E4117EB765C0056DA83 /* NSData+GZip.m in Sources */,
+				CBF53E4117EB765C0056DA83 /* NSData+KSGZip.m in Sources */,
 				CBA8A0C51E2561210019B5B9 /* KSCrashCachedData.c in Sources */,
 				CBF53E2017EB765C0056DA83 /* KSMemory.c in Sources */,
 				CBF53E0817EB765C0056DA83 /* KSFileUtils.c in Sources */,
@@ -2256,7 +2257,7 @@
 				EDF2BEAC1CCF15AD004BADF4 /* KSCrashReportSinkStandard.m in Sources */,
 				CBA8A0C71E2561210019B5B9 /* KSCrashCachedData.c in Sources */,
 				EDF2BEAD1CCF15AD004BADF4 /* KSCString.m in Sources */,
-				EDF2BEAE1CCF15AD004BADF4 /* NSData+GZip.m in Sources */,
+				EDF2BEAE1CCF15AD004BADF4 /* NSData+KSGZip.m in Sources */,
 				EDF2BEB01CCF15AD004BADF4 /* KSObjC.c in Sources */,
 				EDF2BEB11CCF15AD004BADF4 /* KSCrashReportFilterJSON.m in Sources */,
 				EDF2BEB21CCF15AD004BADF4 /* KSCrashInstallation.m in Sources */,


### PR DESCRIPTION
We use KSCrash and GZip through cocoapods,both lib has a NSData category,named "NSData+GZip",so we have to modify the name in cocoapod,which is not a good solution.