### PR TITLE
Fix extern "C" placement

### DIFF
--- a/Sources/KSCrashRecording/KSCrashReport.h
+++ b/Sources/KSCrashRecording/KSCrashReport.h
@@ -32,15 +32,14 @@
 #ifndef HDR_KSCrashReport_h
 #define HDR_KSCrashReport_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #import "KSCrashReportWriter.h"
 #import "KSCrashMonitorContext.h"
 
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // ============================================================================
 #pragma mark - Configuration -

--- a/Sources/KSCrashRecording/KSCrashReportStore.h
+++ b/Sources/KSCrashRecording/KSCrashReportStore.h
@@ -27,12 +27,11 @@
 #ifndef HDR_KSCrashReportStore_h
 #define HDR_KSCrashReportStore_h
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-
-#include <stdint.h>
 
 #define KSCRS_MAX_PATH_LENGTH 500
 

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor.h
@@ -32,15 +32,14 @@
 #ifndef HDR_KSCrashMonitor_h
 #define HDR_KSCrashMonitor_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-
 #include "KSCrashMonitorType.h"
 #include "KSThread.h"
     
 #include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct KSCrash_MonitorContext;
 

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitorContext.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitorContext.h
@@ -28,15 +28,15 @@
 #ifndef HDR_KSCrashMonitorContext_h
 #define HDR_KSCrashMonitorContext_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "KSCrashMonitorType.h"
 #include "KSMachineContext.h"
 
 #include <stdbool.h>
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct KSCrash_MonitorContext
 {

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_AppState.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_AppState.h
@@ -33,14 +33,13 @@
 #ifndef HDR_KSCrashMonitor_AppState_h
 #define HDR_KSCrashMonitor_AppState_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "KSCrashMonitor.h"
 
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct
 {

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.h
@@ -25,11 +25,11 @@
 #ifndef HDR_KSCrashMonitor_CPPException_h
 #define HDR_KSCrashMonitor_CPPException_h
 
+#include "KSCrashMonitor.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "KSCrashMonitor.h"
 
 /** Enable swapping of __cxa_trow symbol with lazy symbols table
  */

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_MachException.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_MachException.h
@@ -32,12 +32,12 @@
 #ifndef HDR_KSCrashMonitor_MachException_h
 #define HDR_KSCrashMonitor_MachException_h
 
+#include "KSCrashMonitor.h"
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "KSCrashMonitor.h"
-#include <stdbool.h>
 
 
 /** Access the Monitor API.

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException.h
@@ -32,12 +32,11 @@
 #ifndef HDR_KSCrashMonitor_NSException_h
 #define HDR_KSCrashMonitor_NSException_h
 
+#include "KSCrashMonitor.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-
-#include "KSCrashMonitor.h"
 
 
 /** Access the Monitor API.

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.h
@@ -32,12 +32,11 @@
 #ifndef HDR_KSCrashMonitor_Signal_h
 #define HDR_KSCrashMonitor_Signal_h
 
+#include "KSCrashMonitor.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-
-#include "KSCrashMonitor.h"
 
 
 /** Access the Monitor API.

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.h
@@ -27,12 +27,11 @@
 #ifndef KSCrashMonitor_System_h
 #define KSCrashMonitor_System_h
 
+#include "KSCrashMonitor.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-
-#include "KSCrashMonitor.h"
 
 
 /** Access the Monitor API.

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_User.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_User.h
@@ -25,14 +25,13 @@
 #ifndef HDR_KSCrashMonitor_User_h
 #define HDR_KSCrashMonitor_User_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-
 #include "KSCrashMonitor.h"
 
 #include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 
 /** Report a custom, user defined exception.

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Zombie.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Zombie.h
@@ -41,13 +41,12 @@
 #ifndef HDR_KSZombie_h
 #define HDR_KSZombie_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "KSCrashMonitor.h"
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** Get the class of a deallocated object pointer, if it was tracked.
  *

--- a/Sources/KSCrashRecording/include/KSCrashC.h
+++ b/Sources/KSCrashRecording/include/KSCrashC.h
@@ -32,16 +32,14 @@
 #ifndef HDR_KSCrashC_h
 #define HDR_KSCrashC_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-
 #include "KSCrashMonitorType.h"
 #include "KSCrashReportWriter.h"
 
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** Install the crash reporter. The reporter will record the next crash and then
  * terminate the program.

--- a/Sources/KSCrashRecording/include/KSCrashReportWriter.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportWriter.h
@@ -33,14 +33,12 @@
 #ifndef HDR_KSCrashReportWriter_h
 #define HDR_KSCrashReportWriter_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * Encapsulates report writing functionality.

--- a/Sources/KSCrashRecordingCore/include/KSCPU.h
+++ b/Sources/KSCrashRecordingCore/include/KSCPU.h
@@ -27,15 +27,14 @@
 #ifndef HDR_KSCPU_h
 #define HDR_KSCPU_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-
 #include "KSMachineContext.h"
 
 #include <stdbool.h>
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** Get the current CPU architecture.
  *

--- a/Sources/KSCrashRecordingCore/include/KSCPU_Apple.h
+++ b/Sources/KSCrashRecordingCore/include/KSCPU_Apple.h
@@ -27,13 +27,12 @@
 #ifndef HDR_KSCPU_Apple_h
 #define HDR_KSCPU_Apple_h
 
+#include <mach/mach_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
-#include <mach/mach_types.h>
-    
 /** Fill in state information about a thread.
  *
  * @param thread The thread to get information about.

--- a/Sources/KSCrashRecordingCore/include/KSDate.h
+++ b/Sources/KSCrashRecordingCore/include/KSDate.h
@@ -25,12 +25,11 @@
 #ifndef KSDate_h
 #define KSDate_h
 
+#include <sys/types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-
-#include <sys/types.h>
 
 /** Convert a UNIX timestamp to an RFC3339 string representation.
  *

--- a/Sources/KSCrashRecordingCore/include/KSDebug.h
+++ b/Sources/KSCrashRecordingCore/include/KSDebug.h
@@ -31,14 +31,12 @@
 
 #ifndef HDR_KSDebug_h
 #define HDR_KSDebug_h
+    
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-    
-    
-#include <stdbool.h>
-    
     
 /** Check if the current process is being traced or not.
  *

--- a/Sources/KSCrashRecordingCore/include/KSDynamicLinker.h
+++ b/Sources/KSCrashRecordingCore/include/KSDynamicLinker.h
@@ -27,14 +27,13 @@
 #ifndef HDR_KSDynamicLinker_h
 #define HDR_KSDynamicLinker_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-
 #include <dlfcn.h>
 #include <stdbool.h>
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct
 {

--- a/Sources/KSCrashRecordingCore/include/KSFileUtils.h
+++ b/Sources/KSCrashRecordingCore/include/KSFileUtils.h
@@ -32,14 +32,12 @@
 #ifndef HDR_KSFileUtils_h
 #define HDR_KSFileUtils_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-
 #include <stdbool.h>
 #include <stdarg.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define KSFU_MAX_PATH_LENGTH 500
 

--- a/Sources/KSCrashRecordingCore/include/KSJSONCodec.h
+++ b/Sources/KSCrashRecordingCore/include/KSJSONCodec.h
@@ -32,13 +32,12 @@
 #ifndef HDR_KSJSONCodec_h
 #define HDR_KSJSONCodec_h
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-
-#include <stdbool.h>
-#include <stdint.h>
 
 /* Tells the encoder to automatically determine the length of a field value.
  * Currently, this is done using strlen().

--- a/Sources/KSCrashRecordingCore/include/KSLogger.h
+++ b/Sources/KSCrashRecordingCore/include/KSLogger.h
@@ -147,13 +147,11 @@
 #ifndef HDR_KSLogger_h
 #define HDR_KSLogger_h
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-
-#include <stdbool.h>
-
 
 #ifdef __OBJC__
 

--- a/Sources/KSCrashRecordingCore/include/KSMach.h
+++ b/Sources/KSCrashRecordingCore/include/KSMach.h
@@ -25,12 +25,11 @@
 #ifndef HDR_KSMach_h
 #define HDR_KSMach_h
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-
-#include <stdint.h>
 
 /** Get the name of a mach exception.
  *

--- a/Sources/KSCrashRecordingCore/include/KSMachineContext.h
+++ b/Sources/KSCrashRecordingCore/include/KSMachineContext.h
@@ -28,13 +28,13 @@
 #ifndef HDR_KSMachineContext_h
 #define HDR_KSMachineContext_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "KSThread.h"
 #include <stdbool.h>
 #include <mach/mach.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** Suspend the runtime environment.
  */

--- a/Sources/KSCrashRecordingCore/include/KSMachineContext_Apple.h
+++ b/Sources/KSCrashRecordingCore/include/KSMachineContext_Apple.h
@@ -28,13 +28,13 @@
 #ifndef HDR_KSMachineContext_Apple_h
 #define HDR_KSMachineContext_Apple_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <mach/mach_types.h>
 #include <stdbool.h>
 #include <sys/ucontext.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #ifdef __arm64__
     #define STRUCT_MCONTEXT_L _STRUCT_MCONTEXT64

--- a/Sources/KSCrashRecordingCore/include/KSMemory.h
+++ b/Sources/KSCrashRecordingCore/include/KSMemory.h
@@ -32,13 +32,11 @@
 #ifndef HDR_ksmemory_h
 #define HDR_ksmemory_h
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-
-#include <stdbool.h>
-
 
 /** Test if the specified memory is safe to read from.
  *

--- a/Sources/KSCrashRecordingCore/include/KSObjC.h
+++ b/Sources/KSCrashRecordingCore/include/KSObjC.h
@@ -28,14 +28,12 @@
 #ifndef HDR_KSObjC_h
 #define HDR_KSObjC_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef enum
 {

--- a/Sources/KSCrashRecordingCore/include/KSObjCApple.h
+++ b/Sources/KSCrashRecordingCore/include/KSObjCApple.h
@@ -19,14 +19,12 @@
 #ifndef HDR_KSObjCApple_h
 #define HDR_KSObjCApple_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-
 #include <objc/objc.h>
 #include <CoreFoundation/CoreFoundation.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define MAKE_LIST_T(TYPE) \
 typedef struct TYPE##_list_t { \

--- a/Sources/KSCrashRecordingCore/include/KSSignalInfo.h
+++ b/Sources/KSCrashRecordingCore/include/KSSignalInfo.h
@@ -32,13 +32,11 @@
 #ifndef HDR_KSSignalInfo_h
 #define HDR_KSSignalInfo_h
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-
-#include <stdint.h>
-
 
 /** Get the name of a signal.
  *

--- a/Sources/KSCrashRecordingCore/include/KSStackCursor.h
+++ b/Sources/KSCrashRecordingCore/include/KSStackCursor.h
@@ -25,16 +25,15 @@
 
 #ifndef KSStackCursor_h
 #define KSStackCursor_h
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-    
     
 #include "KSMachineContext.h"
 
 #include <stdbool.h>
 #include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define KSSC_CONTEXT_SIZE 100
 

--- a/Sources/KSCrashRecordingCore/include/KSStackCursor_Backtrace.h
+++ b/Sources/KSCrashRecordingCore/include/KSStackCursor_Backtrace.h
@@ -25,13 +25,12 @@
 
 #ifndef KSStackCursor_Backtrace_h
 #define KSStackCursor_Backtrace_h
+    
+#include "KSStackCursor.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-    
-    
-#include "KSStackCursor.h"
 
 /** Exposed for other internal systems to use.
  */

--- a/Sources/KSCrashRecordingCore/include/KSStackCursor_MachineContext.h
+++ b/Sources/KSCrashRecordingCore/include/KSStackCursor_MachineContext.h
@@ -25,13 +25,12 @@
 
 #ifndef KSStackCursor_MachineContext_h
 #define KSStackCursor_MachineContext_h
+    
+#include "KSStackCursor.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-    
-    
-#include "KSStackCursor.h"
 
 /** Initialize a stack cursor for a machine context.
  *

--- a/Sources/KSCrashRecordingCore/include/KSStackCursor_SelfThread.h
+++ b/Sources/KSCrashRecordingCore/include/KSStackCursor_SelfThread.h
@@ -25,13 +25,12 @@
 
 #ifndef KSStackCursor_SelfThread_h
 #define KSStackCursor_SelfThread_h
+    
+#include "KSStackCursor.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-    
-    
-#include "KSStackCursor.h"
 
 /** Initialize a stack cursor for the current thread.
  *  You may want to skip some entries to account for the trace immediately leading

--- a/Sources/KSCrashRecordingCore/include/KSString.h
+++ b/Sources/KSCrashRecordingCore/include/KSString.h
@@ -27,14 +27,12 @@
 #ifndef HDR_KSString_h
 #define HDR_KSString_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** Check if a memory location contains a null terminated UTF-8 string.
  *

--- a/Sources/KSCrashRecordingCore/include/KSSymbolicator.h
+++ b/Sources/KSCrashRecordingCore/include/KSSymbolicator.h
@@ -26,13 +26,12 @@
 #ifndef KSSymbolicator_h
 #define KSSymbolicator_h
 
+#include "KSStackCursor.h"
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-
-#include "KSStackCursor.h"
-#include <stdbool.h>
 
 /** Call instruction address is different from return address.
  *

--- a/Sources/KSCrashRecordingCore/include/KSSysCtl.h
+++ b/Sources/KSCrashRecordingCore/include/KSSysCtl.h
@@ -32,15 +32,13 @@
 #ifndef HDR_KSSysCtl_h
 #define HDR_KSSysCtl_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/sysctl.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** Get an int32 value via sysctl.
  *

--- a/Sources/KSCrashRecordingCore/include/KSThread.h
+++ b/Sources/KSCrashRecordingCore/include/KSThread.h
@@ -27,14 +27,12 @@
 #ifndef HDR_KSThread_h
 #define HDR_KSThread_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-
 #include <sys/types.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef uintptr_t KSThread;
 

--- a/Sources/KSCrashRecordingCore/include/KSgetsect.h
+++ b/Sources/KSCrashRecordingCore/include/KSgetsect.h
@@ -25,12 +25,12 @@
 #ifndef KSgetsect_h
 #define KSgetsect_h
 
+#include <mach-o/loader.h>
+#include "KSPlatformSpecificDefines.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
-
-#include <mach-o/loader.h>
-#include "KSPlatformSpecificDefines.h"
 
 /**
  * This routine returns the segment_command structure for the named segment


### PR DESCRIPTION
The tests in Github Actions were complaining about nested `extern "C"` directives.
Was not able to reproduce the error locally, but it makes sesnse that `extern "C"` should be placed after imports.

This change is tested in #467 and extracted from there.