### PR TITLE
Fix compilation for Apple Silicon

### DIFF
--- a/Source/KSCrash/Recording/Tools/KSObjC.c
+++ b/Source/KSCrash/Recording/Tools/KSObjC.c
@@ -195,9 +195,12 @@ static const struct class_t* decodeIsaPointer(const void* const isaPointer)
     if(isa & ISA_TAG_MASK)
     {
 #if defined(__arm64__)
+#if TARGET_OS_IOS
         if (floor(kCFCoreFoundationVersionNumber) <= kCFCoreFoundationVersionNumber_iOS_8_x_Max) {
             return (const struct class_t*)(isa & ISA_MASK_OLD);
         }
+#endif
+        
         return (const struct class_t*)(isa & ISA_MASK);
 #else
         return (const struct class_t*)(isa & ISA_MASK);

--- a/Source/KSCrash/Recording/Tools/KSObjC.c
+++ b/Source/KSCrash/Recording/Tools/KSObjC.c
@@ -49,6 +49,8 @@ typedef unsigned int NSUInteger;
 #include <inttypes.h>
 #include <objc/runtime.h>
 
+#include "TargetConditionals.h"
+
 
 #define kMaxNameLength 128
 

--- a/Source/KSCrash/Recording/Tools/KSObjC.h
+++ b/Source/KSCrash/Recording/Tools/KSObjC.h
@@ -35,6 +35,7 @@ extern "C" {
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "TargetConditionals.h"
 
 
 typedef enum

--- a/Source/KSCrash/Recording/Tools/KSObjC.h
+++ b/Source/KSCrash/Recording/Tools/KSObjC.h
@@ -35,7 +35,6 @@ extern "C" {
 
 #include <stdbool.h>
 #include <stdint.h>
-#include "TargetConditionals.h"
 
 
 typedef enum


### PR DESCRIPTION
`decodeIsaPointer` assumes `__arm64__` is iOS, which was correct prior to Silicon being introduced. 
Trying to build when targeting Apple Silicon results in an error as the constant `kCFCoreFoundationVersionNumber_iOS_8_x_Max ` cannot be found.
 
This is fixed by ensuring the check is wrapped up in a preprocessor directive.

Tested building on an intel mac while targeting silicon, building on an M1 mac for silicon and intel. Crash Reporting also appears unaffected on both native and in the simulator.