### PR TITLE
Fix typo in error message

### DIFF
--- a/Source/KSCrash/Installations/KSCrashInstallation.m
+++ b/Source/KSCrash/Installations/KSCrashInstallation.m
@@ -179,7 +179,7 @@ static void crashCallback(const KSCrashReportWriter* writer)
 - (id) init
 {
     [NSException raise:NSInternalInconsistencyException
-                format:@"%@ does not support init. Subclasses must call initWithMaxReportFieldCount:requiredProperties:", [self class]];
+                format:@"%@ does not support init. Subclasses must call initWithRequiredProperties:", [self class]];
     return nil;
 }
 


### PR DESCRIPTION
I found when calling `.init` that the error message I was getting referred to a method that must have been refactored at some point in the past and no longer exists with that signature.