### PR TITLE
Fix ksobjc_objectType error

### DIFF
--- a/Source/KSCrash/Recording/Tools/KSObjC.c
+++ b/Source/KSCrash/Recording/Tools/KSObjC.c
@@ -924,16 +924,11 @@ KSObjCType ksobjc_objectType(const void* objectOrClassPtr)
         return KSObjCTypeObject;
     }
     
-    if(!isValidObject(objectOrClassPtr))
+    if(!isValidObject(objectOrClassPtr) && !isValidClass(objectOrClassPtr))
     {
         return KSObjCTypeUnknown;
     }
-    
-    if(!isValidClass(objectOrClassPtr))
-    {
-        return KSObjCTypeUnknown;
-    }
-    
+        
     const struct class_t* isa = getIsaPointer(objectOrClassPtr);
 
     if(isBlockClass(isa))


### PR DESCRIPTION
NSObject *obj = [NSObject new];
ksobjc_objectType((__bridge void *)obj);

Both object and block return KSObjCTypeUnknown.