### PR TITLE
fix: prevent possible overflow

### DIFF
--- a/Source/KSCrash/Recording/KSCrashC.h
+++ b/Source/KSCrash/Recording/KSCrashC.h
@@ -131,16 +131,14 @@ void kscrash_setCrashNotifyCallback(const KSReportWriteCallback onCrashNotify);
 
 typedef void (*KSReportWrittenCallback)(int64_t reportID);
 
-/** Set the callback to invoke upon finishing writing a crash report.
+/** Set the callback to invoke upon finishing writing a crash report. Default is @c NULL .
  *
- * WARNING: Only call async-safe functions from this function! DO NOT call
- * Objective-C methods!!!
+ * @warning Only call async-safe functions from this function! DO NOT call
+ * Objective-C methods!!! See https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/sigaction.2.html.
  *
  * @param onReportWrittenNotify Function to call after writing a crash report to
  *                      give the callee an opportunity to react to the report.
  *                      NULL = ignore.
- *
- * Default: NULL
  */
 void kscrash_setReportWrittenCallback(const KSReportWrittenCallback onReportWrittenNotify);
 

--- a/Source/KSCrash/Recording/Monitors/KSCrashMonitor_AppState.c
+++ b/Source/KSCrash/Recording/Monitors/KSCrashMonitor_AppState.c
@@ -175,7 +175,7 @@ static int addJSONData(const char* const data, const int length, void* const use
 #pragma mark - Utility -
 // ============================================================================
 
-static double getCurentTime()
+static double getCurrentTime()
 {
     struct timeval tv;
     gettimeofday(&tv, NULL);
@@ -184,7 +184,7 @@ static double getCurentTime()
 
 static double timeSince(double timeInSeconds)
 {
-    return getCurentTime() - timeInSeconds;
+    return getCurrentTime() - timeInSeconds;
 }
 
 /** Load the persistent state portion of a crash context.
@@ -324,7 +324,7 @@ done:
 static void updateAppState(void)
 {
     const double duration = timeSince(g_state.appStateTransitionTime);
-    g_state.appStateTransitionTime = getCurentTime();
+    g_state.appStateTransitionTime = getCurrentTime();
     
     if(g_state.applicationIsActive)
     {
@@ -384,7 +384,7 @@ void kscrashstate_notifyObjCLoad(void)
     memset(&g_state, 0, sizeof(g_state));
     g_state.applicationIsInForeground = false;
     g_state.applicationIsActive = true;
-    g_state.appStateTransitionTime = getCurentTime();
+    g_state.appStateTransitionTime = getCurrentTime();
 }
 
 void kscrashstate_notifyAppActive(const bool isActive)
@@ -394,8 +394,8 @@ void kscrashstate_notifyAppActive(const bool isActive)
         g_state.applicationIsActive = isActive;
         if(isActive)
         {
-            KSLOG_TRACE("Updating transition time from: %f to: %f", g_state.appStateTransitionTime, getCurentTime());
-            g_state.appStateTransitionTime = getCurentTime();
+            KSLOG_TRACE("Updating transition time from: %f to: %f", g_state.appStateTransitionTime, getCurrentTime());
+            g_state.appStateTransitionTime = getCurrentTime();
         }
         else
         {
@@ -417,7 +417,7 @@ void kscrashstate_notifyAppInForeground(const bool isInForeground)
         g_state.applicationIsInForeground = isInForeground;
         if(isInForeground)
         {
-            double duration = getCurentTime() - g_state.appStateTransitionTime;
+            double duration = getCurrentTime() - g_state.appStateTransitionTime;
             KSLOG_TRACE("Updating backgroundDurationSinceLaunch: %f and backgroundDurationSinceLastCrash: %f with duration: %f",
                         g_state.backgroundDurationSinceLaunch, g_state.backgroundDurationSinceLastCrash, duration);
             g_state.backgroundDurationSinceLaunch += duration;
@@ -427,7 +427,7 @@ void kscrashstate_notifyAppInForeground(const bool isInForeground)
         }
         else
         {
-            g_state.appStateTransitionTime = getCurentTime();
+            g_state.appStateTransitionTime = getCurrentTime();
             saveState(stateFilePath);
         }
     }

--- a/Source/KSCrash/Recording/Monitors/KSCrashMonitor_Signal.c
+++ b/Source/KSCrash/Recording/Monitors/KSCrashMonitor_Signal.c
@@ -111,7 +111,6 @@ static void handleSignal(int sigNum, siginfo_t* signalInfo, void* userContext)
     }
 
     KSLOG_DEBUG("Re-raising signal for regular handlers to catch.");
-    // This is technically not allowed, but it works in OSX and iOS.
     raise(sigNum);
 }
 

--- a/Source/KSCrash/Recording/Tools/KSObjC.c
+++ b/Source/KSCrash/Recording/Tools/KSObjC.c
@@ -882,7 +882,7 @@ bool ksobjc_ivarValue(const void* const objectPtr, int ivarIndex, void* dst)
         return false;
     }
     uintptr_t ivarPtr = (uintptr_t)&ivars->first;
-    const struct ivar_t *ivar = (void *)(ivarPtr + (uintptr_t)ivars->entsizeAndFlags * (uintptr_t)ivarIndex);
+    const struct ivar_t* ivar = (void*)(ivarPtr + (uintptr_t)ivars->entsizeAndFlags * (uintptr_t)ivarIndex);
     
     uintptr_t valuePtr = (uintptr_t)objectPtr + (uintptr_t)*ivar->offset;
     if(!ksmem_copySafely((void*)valuePtr, dst, (int)ivar->size))

--- a/Source/KSCrash/Recording/Tools/KSObjC.c
+++ b/Source/KSCrash/Recording/Tools/KSObjC.c
@@ -882,7 +882,7 @@ bool ksobjc_ivarValue(const void* const objectPtr, int ivarIndex, void* dst)
         return false;
     }
     uintptr_t ivarPtr = (uintptr_t)&ivars->first;
-    const struct ivar_t* ivar = (void*)(ivarPtr + ivars->entsizeAndFlags * (unsigned)ivarIndex);
+    const struct ivar_t *ivar = (void *)(ivarPtr + (uintptr_t)ivars->entsizeAndFlags * (uintptr_t)ivarIndex);
     
     uintptr_t valuePtr = (uintptr_t)objectPtr + (uintptr_t)*ivar->offset;
     if(!ksmem_copySafely((void*)valuePtr, dst, (int)ivar->size))


### PR DESCRIPTION
The main fix is for a possible overflow when performing a multiplication in some pointer arithmetic.

There are a few unrelated changes rolled in, I'm happy to break them out if desired.