### PR TITLE
Update KSMachineContext.c

### DIFF
--- a/Source/KSCrash/Recording/Tools/KSMachineContext.c
+++ b/Source/KSCrash/Recording/Tools/KSMachineContext.c
@@ -89,7 +89,7 @@ static inline bool getThreadList(KSMachineContext* context)
 
     for(mach_msg_type_number_t i = 0; i < actualThreadCount; i++)
     {
-        mach_port_deallocate(thisTask, context->allThreads[i]);
+        mach_port_deallocate(thisTask, threads[i]);
     }
     vm_deallocate(thisTask, (vm_address_t)threads, sizeof(thread_t) * actualThreadCount);
 


### PR DESCRIPTION
The count of the `context->allThreads` is truncated to `maxThreadCount`,so we should use `threads` to release.