### PR TITLE
Add Privacy Report

### DIFF
--- a/KSCrash.podspec
+++ b/KSCrash.podspec
@@ -29,6 +29,8 @@ Pod::Spec.new do |s|
                                     'Source/KSCrash/Recording/Monitors/KSCrashMonitorType.h',
                                     'Source/KSCrash/Reporting/Filters/KSCrashReportFilter.h'
 
+    recording.resource_bundles = { 'KSCrashPrivacy' => 'Source/KSCrash/Recording/PrivacyInfo.xcprivacy' }
+
     recording.subspec 'Tools' do |tools|
       tools.source_files = 'Source/KSCrash/Recording/Tools/*.h'
       tools.compiler_flags = '-fno-optimize-sibling-calls'

--- a/KSCrash.podspec
+++ b/KSCrash.podspec
@@ -16,6 +16,8 @@ Pod::Spec.new do |s|
   s.xcconfig = { 'GCC_ENABLE_CPP_EXCEPTIONS' => 'YES' }
   s.default_subspecs = 'Installations'
 
+  s.resource_bundles = { 'KSCrashPrivacy' => 'Source/KSCrash/Recording/PrivacyInfo.xcprivacy' }
+
   s.subspec 'Recording' do |recording|
     recording.compiler_flags = '-fno-optimize-sibling-calls'
     recording.source_files   = 'Source/KSCrash/Recording/**/*.{h,m,mm,c,cpp}',
@@ -28,8 +30,6 @@ Pod::Spec.new do |s|
                                     'Source/KSCrash/Recording/KSCrashReportFields.h',
                                     'Source/KSCrash/Recording/Monitors/KSCrashMonitorType.h',
                                     'Source/KSCrash/Reporting/Filters/KSCrashReportFilter.h'
-
-    recording.resource_bundles = { 'KSCrashPrivacy' => 'Source/KSCrash/Recording/PrivacyInfo.xcprivacy' }
 
     recording.subspec 'Tools' do |tools|
       tools.source_files = 'Source/KSCrash/Recording/Tools/*.h'

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.1
 
 import PackageDescription
 
@@ -42,9 +42,6 @@ let package = Package(
             exclude: [
                 "Monitors",
                 "Tools"
-            ],
-            resources: [
-                .copy("PrivacyInfo.xcprivacy")
             ],
             publicHeadersPath: ".",
             cxxSettings: [

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -2,6 +2,49 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeDeviceID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePerformanceData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeCrashData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>
@@ -26,49 +69,6 @@
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>C617.1</string>
-			</array>
-		</dict>
-	</array>
-	<key>NSPrivacyTracking</key>
-	<false/>
-	<key>NSPrivacyTrackingDomains</key>
-	<array/>
-	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string>NSPrivacyCollectedDataTypeDeviceID</string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
-			</array>
-		</dict>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string>NSPrivacyCollectedDataTypePerformanceData</string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
-			</array>
-		</dict>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string>NSPrivacyCollectedDataTypeCrashData</string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>
 	</array>

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -6,7 +6,15 @@
 	<array>
 		<dict>
             <key>NSPrivacyAccessedAPIType</key>
-            <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>7D9E.1</string>

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -5,8 +5,8 @@
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>
-            <key>NSPrivacyAccessedAPIType</key>
-            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>CA92.1</string>
@@ -31,9 +31,46 @@
 	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>
-    <key>NSPrivacyTrackingDomains</key>
-    <array/>
-    <key>NSPrivacyCollectedDataTypes</key>
-    <array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeDeviceID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePerformanceData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeCrashData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -31,5 +31,9 @@
 	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
 </dict>
 </plist>

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -5,6 +5,14 @@
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>7D9E.1</string>
+			</array>
+		</dict>
+		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>

--- a/Source/KSCrash/Recording/PrivacyInfo.xcprivacy
+++ b/Source/KSCrash/Recording/PrivacyInfo.xcprivacy
@@ -44,6 +44,18 @@
 				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
 			</array>
 		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
 	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>


### PR DESCRIPTION
## Privacy Accessed APIs

The `stat` function requires declaration as `NSPrivacyAccessedAPICategoryFileTimestamp`. According to [Apple guidelines](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278393), we must declare the reason even if we do not use it for the file timestamp. The purpose of its use is the determination of the type and size of the file, which is part of `C617.1`.

<details>
<summary>Details</summary>

https://github.com/kstenerud/KSCrash/blob/2cff3a74753b0b22f25a138936f0ef029aebaa39/Source/KSCrash/Recording/Tools/KSFileUtils.c#L156-L164
https://github.com/kstenerud/KSCrash/blob/2cff3a74753b0b22f25a138936f0ef029aebaa39/Source/KSCrash/Recording/Tools/KSFileUtils.c#L193-L196

https://github.com/kstenerud/KSCrash/blob/2cff3a74753b0b22f25a138936f0ef029aebaa39/Source/KSCrash/Recording/Tools/KSFileUtils.c#L262-L267
https://github.com/kstenerud/KSCrash/blob/2cff3a74753b0b22f25a138936f0ef029aebaa39/Source/KSCrash/Recording/Tools/KSFileUtils.c#L276-L279
</details>

The `NSFileSystemSize` [requires declaration](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278397) as `NSPrivacyAccessedAPICategoryDiskSpace`. In our case, it falls under `7D9E.1` as we send this information off the device in crash reports. However, Apple requires this part of the crash report to be optional as the user should approve usage of disk space information. 
**Therefore, an opt-out mechanism should be implemented on KSCrash side.**

<details>
<summary>Details</summary>

https://github.com/kstenerud/KSCrash/blob/2cff3a74753b0b22f25a138936f0ef029aebaa39/Source/KSCrash/Recording/Monitors/KSCrashMonitor_System.m#L484-L488

</details>

The `NSUserDefaults` [requires a declaration](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401) as `NSPrivacyAccessedAPICategoryUserDefaults`. According to Apple documentation, there are no restrictions on sending data off the device, so it falls under `CA92.1`.

<details>
<summary>Details</summary>

https://github.com/kstenerud/KSCrash/blob/2cff3a74753b0b22f25a138936f0ef029aebaa39/Source/KSCrash/Reporting/Sinks/KSCrashReportSinkQuincyHockey.m#L177-L200

</details>

## Collected Data Types

- `NSPrivacyCollectedDataTypeCrashData` is used for crash reporting purposes, as it is the main function of the KSCrash library. Not used for linking or tracking. Used for `NSPrivacyCollectedDataTypePurposeAppFunctionality`.
- `NSPrivacyCollectedDataTypePerformanceData` is used to collect the launch time of the app in crash reports. This information is stored in the `app_start_time` field of our JSON crash format. This is exactly specified in the Apple docs.  Not used for linking or tracking. Used for `NSPrivacyCollectedDataTypePurposeAppFunctionality`.
- `NSPrivacyCollectedDataTypeDeviceID` is utilized to generate `app_uuid` and `device_app_hash` in our JSON crash format, which function as device-level identifiers. Additionally, there is a UUID for identifying an installation and potentially sending it from the device in Quincy/Hockey module. It is important to note that KSCrash cannot link this ID to the identity of the user or use it for tracking. This data is collected solely for `NSPrivacyCollectedDataTypePurposeAppFunctionality`. 
