### PR TITLE
Fix tail call optimisation in C++ backtrace capture

### DIFF
--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
@@ -83,6 +83,7 @@ static void captureStackTrace(void*, std::type_info*, void (*)(void*)) __attribu
     {
         kssc_initSelfThread(&g_stackCursor, 2);
     }
+    __asm__ __volatile__(""); // thwart tail-call optimization
 }
 
 typedef void (*cxa_throw_type)(void*, std::type_info*, void (*)(void*));
@@ -103,6 +104,7 @@ extern "C"
             orig_cxa_throw = (cxa_throw_type) dlsym(RTLD_NEXT, "__cxa_throw");
         }
         orig_cxa_throw(thrown_exception, tinfo, dest);
+        __asm__ __volatile__(""); // thwart tail-call optimization
         __builtin_unreachable();
     }
 }

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
@@ -77,7 +77,7 @@ static KSStackCursor g_stackCursor;
 #pragma mark - Callbacks -
 // ============================================================================
 
-static void captureStackTrace(void*, std::type_info*, void (*)(void*))
+static void captureStackTrace(void*, std::type_info*, void (*)(void*)) __attribute__((disable_tail_calls))
 {
     if(g_captureNextStackTrace)
     {
@@ -91,7 +91,7 @@ extern "C"
 {
     void __cxa_throw(void* thrown_exception, std::type_info* tinfo, void (*dest)(void*)) __attribute__ ((weak));
 
-    void __cxa_throw(void* thrown_exception, std::type_info* tinfo, void (*dest)(void*))
+    void __cxa_throw(void* thrown_exception, std::type_info* tinfo, void (*dest)(void*)) __attribute__((disable_tail_calls))
     {
         static cxa_throw_type orig_cxa_throw = NULL;
         if (g_cxaSwapEnabled == false)

--- a/Sources/KSCrashRecordingCore/KSStackCursor_SelfThread.c
+++ b/Sources/KSCrashRecordingCore/KSStackCursor_SelfThread.c
@@ -43,4 +43,5 @@ void kssc_initSelfThread(KSStackCursor *cursor, int skipEntries) __attribute__((
     SelfThreadContext* context = (SelfThreadContext*)cursor->context;
     int backtraceLength = backtrace((void**)context->backtrace, MAX_BACKTRACE_LENGTH);
     kssc_initWithBacktrace(cursor, context->backtrace, backtraceLength, skipEntries + 1);
+    __asm__ __volatile__(""); // thwart tail-call optimization
 }

--- a/Sources/KSCrashRecordingCore/KSStackCursor_SelfThread.c
+++ b/Sources/KSCrashRecordingCore/KSStackCursor_SelfThread.c
@@ -38,7 +38,7 @@ typedef struct
     uintptr_t backtrace[0];
 } SelfThreadContext;
 
-void kssc_initSelfThread(KSStackCursor *cursor, int skipEntries)
+void kssc_initSelfThread(KSStackCursor *cursor, int skipEntries) __attribute__((disable_tail_calls))
 {
     SelfThreadContext* context = (SelfThreadContext*)cursor->context;
     int backtraceLength = backtrace((void**)context->backtrace, MAX_BACKTRACE_LENGTH);


### PR DESCRIPTION
According to [documentation](https://releases.llvm.org/15.0.0/tools/clang/docs/AttributeReference.html#disable-tail-calls) there's a `__attribute__((disable_tail_calls))` attribute that should work fine for our case where we need to make sure the stacktrace has predictable number of calls at the top.