### PR TITLE
State tracking based - isa swizzle

### DIFF
--- a/Sources/KSCrashRecording/KSCrashAppStateTracker+Private.h
+++ b/Sources/KSCrashRecording/KSCrashAppStateTracker+Private.h
@@ -1,0 +1,13 @@
+#import "KSCrashAppStateTracker.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface KSCrashAppStateTracker ()
+
+- (void)_setTransitionState:(KSCrashAppTransitionState)transitionState;
+
+@property (nonatomic, assign) BOOL proxied;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashRecording/KSCrashAppStateTracker.m
+++ b/Sources/KSCrashRecording/KSCrashAppStateTracker.m
@@ -29,8 +29,6 @@
 
 #import <Foundation/Foundation.h>
 #import <os/lock.h>
-#import <objc/runtime.h>
-#import <map>
 
 #if KSCRASH_HAS_UIAPPLICATION
 #import <UIKit/UIKit.h>
@@ -42,6 +40,7 @@ const char *ksapp_transition_state_to_string(KSCrashAppTransitionState state) {
         case KSCrashAppTransitionStateStartupPrewarm: return "prewarm";
         case KSCrashAppTransitionStateActive: return "active";
         case KSCrashAppTransitionStateLaunching: return "launching";
+        case KSCrashAppTransitionStateLaunched: return "launched";
         case KSCrashAppTransitionStateBackground: return "background";
         case KSCrashAppTransitionStateTerminating: return "terminating";
         case KSCrashAppTransitionStateExiting: return "exiting";
@@ -62,6 +61,7 @@ bool ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionState state)
             
         case KSCrashAppTransitionStateStartup:
         case KSCrashAppTransitionStateLaunching:
+        case KSCrashAppTransitionStateLaunched:
         case KSCrashAppTransitionStateForegrounding:
         case KSCrashAppTransitionStateActive:
         case KSCrashAppTransitionStateDeactivating:
@@ -111,6 +111,7 @@ bool ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionState state)
     // transition state and observers protected by the lock
     os_unfair_lock _lock;
     KSCrashAppTransitionState _transitionState;
+    BOOL _transitionComplete;
     NSMutableArray<id<KSCrashAppStateTrackerObserving>> *_observers;
     BOOL _proxied;
 }
@@ -248,20 +249,62 @@ bool ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionState state)
     return ret;
 }
 
+- (void)_locked_completeState:(KSCrashAppTransitionState)transitionState
+{
+    if (_transitionState != transitionState || _transitionComplete) {
+        return;
+    }
+    
+    _transitionComplete = YES;
+    NSLog(@"[AC] %s, completed: %d", ksapp_transition_state_to_string(transitionState), _transitionComplete);
+    
+    // send delegate
+    // ie: didCompleteTransition or something...
+}
+
+- (void)_completeState:(KSCrashAppTransitionState)transitionState
+{
+    os_unfair_lock_lock(&_lock);
+    [self _locked_completeState:transitionState];
+    os_unfair_lock_unlock(&_lock);
+}
+
 - (void)_setTransitionState:(KSCrashAppTransitionState)transitionState
 {
+    BOOL completeOnNextLoop = NO;
     NSArray<id<KSCrashAppStateTrackerObserving>> *observers = nil;
     {
         os_unfair_lock_lock(&_lock);
+        
         if (_transitionState != transitionState) {
+            
+            // finalize the current state
+            [self _locked_completeState:_transitionState];
+            
+            // move to the next state
             _transitionState = transitionState;
+            _transitionComplete = NO;
+            completeOnNextLoop = YES;
             observers = [_observers copy];
         }
+        
         os_unfair_lock_unlock(&_lock);
     }
     
-    for (id<KSCrashAppStateTrackerObserving> obs in observers) {
-        [obs appStateTracker:self didTransitionToState:transitionState];
+    if (observers) {
+        NSLog(@"[AC] %s, completed: %d", ksapp_transition_state_to_string(transitionState), _transitionComplete);
+        
+        for (id<KSCrashAppStateTrackerObserving> obs in observers) {
+            [obs appStateTracker:self didTransitionToState:transitionState];
+        }
+    }
+    
+    
+    if (completeOnNextLoop) {
+        __weak typeof(self)weakMe = self;
+        CFRunLoopPerformBlock(CFRunLoopGetCurrent(), kCFRunLoopCommonModes, ^{
+            [weakMe _locked_completeState:transitionState];
+        });
     }
 }
 
@@ -302,7 +345,7 @@ usingBlock:^(NSNotification *notification)block] \
     _registrations = @[
         
         OBSERVE(_center, UIApplicationDidFinishLaunchingNotification, {
-            [weakMe _setTransitionState:KSCrashAppTransitionStateLaunching];
+            [weakMe _setTransitionState:KSCrashAppTransitionStateLaunched];
         }),
         OBSERVE(_center, UIApplicationWillEnterForegroundNotification, {
             [weakMe _setTransitionState:KSCrashAppTransitionStateForegrounding];
@@ -337,239 +380,6 @@ usingBlock:^(NSNotification *notification)block] \
     }
 }
 
-static BOOL SwizzleInstanceMethod(Class klass, SEL originalSelector, SEL swizzledSelector)
-{
-    //Obtaining original and swizzled method:
-    Method original = class_getInstanceMethod(klass, originalSelector);
-    Method swizzled = class_getInstanceMethod(klass, swizzledSelector);
-    
-    if (!original || !swizzled) {
-        return NO;
-    }
-    
-    method_exchangeImplementations(original, swizzled);
-    
-    return YES;
-}
-
-typedef BOOL (*ApplicationDelegate_TwoArgs)(id, SEL, id, id);
-typedef void (*ApplicationDelegate_OneArg)(id, SEL, id);
-
-static std::map<std::string, Method> gMappings = {};
-
-static void __KS_CALLING_DELEGATE__(id self, SEL cmd, id arg)
-{
-    std::string name(sel_getName(cmd));
-    NSLog(@"[MAP] %s", name.c_str());
-    const auto it = gMappings.find(name);
-    if (it != gMappings.end()) {
-        NSLog(@"[MAP:implemented] %s", name.c_str());
-        ApplicationDelegate_OneArg imp = (ApplicationDelegate_OneArg)method_getImplementation(it->second);
-        imp(self, cmd, arg);
-    }
-}
-
-static BOOL __KS_CALLING_DELEGATE__(id self, SEL cmd, id arg1, id arg2)
-{
-    std::string name(sel_getName(cmd));
-    NSLog(@"[MAP] %s", name.c_str());
-    const auto it = gMappings.find(name);
-    if (it != gMappings.end()) {
-        NSLog(@"[MAP:implemented] %s", name.c_str());
-        ApplicationDelegate_TwoArgs imp = (ApplicationDelegate_TwoArgs)method_getImplementation(it->second);
-        return imp(self, cmd, arg1, arg2);
-    }
-    return YES;
-}
-
 @end
 
-@interface __KS_CALLING_DELEGATE_TEMPLATE__ : NSObject <UIApplicationDelegate>
-@end
 
-@interface UIScene (__KS_CALLING_DELEGATE_TEMPLATE__)
-- (void)__ks_proxyDelegate;
-@end
-
-@implementation __KS_CALLING_DELEGATE_TEMPLATE__
-
-+ (void)load
-{
-#if KSCRASH_HAS_UIAPPLICATION
-    SwizzleInstanceMethod(UIApplication.class, @selector(setDelegate:), @selector(__ks_setDelegate:));
-
-    [[NSNotificationCenter defaultCenter] addObserverForName:UISceneWillConnectNotification
-                                                      object:nil
-                                                       queue:nil
-                                                  usingBlock:^(NSNotification * _Nonnull notification) {
-        UIScene *scene = notification.object;
-        [scene __ks_proxyDelegate];
-    }];
-#endif
-}
-
-#pragma - app delegate
-
-- (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(nullable NSDictionary<UIApplicationLaunchOptionsKey, id> *)launchOptions
-{
-    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateLaunching];
-    return __KS_CALLING_DELEGATE__(self, _cmd, application, launchOptions);
-}
-
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(nullable NSDictionary<UIApplicationLaunchOptionsKey, id> *)launchOptions
-{
-    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateLaunching];
-    return __KS_CALLING_DELEGATE__(self, _cmd, application, launchOptions);
-}
-
-- (void)applicationDidBecomeActive:(UIApplication *)application
-{
-    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateActive];
-    __KS_CALLING_DELEGATE__(self, _cmd, application);
-}
-
-- (void)applicationWillResignActive:(UIApplication *)application
-{
-    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateDeactivating];
-    __KS_CALLING_DELEGATE__(self, _cmd, application);
-}
-
-- (void)applicationDidEnterBackground:(UIApplication *)application
-{
-    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateBackground];
-    __KS_CALLING_DELEGATE__(self, _cmd, application);
-}
-
-- (void)applicationWillEnterForeground:(UIApplication *)application
-{
-    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateForegrounding];
-    __KS_CALLING_DELEGATE__(self, _cmd, application);
-}
-
-- (void)applicationWillTerminate:(UIApplication *)application
-{
-    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateTerminating];
-    __KS_CALLING_DELEGATE__(self, _cmd, application);
-}
-
-#pragma - scene delegate
-
-- (void)sceneWillEnterForeground:(UIScene *)scene
-{
-    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateForegrounding];
-    __KS_CALLING_DELEGATE__(self, _cmd, scene);
-}
-
-- (void)sceneDidBecomeActive:(UIScene *)scene
-{
-    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateActive];
-    __KS_CALLING_DELEGATE__(self, _cmd, scene);
-}
-
-- (void)sceneWillResignActive:(UIScene *)scene
-{
-    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateDeactivating];
-    __KS_CALLING_DELEGATE__(self, _cmd, scene);
-}
-
-- (void)sceneDidEnterBackground:(UIScene *)scene
-{
-    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateBackground];
-    __KS_CALLING_DELEGATE__(self, _cmd, scene);
-}
-
-@end
-
-@interface Proxier : NSObject
-@end
-
-@implementation Proxier
-
-+ (void)copyMethodsFromClass:(Class)fromClass toClass:(Class)toClass baseClass:(Class)baseClass
-{
-    unsigned int count = 0;
-    Method *methods = class_copyMethodList(fromClass, &count);
-    for (unsigned int i = 0; i < count; i++) {
-        
-        SEL name = method_getName(methods[i]);
-        IMP imp = method_getImplementation(methods[i]);
-        const char *type = method_getTypeEncoding(methods[i]);
-        
-        NSLog(@"Adding %s", name);
-        
-        Method originalMethod = class_getInstanceMethod(baseClass, name);
-        if (originalMethod) {
-            gMappings[sel_getName(name)] = originalMethod;
-            NSLog(@"-> original exists");
-        } else {
-            NSLog(@"-> no original");
-        }
-        
-        if (!class_addMethod(toClass, name, imp, type)) {
-            NSLog(@"-> Failed to add %s", name);
-        }
-    }
-    free(methods);
-}
-
-+ (Class)subclassClass:(Class)klass copyMethodsFromClass:(Class)methodSourceClass
-{
-    NSString *subclassName = [[[@"__KSCrash__"
-                                stringByAppendingString:NSStringFromClass(klass)]
-                               stringByAppendingString:@"_"]
-                              stringByAppendingString:[NSUUID UUID].UUIDString];
-    Class subclass = objc_allocateClassPair(klass, subclassName.UTF8String, 0);
-    if (!subclass) {
-        return nil;
-    }
-    
-    [Proxier copyMethodsFromClass:methodSourceClass
-                          toClass:subclass
-                        baseClass:klass];
-    
-    objc_registerClassPair(subclass);
-    
-    return subclass;
-}
-
-+ (void)proxyObject:(NSObject *)object withMethodsFromClass:(Class)methodSourceClass
-{
-    Class subclass = [self subclassClass:object.class copyMethodsFromClass:methodSourceClass];
-    Class originalClass = object_setClass(object, subclass);
-    if (originalClass) {
-        NSLog(@"[AC] Swizzled '%@' with '%@'", NSStringFromClass(originalClass), NSStringFromClass(subclass));
-    } else {
-        NSLog(@"[AC] Swizzled failed");
-    }
-}
-
-@end
-
-@implementation UIApplication (__KS_CALLING_DELEGATE_TEMPLATE__)
-
-- (void)__ks_setDelegate:(id<UIApplicationDelegate>)delegate
-{
-    if (delegate) {
-        [Proxier proxyObject:delegate withMethodsFromClass:__KS_CALLING_DELEGATE_TEMPLATE__.class];
-        KSCrashAppStateTracker.shared.proxied = YES;
-    }
-    [self __ks_setDelegate:delegate];
-}
-
-@end
-
-@interface UIScene (__KS_CALLING_DELEGATE_TEMPLATE__)
-- (void)__ks_proxyDelegate;
-@end
-
-@implementation UIScene (__KS_CALLING_DELEGATE_TEMPLATE__)
-
-- (void)__ks_proxyDelegate
-{
-    if (self.delegate) {
-        [Proxier proxyObject:self.delegate withMethodsFromClass:__KS_CALLING_DELEGATE_TEMPLATE__.class];
-        KSCrashAppStateTracker.shared.proxied = YES;
-    }
-}
-
-@end

--- a/Sources/KSCrashRecording/KSCrashAppStateTracker.mm
+++ b/Sources/KSCrashRecording/KSCrashAppStateTracker.mm
@@ -29,6 +29,8 @@
 
 #import <Foundation/Foundation.h>
 #import <os/lock.h>
+#import <objc/runtime.h>
+#import <map>
 
 #if KSCRASH_HAS_UIAPPLICATION
 #import <UIKit/UIKit.h>
@@ -110,7 +112,11 @@ bool ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionState state)
     os_unfair_lock _lock;
     KSCrashAppTransitionState _transitionState;
     NSMutableArray<id<KSCrashAppStateTrackerObserving>> *_observers;
+    BOOL _proxied;
 }
+
+@property (nonatomic, assign) BOOL proxied;
+
 @end
 
 @implementation KSCrashAppStateTracker
@@ -154,6 +160,15 @@ bool ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionState state)
 - (void)dealloc
 {
     [self stop];
+}
+
+- (void)setProxied:(BOOL)proxied
+{
+    _proxied = proxied;
+    if (proxied) {
+        [self stop];
+        _registrations = @[];
+    }
 }
 
 // Observers are either an object passed in that
@@ -319,6 +334,241 @@ usingBlock:^(NSNotification *notification)block] \
     _registrations = nil;
     for (id<NSObject> registraion in registraions) {
         [_center removeObserver:registraion];
+    }
+}
+
+static BOOL SwizzleInstanceMethod(Class klass, SEL originalSelector, SEL swizzledSelector)
+{
+    //Obtaining original and swizzled method:
+    Method original = class_getInstanceMethod(klass, originalSelector);
+    Method swizzled = class_getInstanceMethod(klass, swizzledSelector);
+    
+    if (!original || !swizzled) {
+        return NO;
+    }
+    
+    method_exchangeImplementations(original, swizzled);
+    
+    return YES;
+}
+
+typedef BOOL (*ApplicationDelegate_TwoArgs)(id, SEL, id, id);
+typedef void (*ApplicationDelegate_OneArg)(id, SEL, id);
+
+static std::map<std::string, Method> gMappings = {};
+
+static void __KS_CALLING_DELEGATE__(id self, SEL cmd, id arg)
+{
+    std::string name(sel_getName(cmd));
+    NSLog(@"[MAP] %s", name.c_str());
+    const auto it = gMappings.find(name);
+    if (it != gMappings.end()) {
+        NSLog(@"[MAP:implemented] %s", name.c_str());
+        ApplicationDelegate_OneArg imp = (ApplicationDelegate_OneArg)method_getImplementation(it->second);
+        imp(self, cmd, arg);
+    }
+}
+
+static BOOL __KS_CALLING_DELEGATE__(id self, SEL cmd, id arg1, id arg2)
+{
+    std::string name(sel_getName(cmd));
+    NSLog(@"[MAP] %s", name.c_str());
+    const auto it = gMappings.find(name);
+    if (it != gMappings.end()) {
+        NSLog(@"[MAP:implemented] %s", name.c_str());
+        ApplicationDelegate_TwoArgs imp = (ApplicationDelegate_TwoArgs)method_getImplementation(it->second);
+        return imp(self, cmd, arg1, arg2);
+    }
+    return YES;
+}
+
+@end
+
+@interface __KS_CALLING_DELEGATE_TEMPLATE__ : NSObject <UIApplicationDelegate>
+@end
+
+@interface UIScene (__KS_CALLING_DELEGATE_TEMPLATE__)
+- (void)__ks_proxyDelegate;
+@end
+
+@implementation __KS_CALLING_DELEGATE_TEMPLATE__
+
++ (void)load
+{
+#if KSCRASH_HAS_UIAPPLICATION
+    SwizzleInstanceMethod(UIApplication.class, @selector(setDelegate:), @selector(__ks_setDelegate:));
+
+    [[NSNotificationCenter defaultCenter] addObserverForName:UISceneWillConnectNotification
+                                                      object:nil
+                                                       queue:nil
+                                                  usingBlock:^(NSNotification * _Nonnull notification) {
+        UIScene *scene = notification.object;
+        [scene __ks_proxyDelegate];
+    }];
+#endif
+}
+
+#pragma - app delegate
+
+- (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(nullable NSDictionary<UIApplicationLaunchOptionsKey, id> *)launchOptions
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateLaunching];
+    return __KS_CALLING_DELEGATE__(self, _cmd, application, launchOptions);
+}
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(nullable NSDictionary<UIApplicationLaunchOptionsKey, id> *)launchOptions
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateLaunching];
+    return __KS_CALLING_DELEGATE__(self, _cmd, application, launchOptions);
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateActive];
+    __KS_CALLING_DELEGATE__(self, _cmd, application);
+}
+
+- (void)applicationWillResignActive:(UIApplication *)application
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateDeactivating];
+    __KS_CALLING_DELEGATE__(self, _cmd, application);
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateBackground];
+    __KS_CALLING_DELEGATE__(self, _cmd, application);
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateForegrounding];
+    __KS_CALLING_DELEGATE__(self, _cmd, application);
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateTerminating];
+    __KS_CALLING_DELEGATE__(self, _cmd, application);
+}
+
+#pragma - scene delegate
+
+- (void)sceneWillEnterForeground:(UIScene *)scene
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateForegrounding];
+    __KS_CALLING_DELEGATE__(self, _cmd, scene);
+}
+
+- (void)sceneDidBecomeActive:(UIScene *)scene
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateActive];
+    __KS_CALLING_DELEGATE__(self, _cmd, scene);
+}
+
+- (void)sceneWillResignActive:(UIScene *)scene
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateDeactivating];
+    __KS_CALLING_DELEGATE__(self, _cmd, scene);
+}
+
+- (void)sceneDidEnterBackground:(UIScene *)scene
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateBackground];
+    __KS_CALLING_DELEGATE__(self, _cmd, scene);
+}
+
+@end
+
+@interface Proxier : NSObject
+@end
+
+@implementation Proxier
+
++ (void)copyMethodsFromClass:(Class)fromClass toClass:(Class)toClass baseClass:(Class)baseClass
+{
+    unsigned int count = 0;
+    Method *methods = class_copyMethodList(fromClass, &count);
+    for (unsigned int i = 0; i < count; i++) {
+        
+        SEL name = method_getName(methods[i]);
+        IMP imp = method_getImplementation(methods[i]);
+        const char *type = method_getTypeEncoding(methods[i]);
+        
+        NSLog(@"Adding %s", name);
+        
+        Method originalMethod = class_getInstanceMethod(baseClass, name);
+        if (originalMethod) {
+            gMappings[sel_getName(name)] = originalMethod;
+            NSLog(@"-> original exists");
+        } else {
+            NSLog(@"-> no original");
+        }
+        
+        if (!class_addMethod(toClass, name, imp, type)) {
+            NSLog(@"-> Failed to add %s", name);
+        }
+    }
+    free(methods);
+}
+
++ (Class)subclassClass:(Class)klass copyMethodsFromClass:(Class)methodSourceClass
+{
+    NSString *subclassName = [[[@"__KSCrash__"
+                                stringByAppendingString:NSStringFromClass(klass)]
+                               stringByAppendingString:@"_"]
+                              stringByAppendingString:[NSUUID UUID].UUIDString];
+    Class subclass = objc_allocateClassPair(klass, subclassName.UTF8String, 0);
+    if (!subclass) {
+        return nil;
+    }
+    
+    [Proxier copyMethodsFromClass:methodSourceClass
+                          toClass:subclass
+                        baseClass:klass];
+    
+    objc_registerClassPair(subclass);
+    
+    return subclass;
+}
+
++ (void)proxyObject:(NSObject *)object withMethodsFromClass:(Class)methodSourceClass
+{
+    Class subclass = [self subclassClass:object.class copyMethodsFromClass:methodSourceClass];
+    Class originalClass = object_setClass(object, subclass);
+    if (originalClass) {
+        NSLog(@"[AC] Swizzled '%@' with '%@'", NSStringFromClass(originalClass), NSStringFromClass(subclass));
+    } else {
+        NSLog(@"[AC] Swizzled failed");
+    }
+}
+
+@end
+
+@implementation UIApplication (__KS_CALLING_DELEGATE_TEMPLATE__)
+
+- (void)__ks_setDelegate:(id<UIApplicationDelegate>)delegate
+{
+    if (delegate) {
+        [Proxier proxyObject:delegate withMethodsFromClass:__KS_CALLING_DELEGATE_TEMPLATE__.class];
+        KSCrashAppStateTracker.shared.proxied = YES;
+    }
+    [self __ks_setDelegate:delegate];
+}
+
+@end
+
+@interface UIScene (__KS_CALLING_DELEGATE_TEMPLATE__)
+- (void)__ks_proxyDelegate;
+@end
+
+@implementation UIScene (__KS_CALLING_DELEGATE_TEMPLATE__)
+
+- (void)__ks_proxyDelegate
+{
+    if (self.delegate) {
+        [Proxier proxyObject:self.delegate withMethodsFromClass:__KS_CALLING_DELEGATE_TEMPLATE__.class];
+        KSCrashAppStateTracker.shared.proxied = YES;
     }
 }
 

--- a/Sources/KSCrashRecording/KSCrashLifecycleHandler.mm
+++ b/Sources/KSCrashRecording/KSCrashLifecycleHandler.mm
@@ -1,0 +1,307 @@
+//
+//  KSCrashLifecycleHandler.mm
+//
+//  Created by Alexander Cohen on 2024-05-20.
+//
+//  Copyright (c) 2024 Alexander Cohen. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+#import "KSSystemCapabilities.h"
+
+/**
+ * If we can, we try and swizzle App and Scene delegates.
+ *
+ * Lifecycle delegate and notifications happen at different times,
+ * here's what it looks like:
+ *
+ * run loop cycle 1: Application -> Delegate
+ * run loop cycle 2: Application -> Notification
+ *
+ * Due to this, it's very hard for a system to receive lifecycle
+ * events before the app it is being installed in. This can lead
+ * to mismatched user perception (foreground when the app is actually
+ * background). That mismatch leads to wrongly categorizing
+ * issues reported by the system.
+ *
+ * To fix this, we need to swizzle app an scene delegates. This allows
+ * us to receive delegate callbacks before anyone else and correctly
+ * record the state of the app before the app has a chance to run any
+ * code in those transitions and possibly cause a reliability event.
+ *
+ *
+ */
+// We need to have UIApplication to do any of this.
+#if KSCRASH_HAS_UIAPPLICATION
+
+#import "KSCrashAppStateTracker+Private.h"
+
+#import <objc/runtime.h>
+#import <map>
+
+#import <UIKit/UIKit.h>
+
+@interface __KS_CALLING_DELEGATE_TEMPLATE__ : NSObject <UIApplicationDelegate>
+@end
+
+#define UISCENE_AVAILABLE API_AVAILABLE(ios(13.0))
+
+UISCENE_AVAILABLE
+@interface UIScene (__KS_CALLING_DELEGATE_TEMPLATE__)
+- (void)__ks_proxyDelegate;
+@end
+
+@interface UIApplication (__KS_CALLING_DELEGATE_TEMPLATE__)
+- (void)__ks_setDelegate:(id<UIApplicationDelegate>)delegate;
+@end
+
+UISCENE_AVAILABLE
+@interface __KS_CALLING_DELEGATE_TEMPLATE__ () <UISceneDelegate>
+@end
+
+@implementation __KS_CALLING_DELEGATE_TEMPLATE__
+
+static BOOL SwizzleInstanceMethod(Class klass, SEL originalSelector, SEL swizzledSelector)
+{
+    Method original = class_getInstanceMethod(klass, originalSelector);
+    Method swizzled = class_getInstanceMethod(klass, swizzledSelector);
+    
+    if (!original || !swizzled) {
+        return NO;
+    }
+    
+    method_exchangeImplementations(original, swizzled);
+    return YES;
+}
+
+typedef BOOL (*ApplicationDelegate_TwoArgs)(id, SEL, id, id);
+typedef void (*ApplicationDelegate_OneArg)(id, SEL, id);
+
+static std::map<std::string, Method> gMappings = {};
+
+static void __KS_CALLING_DELEGATE__(id self, SEL cmd, id arg)
+{
+    std::string name(sel_getName(cmd));
+    NSLog(@"[MAP] %s", name.c_str());
+    const auto it = gMappings.find(name);
+    if (it != gMappings.end()) {
+        NSLog(@"[MAP:implemented] %s", name.c_str());
+        ApplicationDelegate_OneArg imp = (ApplicationDelegate_OneArg)method_getImplementation(it->second);
+        imp(self, cmd, arg);
+    }
+}
+
+static BOOL __KS_CALLING_DELEGATE__(id self, SEL cmd, id arg1, id arg2)
+{
+    std::string name(sel_getName(cmd));
+    NSLog(@"[MAP] %s", name.c_str());
+    const auto it = gMappings.find(name);
+    if (it != gMappings.end()) {
+        NSLog(@"[MAP:implemented] %s", name.c_str());
+        ApplicationDelegate_TwoArgs imp = (ApplicationDelegate_TwoArgs)method_getImplementation(it->second);
+        return imp(self, cmd, arg1, arg2);
+    }
+    return YES;
+}
+
++ (void)load
+{
+    static BOOL sDontSwizzle = [NSProcessInfo.processInfo.environment[@"KSCRASH_APP_SCENE_DELEGATE_SWIZZLE_DISABLED"] boolValue];
+    if (sDontSwizzle) {
+        return;
+    }
+#if KSCRASH_HAS_UIAPPLICATION
+    SwizzleInstanceMethod(UIApplication.class, @selector(setDelegate:), @selector(__ks_setDelegate:));
+    
+    if (@available(iOS 13.0, tvOS 13.0, *)) {
+        [[NSNotificationCenter defaultCenter] addObserverForName:UISceneWillConnectNotification
+                                                          object:nil
+                                                           queue:nil
+                                                      usingBlock:^(NSNotification * _Nonnull notification) {
+            UIScene *scene = notification.object;
+            [scene __ks_proxyDelegate];
+        }];
+    }
+#endif
+}
+
+#pragma - app delegate
+
+- (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(nullable NSDictionary<UIApplicationLaunchOptionsKey, id> *)launchOptions
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateLaunching];
+    return __KS_CALLING_DELEGATE__(self, _cmd, application, launchOptions);
+}
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(nullable NSDictionary<UIApplicationLaunchOptionsKey, id> *)launchOptions
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateLaunched];
+    return __KS_CALLING_DELEGATE__(self, _cmd, application, launchOptions);
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateActive];
+    __KS_CALLING_DELEGATE__(self, _cmd, application);
+}
+
+- (void)applicationWillResignActive:(UIApplication *)application
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateDeactivating];
+    __KS_CALLING_DELEGATE__(self, _cmd, application);
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateBackground];
+    __KS_CALLING_DELEGATE__(self, _cmd, application);
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateForegrounding];
+    __KS_CALLING_DELEGATE__(self, _cmd, application);
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateTerminating];
+    __KS_CALLING_DELEGATE__(self, _cmd, application);
+}
+
+#pragma - scene delegate
+
+- (void)sceneWillEnterForeground:(UIScene *)scene UISCENE_AVAILABLE
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateForegrounding];
+    __KS_CALLING_DELEGATE__(self, _cmd, scene);
+}
+
+- (void)sceneDidBecomeActive:(UIScene *)scene UISCENE_AVAILABLE
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateActive];
+    __KS_CALLING_DELEGATE__(self, _cmd, scene);
+}
+
+- (void)sceneWillResignActive:(UIScene *)scene UISCENE_AVAILABLE
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateDeactivating];
+    __KS_CALLING_DELEGATE__(self, _cmd, scene);
+}
+
+- (void)sceneDidEnterBackground:(UIScene *)scene UISCENE_AVAILABLE
+{
+    [KSCrashAppStateTracker.shared _setTransitionState:KSCrashAppTransitionStateBackground];
+    __KS_CALLING_DELEGATE__(self, _cmd, scene);
+}
+
+@end
+
+@interface Proxier : NSObject
+@end
+
+@implementation Proxier
+
++ (void)copyMethodsFromClass:(Class)fromClass toClass:(Class)toClass baseClass:(Class)baseClass
+{
+    unsigned int count = 0;
+    Method *methods = class_copyMethodList(fromClass, &count);
+    for (unsigned int i = 0; i < count; i++) {
+        
+        SEL name = method_getName(methods[i]);
+        IMP imp = method_getImplementation(methods[i]);
+        const char *type = method_getTypeEncoding(methods[i]);
+        
+        NSLog(@"Adding %s", sel_getName(name));
+        
+        Method originalMethod = class_getInstanceMethod(baseClass, name);
+        if (originalMethod) {
+            gMappings[sel_getName(name)] = originalMethod;
+            NSLog(@"-> original exists");
+        } else {
+            NSLog(@"-> no original");
+        }
+        
+        if (!class_addMethod(toClass, name, imp, type)) {
+            NSLog(@"-> Failed to add %s", sel_getName(name));
+        }
+    }
+    free(methods);
+}
+
++ (Class)subclassClass:(Class)klass copyMethodsFromClass:(Class)methodSourceClass
+{
+    NSString *subclassName = [[[@"__KSCrash__"
+                                stringByAppendingString:NSStringFromClass(klass)]
+                               stringByAppendingString:@"_"]
+                              stringByAppendingString:[NSUUID UUID].UUIDString];
+    Class subclass = objc_allocateClassPair(klass, subclassName.UTF8String, 0);
+    if (!subclass) {
+        return nil;
+    }
+    
+    [Proxier copyMethodsFromClass:methodSourceClass
+                          toClass:subclass
+                        baseClass:klass];
+    
+    objc_registerClassPair(subclass);
+    
+    return subclass;
+}
+
++ (void)proxyObject:(NSObject *)object withMethodsFromClass:(Class)methodSourceClass
+{
+    Class subclass = [self subclassClass:object.class copyMethodsFromClass:methodSourceClass];
+    Class originalClass = object_setClass(object, subclass);
+    if (originalClass) {
+        NSLog(@"[AC] Swizzled '%@' with '%@'", NSStringFromClass(originalClass), NSStringFromClass(subclass));
+    } else {
+        NSLog(@"[AC] Swizzled failed");
+    }
+}
+
+@end
+
+@implementation UIApplication (__KS_CALLING_DELEGATE_TEMPLATE__)
+
+- (void)__ks_setDelegate:(id<UIApplicationDelegate>)delegate
+{
+    if (delegate) {
+        [Proxier proxyObject:delegate withMethodsFromClass:__KS_CALLING_DELEGATE_TEMPLATE__.class];
+        KSCrashAppStateTracker.shared.proxied = YES;
+    }
+    [self __ks_setDelegate:delegate];
+}
+
+@end
+
+UISCENE_AVAILABLE
+@implementation UIScene (__KS_CALLING_DELEGATE_TEMPLATE__)
+
+- (void)__ks_proxyDelegate
+{
+    if (self.delegate) {
+        [Proxier proxyObject:self.delegate withMethodsFromClass:__KS_CALLING_DELEGATE_TEMPLATE__.class];
+        KSCrashAppStateTracker.shared.proxied = YES;
+    }
+}
+
+@end
+
+#endif

--- a/Sources/KSCrashRecording/KSCrashLifecycleHandler.mm
+++ b/Sources/KSCrashRecording/KSCrashLifecycleHandler.mm
@@ -54,6 +54,7 @@
 
 #import <objc/runtime.h>
 #import <map>
+#import <string>
 
 #import <UIKit/UIKit.h>
 

--- a/Sources/KSCrashRecording/include/KSCrashAppStateTracker.h
+++ b/Sources/KSCrashRecording/include/KSCrashAppStateTracker.h
@@ -59,6 +59,7 @@ typedef void (^KSCrashAppStateTrackerObserverBlock)(KSCrashAppTransitionState tr
 - (instancetype)initWithNotificationCenter:(NSNotificationCenter *)notificationCenter NS_DESIGNATED_INITIALIZER;
 
 @property (atomic, readonly) KSCrashAppTransitionState transitionState;
+@property (atomic, readonly, getter=isTransitionStateComplete) BOOL transitionStateComplete;
 
 /** 
  * Adds an observer that implements the _KSCrashAppStateTrackerObserving_ protocol.

--- a/Sources/KSCrashRecording/include/KSCrashAppTransitionState.h
+++ b/Sources/KSCrashRecording/include/KSCrashAppTransitionState.h
@@ -38,6 +38,7 @@ enum {
     KSCrashAppTransitionStateStartup = 0,
     KSCrashAppTransitionStateStartupPrewarm,
     KSCrashAppTransitionStateLaunching,
+    KSCrashAppTransitionStateLaunched,
     KSCrashAppTransitionStateForegrounding,
     KSCrashAppTransitionStateActive,
     KSCrashAppTransitionStateDeactivating,

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_Memory_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_Memory_Tests.m
@@ -187,6 +187,7 @@
     
     XCTAssertTrue(ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionStateStartup));
     XCTAssertTrue(ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionStateLaunching));
+    XCTAssertTrue(ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionStateLaunched));
     XCTAssertTrue(ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionStateForegrounding));
     XCTAssertTrue(ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionStateActive));
     XCTAssertTrue(ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionStateDeactivating));
@@ -234,7 +235,7 @@ static KSCrashAppMemory *Memory(uint64_t footprint) {
     
 #if KSCRASH_HAS_UIAPPLICATION
     [center postNotificationName:UIApplicationDidFinishLaunchingNotification object:nil];
-    XCTAssertEqual(tracker.transitionState, KSCrashAppTransitionStateLaunching);
+    XCTAssertEqual(tracker.transitionState, KSCrashAppTransitionStateLaunched);
     XCTAssertEqual(tracker.transitionState, state);
     
     [center postNotificationName:UIApplicationWillEnterForegroundNotification object:nil];
@@ -252,11 +253,7 @@ static KSCrashAppMemory *Memory(uint64_t footprint) {
     [center postNotificationName:UIApplicationDidEnterBackgroundNotification object:nil];
     XCTAssertEqual(tracker.transitionState, KSCrashAppTransitionStateBackground);
     XCTAssertEqual(tracker.transitionState, state);
-    
-    [center postNotificationName:UIApplicationDidFinishLaunchingNotification object:nil];
-    XCTAssertEqual(tracker.transitionState, KSCrashAppTransitionStateLaunching);
-    XCTAssertEqual(tracker.transitionState, state);
-    
+
     [center postNotificationName:UIApplicationWillTerminateNotification object:nil];
     XCTAssertEqual(tracker.transitionState, KSCrashAppTransitionStateTerminating);
     XCTAssertEqual(tracker.transitionState, state);


### PR DESCRIPTION
## If we can, we try and swizzle App and Scene delegates.
----

This is a proposal. What you have already works just fine, but it could be a bit more precise.

----
Lifecycle delegate and notifications don't happen in the same stack, the stack unwinds after the delegate calls.

run loop cycle 1: Application -> Delegate
run loop cycle 2: Application -> Notification

Due to this, it's very hard for a system to receive lifecycle events before the app it is being installed in. This can lead to mismatched user perception (foreground when the app is actually background). That mismatch leads to wrongly categorizing issues reported by the system. 

To fix this, we need to swizzle app a scene delegates. This allows us to receive delegate callbacks before anyone else and correctly record the state of the app before the app has a chance to run any code in those transitions and possibly cause a reliability event.

----

The swizzle is the same kind of swizzling [used in KVC as described here](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/KeyValueObserving/Articles/KVOImplementation.html).