### PR TITLE
Include def files in podspec

### DIFF
--- a/KSCrash.podspec
+++ b/KSCrash.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
     recording.compiler_flags = '-fno-optimize-sibling-calls'
     recording.source_files   = 'Source/KSCrash/Recording/**/*.{h,m,mm,c,cpp}',
                                'Source/KSCrash/llvm/**/*.{h,m,mm,c,cpp}',
-                               'Source/KSCrash/swift/**/*.{h,m,mm,c,cpp}',
+                               'Source/KSCrash/swift/**/*.{h,m,mm,c,cpp,def}',
                                'Source/KSCrash/Reporting/Filters/KSCrashReportFilter.h'
     recording.public_header_files = 'Source/KSCrash/Recording/KSCrash.h',
                                     'Source/KSCrash/Recording/KSCrashC.h',


### PR DESCRIPTION
Pull Request #385 updated the swift demangler files to the latest version at the time, which included some new `.def` files. These have not been included in the podspec, which results in compilation errors when importing KSCrash via CocoaPods, as it cannot find those files.