### PR TITLE
Move Privacy Manifest to Recording subspec

### DIFF
--- a/KSCrash.podspec
+++ b/KSCrash.podspec
@@ -16,8 +16,6 @@ Pod::Spec.new do |s|
   s.xcconfig = { 'GCC_ENABLE_CPP_EXCEPTIONS' => 'YES' }
   s.default_subspecs = 'Installations'
 
-  s.resource_bundles = { 'KSCrashPrivacy' => 'Source/KSCrash/Recording/PrivacyInfo.xcprivacy' }
-
   s.subspec 'Recording' do |recording|
     recording.compiler_flags = '-fno-optimize-sibling-calls'
     recording.source_files   = 'Source/KSCrash/Recording/**/*.{h,m,mm,c,cpp}',
@@ -35,6 +33,8 @@ Pod::Spec.new do |s|
       tools.source_files = 'Source/KSCrash/Recording/Tools/*.h'
       tools.compiler_flags = '-fno-optimize-sibling-calls'
     end
+
+    recording.resource_bundles = { 'KSCrashPrivacy' => 'Source/KSCrash/Recording/PrivacyInfo.xcprivacy' }
   end
 
   s.subspec 'Reporting' do |reporting|


### PR DESCRIPTION
Initially, it was expected that resources specified in the root of our CocoaPods spec for the KSCrash library would be inherited by all subspecs. However, this inheritance appears to only occur when declaring a dependency on the entire library with `s.dependency 'KSCrash', '= 1.17.0'` rather than on a specific subspec like `s.dependency 'KSCrash/Recording', '= 1.17.0'`. This behavior necessitated moving the resource declaration from the root to the 'Recording' subspec to ensure proper resource handling and availability when integrating the pod into projects using specific subspec dependencies.