### PR TITLE
Add __crash_info signature and backtrace to report

### DIFF
--- a/Source/KSCrash/Recording/KSCrashReport.c
+++ b/Source/KSCrash/Recording/KSCrashReport.c
@@ -1296,6 +1296,14 @@ static void writeBinaryImage(const KSCrashReportWriter* const writer,
         {
             writer->addStringElement(writer, KSCrashField_ImageCrashInfoMessage2, image.crashInfoMessage2);
         }
+        if(image.crashInfoBacktrace != NULL)
+        {
+            writer->addStringElement(writer, KSCrashField_ImageCrashInfoBacktrace, image.crashInfoBacktrace);
+        }
+        if(image.crashInfoSignature != NULL)
+        {
+            writer->addStringElement(writer, KSCrashField_ImageCrashInfoSignature, image.crashInfoSignature);
+        }
     }
     writer->endContainer(writer);
 }

--- a/Source/KSCrash/Recording/KSCrashReportFields.h
+++ b/Source/KSCrash/Recording/KSCrashReportFields.h
@@ -126,6 +126,8 @@
 #define KSCrashField_ImageRevisionVersion  "revision_version"
 #define KSCrashField_ImageCrashInfoMessage    "crash_info_message"
 #define KSCrashField_ImageCrashInfoMessage2   "crash_info_message2"
+#define KSCrashField_ImageCrashInfoBacktrace  "crash_info_backtrace"
+#define KSCrashField_ImageCrashInfoSignature  "crash_info_signature"
 
 
 #pragma mark - Memory -

--- a/Source/KSCrash/Recording/Tools/KSDynamicLinker.c
+++ b/Source/KSCrash/Recording/Tools/KSDynamicLinker.c
@@ -38,7 +38,7 @@
 #include "KSPlatformSpecificDefines.h"
 
 #ifndef KSDL_MaxCrashInfoStringLength
-    #define KSDL_MaxCrashInfoStringLength 1024
+    #define KSDL_MaxCrashInfoStringLength 4096
 #endif
 
 #pragma pack(8)
@@ -380,6 +380,16 @@ static void getCrashInfo(const struct mach_header* header, KSBinaryImage* buffer
     {
         KSLOG_DEBUG("Found second message: %s", crashInfo->message2);
         buffer->crashInfoMessage2 = crashInfo->message2;
+    }
+    if(isValidCrashInfoMessage(crashInfo->backtrace))
+    {
+        KSLOG_DEBUG("Found backtrace: %s", crashInfo->backtrace);
+        buffer->crashInfoBacktrace = crashInfo->backtrace;
+    }
+    if(isValidCrashInfoMessage(crashInfo->signature))
+    {
+        KSLOG_DEBUG("Found signature: %s", crashInfo->signature);
+        buffer->crashInfoSignature = crashInfo->signature;
     }
 }
 

--- a/Source/KSCrash/Recording/Tools/KSDynamicLinker.h
+++ b/Source/KSCrash/Recording/Tools/KSDynamicLinker.h
@@ -50,6 +50,8 @@ typedef struct
     uint64_t revisionVersion;
     const char* crashInfoMessage;
     const char* crashInfoMessage2;
+    const char* crashInfoBacktrace;
+    const char* crashInfoSignature;
 } KSBinaryImage;
 
 /** Get the number of loaded binary images.


### PR DESCRIPTION
This increases KSDL_MaxCrashInfoStringLength to 4096 to accommodate for backtraces being longer than ordinary chrashinfo messages.