### PR TITLE
Swiftify API

### DIFF
--- a/Sources/KSCrashFilters/KSCrashReportFilterAlert.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterAlert.m
@@ -144,10 +144,10 @@
 @synthesize yesAnswer = _yesAnswer;
 @synthesize noAnswer = _noAnswer;
 
-+ (KSCrashReportFilterAlert*) filterWithTitle:(NSString*) title
-                                      message:(nullable NSString*) message
-                                    yesAnswer:(NSString*) yesAnswer
-                                     noAnswer:(nullable NSString*) noAnswer;
++ (instancetype) filterWithTitle:(NSString*) title
+                         message:(nullable NSString*) message
+                       yesAnswer:(NSString*) yesAnswer
+                        noAnswer:(nullable NSString*) noAnswer;
 {
     return [[self alloc] initWithTitle:title
                                message:message

--- a/Sources/KSCrashFilters/KSCrashReportFilterAlert.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterAlert.m
@@ -145,9 +145,9 @@
 @synthesize noAnswer = _noAnswer;
 
 + (KSCrashReportFilterAlert*) filterWithTitle:(NSString*) title
-                                      message:(NSString*) message
+                                      message:(nullable NSString*) message
                                     yesAnswer:(NSString*) yesAnswer
-                                     noAnswer:(NSString*) noAnswer
+                                     noAnswer:(nullable NSString*) noAnswer;
 {
     return [[self alloc] initWithTitle:title
                                message:message
@@ -155,10 +155,10 @@
                               noAnswer:noAnswer];
 }
 
-- (id) initWithTitle:(NSString*) title
-             message:(NSString*) message
-           yesAnswer:(NSString*) yesAnswer
-            noAnswer:(NSString*) noAnswer
+- (instancetype) initWithTitle:(NSString*) title
+                       message:(nullable NSString*) message
+                     yesAnswer:(NSString*) yesAnswer
+                      noAnswer:(nullable NSString*) noAnswer;
 {
     if((self = [super init]))
     {

--- a/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
@@ -205,7 +205,7 @@ static NSDictionary* g_registerOrders;
 - (int) majorVersion:(NSDictionary*) report
 {
     NSDictionary* info = [self infoReport:report];
-    NSString* version = [info objectForKey:@KSCrashField_Version];
+    NSString* version = [info objectForKey:KSCrashField_Version];
     if ([version isKindOfClass:[NSDictionary class]])
     {
         NSDictionary *oldVersion = (NSDictionary *)version;
@@ -329,13 +329,13 @@ static NSDictionary* g_registerOrders;
     NSMutableString* str = [NSMutableString string];
 
     int traceNum = 0;
-    for(NSDictionary* trace in [backtrace objectForKey:@KSCrashField_Contents])
+    for(NSDictionary* trace in [backtrace objectForKey:KSCrashField_Contents])
     {
-        uintptr_t pc = (uintptr_t)[[trace objectForKey:@KSCrashField_InstructionAddr] longLongValue];
-        uintptr_t objAddr = (uintptr_t)[[trace objectForKey:@KSCrashField_ObjectAddr] longLongValue];
-        NSString* objName = [[trace objectForKey:@KSCrashField_ObjectName] lastPathComponent];
-        uintptr_t symAddr = (uintptr_t)[[trace objectForKey:@KSCrashField_SymbolAddr] longLongValue];
-        NSString* symName = [trace objectForKey:@KSCrashField_SymbolName];
+        uintptr_t pc = (uintptr_t)[[trace objectForKey:KSCrashField_InstructionAddr] longLongValue];
+        uintptr_t objAddr = (uintptr_t)[[trace objectForKey:KSCrashField_ObjectAddr] longLongValue];
+        NSString* objName = [[trace objectForKey:KSCrashField_ObjectName] lastPathComponent];
+        uintptr_t symAddr = (uintptr_t)[[trace objectForKey:KSCrashField_SymbolAddr] longLongValue];
+        NSString* symName = [trace objectForKey:KSCrashField_SymbolName];
         bool isMainExecutable = mainExecutableName && [objName isEqualToString:mainExecutableName];
         KSAppleReportStyle thisLineStyle = reportStyle;
         if(thisLineStyle == KSAppleReportStylePartiallySymbolicated)
@@ -400,61 +400,61 @@ static NSDictionary* g_registerOrders;
 
 - (NSDictionary*) recrashReport:(NSDictionary*) report
 {
-    return [report objectForKey:@KSCrashField_RecrashReport];
+    return [report objectForKey:KSCrashField_RecrashReport];
 }
 
 - (NSDictionary*) systemReport:(NSDictionary*) report
 {
-    return [report objectForKey:@KSCrashField_System];
+    return [report objectForKey:KSCrashField_System];
 }
 
 - (NSDictionary*) infoReport:(NSDictionary*) report
 {
-    return [report objectForKey:@KSCrashField_Report];
+    return [report objectForKey:KSCrashField_Report];
 }
 
 - (NSDictionary*) processReport:(NSDictionary*) report
 {
-    return [report objectForKey:@KSCrashField_ProcessState];
+    return [report objectForKey:KSCrashField_ProcessState];
 }
 
 - (NSDictionary*) crashReport:(NSDictionary*) report
 {
-    return [report objectForKey:@KSCrashField_Crash];
+    return [report objectForKey:KSCrashField_Crash];
 }
 
 - (NSArray*) binaryImagesReport:(NSDictionary*) report
 {
-    return [report objectForKey:@KSCrashField_BinaryImages];
+    return [report objectForKey:KSCrashField_BinaryImages];
 }
 
 - (NSDictionary*) crashedThread:(NSDictionary*) report
 {
     NSDictionary* crash = [self crashReport:report];
-    NSArray* threads = [crash objectForKey:@KSCrashField_Threads];
+    NSArray* threads = [crash objectForKey:KSCrashField_Threads];
     for(NSDictionary* thread in threads)
     {
-        BOOL crashed = [[thread objectForKey:@KSCrashField_Crashed] boolValue];
+        BOOL crashed = [[thread objectForKey:KSCrashField_Crashed] boolValue];
         if(crashed)
         {
             return thread;
         }
     }
 
-    return [crash objectForKey:@KSCrashField_CrashedThread];
+    return [crash objectForKey:KSCrashField_CrashedThread];
 }
 
 - (NSString*) mainExecutableNameForReport:(NSDictionary*) report
 {
     NSDictionary* info = [self infoReport:report];
-    return [info objectForKey:@KSCrashField_ProcessName];
+    return [info objectForKey:KSCrashField_ProcessName];
 }
 
 - (NSString*) cpuArchForReport:(NSDictionary*) report
 {
     NSDictionary* system = [self systemReport:report];
-    cpu_type_t cpuType = [[system objectForKey:@KSCrashField_BinaryCPUType] intValue];
-    cpu_subtype_t cpuSubType = [[system objectForKey:@KSCrashField_BinaryCPUSubType] intValue];
+    cpu_type_t cpuType = [[system objectForKey:KSCrashField_BinaryCPUType] intValue];
+    cpu_subtype_t cpuSubType = [[system objectForKey:KSCrashField_BinaryCPUSubType] intValue];
     return [self CPUArchForMajor:cpuType minor:cpuSubType];
 }
 
@@ -462,8 +462,8 @@ static NSDictionary* g_registerOrders;
 {
     NSDictionary* system = [self systemReport:report];
     NSDictionary* reportInfo = [self infoReport:report];
-    NSString *reportID = [reportInfo objectForKey:@KSCrashField_ID];
-    NSDate* crashTime = [g_rfc3339DateFormatter dateFromString:[reportInfo objectForKey:@KSCrashField_Timestamp]];
+    NSString *reportID = [reportInfo objectForKey:KSCrashField_ID];
+    NSDate* crashTime = [g_rfc3339DateFormatter dateFromString:[reportInfo objectForKey:KSCrashField_Timestamp]];
 
     return [self headerStringForSystemInfo:system reportID:reportID crashTime:crashTime];
 }
@@ -471,32 +471,32 @@ static NSDictionary* g_registerOrders;
 - (NSString*)headerStringForSystemInfo:(NSDictionary*)system reportID:(NSString*)reportID crashTime:(NSDate*)crashTime
 {
     NSMutableString* str = [NSMutableString string];
-    NSString* executablePath = [system objectForKey:@KSCrashField_ExecutablePath];
-    NSString* cpuArch = [system objectForKey:@KSCrashField_CPUArch];
+    NSString* executablePath = [system objectForKey:KSCrashField_ExecutablePath];
+    NSString* cpuArch = [system objectForKey:KSCrashField_CPUArch];
     NSString* cpuArchType = [self CPUType:cpuArch isSystemInfoHeader:YES];
     NSString* parentProcess = @"launchd"; // In iOS and most macOS regulard apps "launchd" is always the launcher. This might need a fix for other kind of apps
     NSString* processRole = @"Foreground"; // In iOS and most macOS regulard apps the role is "Foreground". This might need a fix for other kind of apps
 
     [str appendFormat:@"Incident Identifier: %@\n", reportID];
-    [str appendFormat:@"CrashReporter Key:   %@\n", [system objectForKey:@KSCrashField_DeviceAppHash]];
-    [str appendFormat:@"Hardware Model:      %@\n", [system objectForKey:@KSCrashField_Machine]];
+    [str appendFormat:@"CrashReporter Key:   %@\n", [system objectForKey:KSCrashField_DeviceAppHash]];
+    [str appendFormat:@"Hardware Model:      %@\n", [system objectForKey:KSCrashField_Machine]];
     [str appendFormat:@"Process:             %@ [%@]\n",
-     [system objectForKey:@KSCrashField_ProcessName],
-     [system objectForKey:@KSCrashField_ProcessID]];
+     [system objectForKey:KSCrashField_ProcessName],
+     [system objectForKey:KSCrashField_ProcessID]];
     [str appendFormat:@"Path:                %@\n", executablePath];
-    [str appendFormat:@"Identifier:          %@\n", [system objectForKey:@KSCrashField_BundleID]];
+    [str appendFormat:@"Identifier:          %@\n", [system objectForKey:KSCrashField_BundleID]];
     [str appendFormat:@"Version:             %@ (%@)\n",
-     [system objectForKey:@KSCrashField_BundleVersion],
-     [system objectForKey:@KSCrashField_BundleShortVersion]];
+     [system objectForKey:KSCrashField_BundleVersion],
+     [system objectForKey:KSCrashField_BundleShortVersion]];
     [str appendFormat:@"Code Type:           %@\n", cpuArchType];
     [str appendFormat:@"Role:                %@\n", processRole];
-    [str appendFormat:@"Parent Process:      %@ [%@]\n", parentProcess, [system objectForKey:@KSCrashField_ParentProcessID]];
+    [str appendFormat:@"Parent Process:      %@ [%@]\n", parentProcess, [system objectForKey:KSCrashField_ParentProcessID]];
     [str appendFormat:@"\n"];
     [str appendFormat:@"Date/Time:           %@\n", [self stringFromDate:crashTime]];
     [str appendFormat:@"OS Version:          %@ %@ (%@)\n",
-     [system objectForKey:@KSCrashField_SystemName],
-     [system objectForKey:@KSCrashField_SystemVersion],
-     [system objectForKey:@KSCrashField_OSVersion]];
+     [system objectForKey:KSCrashField_SystemName],
+     [system objectForKey:KSCrashField_SystemVersion],
+     [system objectForKey:KSCrashField_OSVersion]];
     [str appendFormat:@"Report Version:      104\n"];
 
     return str;
@@ -514,8 +514,8 @@ static NSDictionary* g_registerOrders;
         NSMutableArray* images = [NSMutableArray arrayWithArray:binaryImages];
         [images sortUsingComparator:^NSComparisonResult(id obj1, id obj2)
          {
-             NSNumber* num1 = [(NSDictionary*)obj1 objectForKey:@KSCrashField_ImageAddress];
-             NSNumber* num2 = [(NSDictionary*)obj2 objectForKey:@KSCrashField_ImageAddress];
+             NSNumber* num1 = [(NSDictionary*)obj1 objectForKey:KSCrashField_ImageAddress];
+             NSNumber* num2 = [(NSDictionary*)obj2 objectForKey:KSCrashField_ImageAddress];
              if(num1 == nil || num2 == nil)
              {
                  return NSOrderedSame;
@@ -524,13 +524,13 @@ static NSDictionary* g_registerOrders;
          }];
         for(NSDictionary* image in images)
         {
-            cpu_type_t cpuType = [[image objectForKey:@KSCrashField_CPUType] intValue];
-            cpu_subtype_t cpuSubtype = [[image objectForKey:@KSCrashField_CPUSubType] intValue];
-            uintptr_t imageAddr = (uintptr_t)[[image objectForKey:@KSCrashField_ImageAddress] longLongValue];
-            uintptr_t imageSize = (uintptr_t)[[image objectForKey:@KSCrashField_ImageSize] longLongValue];
-            NSString* path = [image objectForKey:@KSCrashField_Name];
+            cpu_type_t cpuType = [[image objectForKey:KSCrashField_CPUType] intValue];
+            cpu_subtype_t cpuSubtype = [[image objectForKey:KSCrashField_CPUSubType] intValue];
+            uintptr_t imageAddr = (uintptr_t)[[image objectForKey:KSCrashField_ImageAddress] longLongValue];
+            uintptr_t imageSize = (uintptr_t)[[image objectForKey:KSCrashField_ImageSize] longLongValue];
+            NSString* path = [image objectForKey:KSCrashField_Name];
             NSString* name = [path lastPathComponent];
-            NSString* uuid = [self toCompactUUID:[image objectForKey:@KSCrashField_UUID]];
+            NSString* uuid = [self toCompactUUID:[image objectForKey:KSCrashField_UUID]];
             NSString* arch = [self CPUArchForMajor:cpuType minor:cpuSubtype];
             [str appendFormat:FMT_PTR_RJ @" - " FMT_PTR_RJ @" %@ %@  <%@> %@\n",
              imageAddr,
@@ -555,7 +555,7 @@ static NSDictionary* g_registerOrders;
     {
         return @"";
     }
-    int threadIndex = [[thread objectForKey:@KSCrashField_Index] intValue];
+    int threadIndex = [[thread objectForKey:KSCrashField_Index] intValue];
 
     NSString* cpuArchType = [self CPUType:cpuArch isSystemInfoHeader:NO];
 
@@ -564,7 +564,7 @@ static NSDictionary* g_registerOrders;
     [str appendFormat:@"\nThread %d crashed with %@ Thread State:\n",
      threadIndex, cpuArchType];
 
-    NSDictionary* registers = [(NSDictionary*)[thread objectForKey:@KSCrashField_Registers] objectForKey:@KSCrashField_Basic];
+    NSDictionary* registers = [(NSDictionary*)[thread objectForKey:KSCrashField_Registers] objectForKey:KSCrashField_Basic];
     NSArray* regOrder = [g_registerOrders objectForKey:cpuArch];
     if(regOrder == nil)
     {
@@ -602,9 +602,9 @@ static NSDictionary* g_registerOrders;
 
     NSDictionary* system = [self systemReport:report];
     NSDictionary* crash = [self crashReport:report];
-    NSDictionary* error = [crash objectForKey:@KSCrashField_Error];
-    NSDictionary* nsexception = [error objectForKey:@KSCrashField_NSException];
-    NSDictionary* referencedObject = [nsexception objectForKey:@KSCrashField_ReferencedObject];
+    NSDictionary* error = [crash objectForKey:KSCrashField_Error];
+    NSDictionary* nsexception = [error objectForKey:KSCrashField_NSException];
+    NSDictionary* referencedObject = [nsexception objectForKey:KSCrashField_ReferencedObject];
     if(referencedObject != nil)
     {
         [str appendFormat:@"Object referenced by NSException:\n%@\n", [self JSONForObject:referencedObject]];
@@ -613,29 +613,29 @@ static NSDictionary* g_registerOrders;
     NSDictionary* crashedThread = [self crashedThread:report];
     if(crashedThread != nil)
     {
-        NSDictionary* stack = [crashedThread objectForKey:@KSCrashField_Stack];
+        NSDictionary* stack = [crashedThread objectForKey:KSCrashField_Stack];
         if(stack != nil)
         {
             [str appendFormat:@"\nStack Dump (" FMT_PTR_LONG "-" FMT_PTR_LONG "):\n\n%@\n",
-             (uintptr_t)[[stack objectForKey:@KSCrashField_DumpStart] unsignedLongLongValue],
-             (uintptr_t)[[stack objectForKey:@KSCrashField_DumpEnd] unsignedLongLongValue],
-             [stack objectForKey:@KSCrashField_Contents]];
+             (uintptr_t)[[stack objectForKey:KSCrashField_DumpStart] unsignedLongLongValue],
+             (uintptr_t)[[stack objectForKey:KSCrashField_DumpEnd] unsignedLongLongValue],
+             [stack objectForKey:KSCrashField_Contents]];
         }
 
-        NSDictionary* notableAddresses = [crashedThread objectForKey:@KSCrashField_NotableAddresses];
+        NSDictionary* notableAddresses = [crashedThread objectForKey:KSCrashField_NotableAddresses];
         if(notableAddresses.count)
         {
             [str appendFormat:@"\nNotable Addresses:\n%@\n", [self JSONForObject:notableAddresses]];
         }
     }
 
-    NSDictionary* lastException = [[self processReport:report] objectForKey:@KSCrashField_LastDeallocedNSException];
+    NSDictionary* lastException = [[self processReport:report] objectForKey:KSCrashField_LastDeallocedNSException];
     if(lastException != nil)
     {
-        uintptr_t address = (uintptr_t)[[lastException objectForKey:@KSCrashField_Address] unsignedLongLongValue];
-        NSString* name = [lastException objectForKey:@KSCrashField_Name];
-        NSString* reason = [lastException objectForKey:@KSCrashField_Reason];
-        referencedObject = [lastException objectForKey:@KSCrashField_ReferencedObject];
+        uintptr_t address = (uintptr_t)[[lastException objectForKey:KSCrashField_Address] unsignedLongLongValue];
+        NSString* name = [lastException objectForKey:KSCrashField_Name];
+        NSString* reason = [lastException objectForKey:KSCrashField_Reason];
+        referencedObject = [lastException objectForKey:KSCrashField_ReferencedObject];
         [str appendFormat:@"\nLast deallocated NSException (" FMT_PTR_LONG "): %@: %@\n",
          address, name, reason];
         if(referencedObject != nil)
@@ -643,25 +643,25 @@ static NSDictionary* g_registerOrders;
             [str appendFormat:@"Referenced object:\n%@\n", [self JSONForObject:referencedObject]];
         }
         [str appendString:
-         [self backtraceString:[lastException objectForKey:@KSCrashField_Backtrace]
+         [self backtraceString:[lastException objectForKey:KSCrashField_Backtrace]
                    reportStyle:self.reportStyle
             mainExecutableName:mainExecutableName]];
     }
 
-    NSDictionary* appStats = [system objectForKey:@KSCrashField_AppStats];
+    NSDictionary* appStats = [system objectForKey:KSCrashField_AppStats];
     if(appStats != nil)
     {
         [str appendFormat:@"\nApplication Stats:\n%@\n", [self JSONForObject:appStats]];
     }
     
-    NSDictionary* memoryStats = [system objectForKey:@KSCrashField_AppMemory];
+    NSDictionary* memoryStats = [system objectForKey:KSCrashField_AppMemory];
     if(memoryStats != nil)
     {
         [str appendFormat:@"\nMemory Statistics:\n%@\n", [self JSONForObject:memoryStats]];
     }
     
-    NSDictionary* crashReport = [report objectForKey:@KSCrashField_Crash];
-    NSString* diagnosis = [crashReport objectForKey:@KSCrashField_Diagnosis];
+    NSDictionary* crashReport = [report objectForKey:KSCrashField_Crash];
+    NSString* diagnosis = [crashReport objectForKey:KSCrashField_Diagnosis];
     if(diagnosis != nil)
     {
         [str appendFormat:@"\nCrashDoctor Diagnosis: %@\n", diagnosis];
@@ -690,25 +690,25 @@ static NSDictionary* g_registerOrders;
 - (BOOL) isZombieNSException:(NSDictionary*) report
 {
     NSDictionary* crash = [self crashReport:report];
-    NSDictionary* error = [crash objectForKey:@KSCrashField_Error];
-    NSDictionary* mach = [error objectForKey:@KSCrashField_Mach];
-    NSString* machExcName = [mach objectForKey:@KSCrashField_ExceptionName];
-    NSString* machCodeName = [mach objectForKey:@KSCrashField_CodeName];
+    NSDictionary* error = [crash objectForKey:KSCrashField_Error];
+    NSDictionary* mach = [error objectForKey:KSCrashField_Mach];
+    NSString* machExcName = [mach objectForKey:KSCrashField_ExceptionName];
+    NSString* machCodeName = [mach objectForKey:KSCrashField_CodeName];
     if(![machExcName isEqualToString:@"EXC_BAD_ACCESS"] ||
        ![machCodeName isEqualToString:@"KERN_INVALID_ADDRESS"])
     {
         return NO;
     }
 
-    NSDictionary* lastException = [[self processReport:report] objectForKey:@KSCrashField_LastDeallocedNSException];
+    NSDictionary* lastException = [[self processReport:report] objectForKey:KSCrashField_LastDeallocedNSException];
     if(lastException == nil)
     {
         return NO;
     }
-    NSNumber* lastExceptionAddress = [lastException objectForKey:@KSCrashField_Address];
+    NSNumber* lastExceptionAddress = [lastException objectForKey:KSCrashField_Address];
 
     NSDictionary* thread = [self crashedThread:report];
-    NSDictionary* registers = [(NSDictionary*)[thread objectForKey:@KSCrashField_Registers] objectForKey:@KSCrashField_Basic];
+    NSDictionary* registers = [(NSDictionary*)[thread objectForKey:KSCrashField_Registers] objectForKey:KSCrashField_Basic];
 
     for(NSString* reg in registers)
     {
@@ -728,27 +728,27 @@ static NSDictionary* g_registerOrders;
 
     NSDictionary* thread = [self crashedThread:report];
     NSDictionary* crash = [self crashReport:report];
-    NSDictionary* error = [crash objectForKey:@KSCrashField_Error];
-    NSDictionary* type = [error objectForKey:@KSCrashField_Type];
+    NSDictionary* error = [crash objectForKey:KSCrashField_Error];
+    NSDictionary* type = [error objectForKey:KSCrashField_Type];
 
-    NSDictionary* nsexception = [error objectForKey:@KSCrashField_NSException];
-    NSDictionary* cppexception = [error objectForKey:@KSCrashField_CPPException];
-    NSDictionary* lastException = [[self processReport:report] objectForKey:@KSCrashField_LastDeallocedNSException];
-    NSDictionary* userException = [error objectForKey:@KSCrashField_UserReported];
-    NSDictionary* mach = [error objectForKey:@KSCrashField_Mach];
-    NSDictionary* signal = [error objectForKey:@KSCrashField_Signal];
+    NSDictionary* nsexception = [error objectForKey:KSCrashField_NSException];
+    NSDictionary* cppexception = [error objectForKey:KSCrashField_CPPException];
+    NSDictionary* lastException = [[self processReport:report] objectForKey:KSCrashField_LastDeallocedNSException];
+    NSDictionary* userException = [error objectForKey:KSCrashField_UserReported];
+    NSDictionary* mach = [error objectForKey:KSCrashField_Mach];
+    NSDictionary* signal = [error objectForKey:KSCrashField_Signal];
 
-    NSString* machExcName = [mach objectForKey:@KSCrashField_ExceptionName];
+    NSString* machExcName = [mach objectForKey:KSCrashField_ExceptionName];
     if(machExcName == nil)
     {
         machExcName = @"0";
     }
-    NSString* signalName = [signal objectForKey:@KSCrashField_Name];
+    NSString* signalName = [signal objectForKey:KSCrashField_Name];
     if(signalName == nil)
     {
-        signalName = [[signal objectForKey:@KSCrashField_Signal] stringValue];
+        signalName = [[signal objectForKey:KSCrashField_Signal] stringValue];
     }
-    NSString* machCodeName = [mach objectForKey:@KSCrashField_CodeName];
+    NSString* machCodeName = [mach objectForKey:KSCrashField_CodeName];
     if(machCodeName == nil)
     {
         machCodeName = @"0x00000000";
@@ -758,40 +758,40 @@ static NSDictionary* g_registerOrders;
     [str appendFormat:@"Exception Type:  %@ (%@)\n", machExcName, signalName];
     [str appendFormat:@"Exception Codes: %@ at " FMT_PTR_LONG @"\n",
      machCodeName,
-     (uintptr_t)[[error objectForKey:@KSCrashField_Address] longLongValue]];
+     (uintptr_t)[[error objectForKey:KSCrashField_Address] longLongValue]];
 
     [str appendFormat:@"Triggered by Thread:  %d\n",
-     [[thread objectForKey:@KSCrashField_Index] intValue]];
+     [[thread objectForKey:KSCrashField_Index] intValue]];
 
     if(nsexception != nil)
     {
-        [str appendString:[self stringWithUncaughtExceptionName:[nsexception objectForKey:@KSCrashField_Name]
-                                                         reason:[error objectForKey:@KSCrashField_Reason]]];
+        [str appendString:[self stringWithUncaughtExceptionName:[nsexception objectForKey:KSCrashField_Name]
+                                                         reason:[error objectForKey:KSCrashField_Reason]]];
     }
     else if([self isZombieNSException:report])
     {
-        [str appendString:[self stringWithUncaughtExceptionName:[lastException objectForKey:@KSCrashField_Name]
-                                                         reason:[lastException objectForKey:@KSCrashField_Reason]]];
+        [str appendString:[self stringWithUncaughtExceptionName:[lastException objectForKey:KSCrashField_Name]
+                                                         reason:[lastException objectForKey:KSCrashField_Reason]]];
         [str appendString:@"NOTE: This exception has been deallocated! Stack trace is crash from attempting to access this zombie exception.\n"];
     }
     else if(userException != nil)
     {
-        [str appendString:[self stringWithUncaughtExceptionName:[userException objectForKey:@KSCrashField_Name]
-                                                         reason:[error objectForKey:@KSCrashField_Reason]]];
+        [str appendString:[self stringWithUncaughtExceptionName:[userException objectForKey:KSCrashField_Name]
+                                                         reason:[error objectForKey:KSCrashField_Reason]]];
         NSString* trace = [self userExceptionTrace:userException];
         if(trace.length > 0)
         {
             [str appendFormat:@"\n%@\n", trace];
         }
     }
-    else if([type isEqual:@KSCrashExcType_CPPException])
+    else if([type isEqual:KSCrashExcType_CPPException])
     {
-        [str appendString:[self stringWithUncaughtExceptionName:[cppexception objectForKey:@KSCrashField_Name]
-                                                         reason:[error objectForKey:@KSCrashField_Reason]]];
+        [str appendString:[self stringWithUncaughtExceptionName:[cppexception objectForKey:KSCrashField_Name]
+                                                         reason:[error objectForKey:KSCrashField_Reason]]];
     }
 
-    NSString* crashType = [error objectForKey:@KSCrashField_Type];
-    if(crashType && [@KSCrashExcType_Deadlock isEqualToString:crashType])
+    NSString* crashType = [error objectForKey:KSCrashField_Type];
+    if(crashType && [KSCrashExcType_Deadlock isEqualToString:crashType])
     {
         [str appendFormat:@"\nApplication main thread deadlocked\n"];
     }
@@ -810,12 +810,12 @@ static NSDictionary* g_registerOrders;
 - (NSString*) userExceptionTrace:(NSDictionary*)userException
 {
     NSMutableString* str = [NSMutableString string];
-    NSString* line = [userException objectForKey:@KSCrashField_LineOfCode];
+    NSString* line = [userException objectForKey:KSCrashField_LineOfCode];
     if(line != nil)
     {
         [str appendFormat:@"Line: %@\n", line];
     }
-    NSArray* backtrace = [userException objectForKey:@KSCrashField_Backtrace];
+    NSArray* backtrace = [userException objectForKey:KSCrashField_Backtrace];
     for(NSString* entry in backtrace)
     {
         [str appendFormat:@"%@\n", entry];
@@ -834,10 +834,10 @@ static NSDictionary* g_registerOrders;
     NSMutableString* str = [NSMutableString string];
 
     [str appendFormat:@"\n"];
-    BOOL crashed = [[thread objectForKey:@KSCrashField_Crashed] boolValue];
-    int index = [[thread objectForKey:@KSCrashField_Index] intValue];
-    NSString* name = [thread objectForKey:@KSCrashField_Name];
-    NSString* queueName = [thread objectForKey:@KSCrashField_DispatchQueue];
+    BOOL crashed = [[thread objectForKey:KSCrashField_Crashed] boolValue];
+    int index = [[thread objectForKey:KSCrashField_Index] intValue];
+    NSString* name = [thread objectForKey:KSCrashField_Name];
+    NSString* queueName = [thread objectForKey:KSCrashField_DispatchQueue];
 
     if(name != nil)
     {
@@ -858,7 +858,7 @@ static NSDictionary* g_registerOrders;
     }
 
     [str appendString:
-     [self backtraceString:[thread objectForKey:@KSCrashField_Backtrace]
+     [self backtraceString:[thread objectForKey:KSCrashField_Backtrace]
                reportStyle:self.reportStyle
         mainExecutableName:mainExecutableName]];
 
@@ -871,7 +871,7 @@ static NSDictionary* g_registerOrders;
     NSMutableString* str = [NSMutableString string];
 
     NSDictionary* crash = [self crashReport:report];
-    NSArray* threads = [crash objectForKey:@KSCrashField_Threads];
+    NSArray* threads = [crash objectForKey:KSCrashField_Threads];
 
     for(NSDictionary* thread in threads)
     {
@@ -902,17 +902,17 @@ static NSDictionary* g_registerOrders;
     
     NSDictionary* recrashReport = [self recrashReport:report];
     NSDictionary* system = [self systemReport:recrashReport];
-    NSString* executablePath = [system objectForKey:@KSCrashField_ExecutablePath];
+    NSString* executablePath = [system objectForKey:KSCrashField_ExecutablePath];
     NSString* executableName = [executablePath lastPathComponent];
     NSDictionary* crash = [self crashReport:report];
-    NSDictionary* thread = [crash objectForKey:@KSCrashField_CrashedThread];
+    NSDictionary* thread = [crash objectForKey:KSCrashField_CrashedThread];
 
     [str appendString:@"\nHandler crashed while reporting:\n"];
     [str appendString:[self errorInfoStringForReport:report]];
     [str appendString:[self threadStringForThread:thread mainExecutableName:executableName]];
     [str appendString:[self crashedThreadCPUStateStringForReport:report
                                                          cpuArch:[self cpuArchForReport:recrashReport]]];
-    NSString* diagnosis = [crash objectForKey:@KSCrashField_Diagnosis];
+    NSString* diagnosis = [crash objectForKey:KSCrashField_Diagnosis];
     if(diagnosis != nil)
     {
         [str appendFormat:@"\nRecrash Diagnosis: %@", diagnosis];
@@ -926,7 +926,7 @@ static NSDictionary* g_registerOrders;
 {
     NSMutableString* str = [NSMutableString string];
     
-    NSDictionary* recrashReport = report[@KSCrashField_RecrashReport];
+    NSDictionary* recrashReport = report[KSCrashField_RecrashReport];
     if (recrashReport) {
         [str appendString:[self crashReportString:recrashReport]];
         [str appendString:[self recrashReportString:report]];

--- a/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
@@ -193,7 +193,7 @@ static NSDictionary* g_registerOrders;
     return [[self alloc] initWithReportStyle:reportStyle];
 }
 
-- (id) initWithReportStyle:(KSAppleReportStyle) reportStyle
+- (instancetype) initWithReportStyle:(KSAppleReportStyle) reportStyle
 {
     if((self = [super init]))
     {
@@ -468,7 +468,9 @@ static NSDictionary* g_registerOrders;
     return [self headerStringForSystemInfo:system reportID:reportID crashTime:crashTime];
 }
 
-- (NSString*)headerStringForSystemInfo:(NSDictionary*)system reportID:(NSString*)reportID crashTime:(NSDate*)crashTime
+- (NSString*)headerStringForSystemInfo:(NSDictionary<NSString*, id>*)system
+                              reportID:(nullable NSString*)reportID
+                             crashTime:(nullable NSDate*)crashTime
 {
     NSMutableString* str = [NSMutableString string];
     NSString* executablePath = [system objectForKey:KSCrashField_ExecutablePath];

--- a/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
@@ -188,7 +188,7 @@ static NSDictionary* g_registerOrders;
                         nil];
 }
 
-+ (KSCrashReportFilterAppleFmt*) filterWithReportStyle:(KSAppleReportStyle) reportStyle
++ (instancetype) filterWithReportStyle:(KSAppleReportStyle) reportStyle
 {
     return [[self alloc] initWithReportStyle:reportStyle];
 }

--- a/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
@@ -36,7 +36,7 @@
 
 @implementation KSCrashReportFilterPassthrough
 
-+ (KSCrashReportFilterPassthrough*) filter
++ (instancetype) filter
 {
     return [[self alloc] init];
 }
@@ -111,7 +111,7 @@
     return [block copy];
 }
 
-+ (KSCrashReportFilterCombine*) filterWithFiltersAndKeys:(id) firstFilter, ...
++ (instancetype) filterWithFiltersAndKeys:(id) firstFilter, ...
 {
     NSMutableArray* filters = [NSMutableArray array];
     NSMutableArray* keys = [NSMutableArray array];
@@ -119,7 +119,7 @@
     return [[self class] filterWithFilters:filters keys:keys];
 }
 
-+ (KSCrashReportFilterCombine *)filterWithFilters:(NSArray*)filters keys:(NSArray<NSString*>*)keys
++ (instancetype)filterWithFilters:(NSArray*)filters keys:(NSArray<NSString*>*)keys
 {
     return [[self alloc] initWithFilters:filters keys:keys];
 }
@@ -236,7 +236,7 @@
 
 @interface KSCrashReportFilterPipeline ()
 
-@property(nonatomic,readwrite,retain) NSArray* filters;
+@property(nonatomic,readwrite,copy) NSArray<id<KSCrashReportFilter>>* filters;
 
 @end
 
@@ -245,13 +245,13 @@
 
 @synthesize filters = _filters;
 
-+ (KSCrashReportFilterPipeline*) filterWithFilters:(id) firstFilter, ...
++ (instancetype) filterWithFilters:(id) firstFilter, ...
 {
     ksva_list_to_nsarray(firstFilter, filters);
     return [[self class] filterWithFiltersArray:filters];
 }
 
-+ (KSCrashReportFilterPipeline*) filterWithFiltersArray:(NSArray*) filters
++ (instancetype) filterWithFiltersArray:(NSArray*) filters
 {
     return [[self alloc] initWithFiltersArray:filters];
 }
@@ -371,14 +371,12 @@
 @synthesize key = _key;
 @synthesize allowNotFound = _allowNotFound;
 
-+ (KSCrashReportFilterObjectForKey*) filterWithKey:(id)key
-                                     allowNotFound:(BOOL) allowNotFound
++ (instancetype) filterWithKey:(id)key allowNotFound:(BOOL) allowNotFound
 {
     return [[self alloc] initWithKey:key allowNotFound:allowNotFound];
 }
 
-- (instancetype) initWithKey:(id)key
-               allowNotFound:(BOOL) allowNotFound
+- (instancetype) initWithKey:(id)key allowNotFound:(BOOL) allowNotFound
 {
     if((self = [super init]))
     {
@@ -438,13 +436,13 @@
 @synthesize separatorFmt = _separatorFmt;
 @synthesize keys = _keys;
 
-+ (KSCrashReportFilterConcatenate*) filterWithSeparatorFmt:(NSString*) separatorFmt keys:(id) firstKey, ...
++ (instancetype) filterWithSeparatorFmt:(NSString*) separatorFmt keys:(id) firstKey, ...
 {
     ksva_list_to_nsarray(firstKey, keys);
     return [[self class] filterWithSeparatorFmt:separatorFmt keysArray:keys];
 }
 
-+ (KSCrashReportFilterConcatenate*) filterWithSeparatorFmt:(NSString*) separatorFmt keysArray:(NSArray<NSString*>*) keys
++ (instancetype) filterWithSeparatorFmt:(NSString*) separatorFmt keysArray:(NSArray<NSString*>*) keys
 {
     return [[self alloc] initWithSeparatorFmt:separatorFmt keysArray:keys];
 }
@@ -517,13 +515,13 @@
 
 @synthesize keyPaths = _keyPaths;
 
-+ (KSCrashReportFilterSubset*) filterWithKeys:(id) firstKeyPath, ...
++ (instancetype) filterWithKeys:(id) firstKeyPath, ...
 {
     ksva_list_to_nsarray(firstKeyPath, keyPaths);
     return [[self class] filterWithKeysArray:keyPaths];
 }
 
-+ (KSCrashReportFilterSubset*) filterWithKeysArray:(NSArray<NSString*>*) keyPaths
++ (instancetype) filterWithKeysArray:(NSArray<NSString*>*) keyPaths
 {
     return [[self alloc] initWithKeysArray:keyPaths];
 }
@@ -586,7 +584,7 @@
 
 @implementation KSCrashReportFilterDataToString
 
-+ (KSCrashReportFilterDataToString*) filter
++ (instancetype) filter
 {
     return [[self alloc] init];
 }
@@ -609,7 +607,7 @@
 
 @implementation KSCrashReportFilterStringToData
 
-+ (KSCrashReportFilterStringToData*) filter
++ (instancetype) filter
 {
     return [[self alloc] init];
 }

--- a/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
@@ -55,8 +55,6 @@
 @property(nonatomic,readwrite,retain) NSArray* filters;
 @property(nonatomic,readwrite,retain) NSArray* keys;
 
-- (id) initWithFilters:(NSArray*) filters keys:(NSArray*) keys;
-
 @end
 
 

--- a/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
@@ -65,7 +65,7 @@
 @synthesize filters = _filters;
 @synthesize keys = _keys;
 
-- (id) initWithFilters:(NSArray*) filters keys:(NSArray*) keys
+- (instancetype) initWithFilters:(NSArray*) filters keys:(NSArray<NSString*>*) keys
 {
     if((self = [super init]))
     {
@@ -118,10 +118,15 @@
     NSMutableArray* filters = [NSMutableArray array];
     NSMutableArray* keys = [NSMutableArray array];
     ksva_iterate_list(firstFilter, [self argBlockWithFilters:filters andKeys:keys]);
+    return [[self class] filterWithFilters:filters keys:keys];
+}
+
++ (KSCrashReportFilterCombine *)filterWithFilters:(NSArray*)filters keys:(NSArray<NSString*>*)keys
+{
     return [[self alloc] initWithFilters:filters keys:keys];
 }
 
-- (id) initWithFiltersAndKeys:(id) firstFilter, ...
+- (instancetype) initWithFiltersAndKeys:(id) firstFilter, ...
 {
     NSMutableArray* filters = [NSMutableArray array];
     NSMutableArray* keys = [NSMutableArray array];
@@ -245,16 +250,21 @@
 + (KSCrashReportFilterPipeline*) filterWithFilters:(id) firstFilter, ...
 {
     ksva_list_to_nsarray(firstFilter, filters);
+    return [[self class] filterWithFiltersArray:filters];
+}
+
++ (KSCrashReportFilterPipeline*) filterWithFiltersArray:(NSArray*) filters
+{
     return [[self alloc] initWithFiltersArray:filters];
 }
 
-- (id) initWithFilters:(id) firstFilter, ...
+- (instancetype) initWithFilters:(id) firstFilter, ...
 {
     ksva_list_to_nsarray(firstFilter, filters);
     return [self initWithFiltersArray:filters];
 }
 
-- (id) initWithFiltersArray:(NSArray*) filters
+- (instancetype) initWithFiltersArray:(NSArray*) filters
 {
     if((self = [super init]))
     {
@@ -369,8 +379,8 @@
     return [[self alloc] initWithKey:key allowNotFound:allowNotFound];
 }
 
-- (id) initWithKey:(id)key
-     allowNotFound:(BOOL) allowNotFound
+- (instancetype) initWithKey:(id)key
+               allowNotFound:(BOOL) allowNotFound
 {
     if((self = [super init]))
     {
@@ -421,7 +431,7 @@
 @interface KSCrashReportFilterConcatenate ()
 
 @property(nonatomic, readwrite, retain) NSString* separatorFmt;
-@property(nonatomic, readwrite, retain) NSArray* keys;
+@property(nonatomic, readwrite, retain) NSArray<NSString*>* keys;
 
 @end
 
@@ -433,16 +443,21 @@
 + (KSCrashReportFilterConcatenate*) filterWithSeparatorFmt:(NSString*) separatorFmt keys:(id) firstKey, ...
 {
     ksva_list_to_nsarray(firstKey, keys);
+    return [[self class] filterWithSeparatorFmt:separatorFmt keysArray:keys];
+}
+
++ (KSCrashReportFilterConcatenate*) filterWithSeparatorFmt:(NSString*) separatorFmt keysArray:(NSArray<NSString*>*) keys
+{
     return [[self alloc] initWithSeparatorFmt:separatorFmt keysArray:keys];
 }
 
-- (id) initWithSeparatorFmt:(NSString*) separatorFmt keys:(id) firstKey, ...
+- (instancetype) initWithSeparatorFmt:(NSString*) separatorFmt keys:(id) firstKey, ...
 {
     ksva_list_to_nsarray(firstKey, keys);
     return [self initWithSeparatorFmt:separatorFmt keysArray:keys];
 }
 
-- (id) initWithSeparatorFmt:(NSString*) separatorFmt keysArray:(NSArray*) keys
+- (instancetype) initWithSeparatorFmt:(NSString*) separatorFmt keysArray:(NSArray<NSString*>*) keys
 {
     if((self = [super init]))
     {
@@ -507,16 +522,21 @@
 + (KSCrashReportFilterSubset*) filterWithKeys:(id) firstKeyPath, ...
 {
     ksva_list_to_nsarray(firstKeyPath, keyPaths);
+    return [[self class] filterWithKeysArray:keyPaths];
+}
+
++ (KSCrashReportFilterSubset*) filterWithKeysArray:(NSArray<NSString*>*) keyPaths
+{
     return [[self alloc] initWithKeysArray:keyPaths];
 }
 
-- (id) initWithKeys:(id) firstKeyPath, ...
+- (instancetype) initWithKeys:(id) firstKeyPath, ...
 {
     ksva_list_to_nsarray(firstKeyPath, keyPaths);
     return [self initWithKeysArray:keyPaths];
 }
 
-- (id) initWithKeysArray:(NSArray*) keyPaths
+- (instancetype) initWithKeysArray:(NSArray<NSString*>*) keyPaths
 {
     if((self = [super init]))
     {

--- a/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
@@ -278,15 +278,14 @@
                 [expandedFilters addObject:filter];
             }
         }
-        self.filters = expandedFilters;
+        self.filters = [expandedFilters copy];
     }
     return self;
 }
 
 - (void) addFilter:(id<KSCrashReportFilter>) filter
 {
-    NSMutableArray* mutableFilters = (NSMutableArray*)self.filters; // Shh! Don't tell anyone!
-    [mutableFilters insertObject:filter atIndex:0];
+    self.filters = [@[filter] arrayByAddingObjectsFromArray:self.filters];
 }
 
 - (void) filterReports:(NSArray*) reports

--- a/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
@@ -278,7 +278,7 @@
                 [expandedFilters addObject:filter];
             }
         }
-        self.filters = [expandedFilters copy];
+        _filters = [expandedFilters copy];
     }
     return self;
 }

--- a/Sources/KSCrashFilters/KSCrashReportFilterGZip.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterGZip.m
@@ -39,7 +39,7 @@
 
 @synthesize compressionLevel = _compressionLevel;
 
-+ (KSCrashReportFilterGZipCompress*) filterWithCompressionLevel:(NSInteger) compressionLevel
++ (instancetype) filterWithCompressionLevel:(NSInteger) compressionLevel
 {
     return [[self alloc] initWithCompressionLevel:compressionLevel];
 }
@@ -81,7 +81,7 @@
 
 @implementation KSCrashReportFilterGZipDecompress
 
-+ (KSCrashReportFilterGZipDecompress*) filter
++ (instancetype) filter
 {
     return [[self alloc] init];
 }

--- a/Sources/KSCrashFilters/KSCrashReportFilterGZip.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterGZip.m
@@ -31,7 +31,7 @@
 
 @interface KSCrashReportFilterGZipCompress ()
 
-@property(nonatomic,readwrite,assign) int compressionLevel;
+@property(nonatomic,readwrite,assign) NSInteger compressionLevel;
 
 @end
 
@@ -39,12 +39,12 @@
 
 @synthesize compressionLevel = _compressionLevel;
 
-+ (KSCrashReportFilterGZipCompress*) filterWithCompressionLevel:(int) compressionLevel
++ (KSCrashReportFilterGZipCompress*) filterWithCompressionLevel:(NSInteger) compressionLevel
 {
     return [[self alloc] initWithCompressionLevel:compressionLevel];
 }
 
-- (id) initWithCompressionLevel:(int) compressionLevel
+- (instancetype) initWithCompressionLevel:(NSInteger) compressionLevel
 {
     if((self = [super init]))
     {
@@ -60,7 +60,7 @@
     for(NSData* report in reports)
     {
         NSError* error = nil;
-        NSData* compressedData = [report gzippedWithCompressionLevel:self.compressionLevel
+        NSData* compressedData = [report gzippedWithCompressionLevel:(int)self.compressionLevel
                                                                error:&error];
         if(compressedData == nil)
         {

--- a/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
@@ -44,10 +44,10 @@
 
 + (KSCrashReportFilterJSONEncode*) filterWithOptions:(KSJSONEncodeOption) options
 {
-    return [(KSCrashReportFilterJSONEncode*)[self alloc] initWithOptions:options];
+    return [[self alloc] initWithOptions:options];
 }
 
-- (id) initWithOptions:(KSJSONEncodeOption) options
+- (instancetype) initWithOptions:(KSJSONEncodeOption) options
 {
     if((self = [super init]))
     {
@@ -96,10 +96,10 @@
 
 + (KSCrashReportFilterJSONDecode*) filterWithOptions:(KSJSONDecodeOption) options
 {
-    return [(KSCrashReportFilterJSONDecode*)[self alloc] initWithOptions:options];
+    return [[self alloc] initWithOptions:options];
 }
 
-- (id) initWithOptions:(KSJSONDecodeOption) options
+- (instancetype) initWithOptions:(KSJSONDecodeOption) options
 {
     if((self = [super init]))
     {

--- a/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
@@ -42,7 +42,7 @@
 
 @synthesize encodeOptions = _encodeOptions;
 
-+ (KSCrashReportFilterJSONEncode*) filterWithOptions:(KSJSONEncodeOption) options
++ (instancetype) filterWithOptions:(KSJSONEncodeOption) options
 {
     return [[self alloc] initWithOptions:options];
 }
@@ -94,7 +94,7 @@
 
 @synthesize decodeOptions = _encodeOptions;
 
-+ (KSCrashReportFilterJSONDecode*) filterWithOptions:(KSJSONDecodeOption) options
++ (instancetype) filterWithOptions:(KSJSONDecodeOption) options
 {
     return [[self alloc] initWithOptions:options];
 }

--- a/Sources/KSCrashFilters/KSCrashReportFilterSets.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterSets.m
@@ -39,8 +39,8 @@
     id<KSCrashReportFilter> appleFilter = [KSCrashReportFilterAppleFmt filterWithReportStyle:reportStyle];
     id<KSCrashReportFilter> userSystemFilter = [KSCrashReportFilterPipeline filterWithFilters:
                                                 [KSCrashReportFilterSubset filterWithKeys:
-                                                 @KSCrashField_System,
-                                                 @KSCrashField_User,
+                                                 KSCrashField_System,
+                                                 KSCrashField_User,
                                                  nil],
                                                 [KSCrashReportFilterJSONEncode filterWithOptions:KSJSONEncodeOptionPretty | KSJSONEncodeOptionSorted],
                                                 [KSCrashReportFilterDataToString filter],

--- a/Sources/KSCrashFilters/KSCrashReportFilterStringify.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterStringify.m
@@ -27,7 +27,7 @@
 
 @implementation KSCrashReportFilterStringify
 
-+ (KSCrashReportFilterStringify*) filter
++ (instancetype) filter
 {
     return [[self alloc] init];
 }

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterAlert.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterAlert.h
@@ -28,6 +28,7 @@
 #import <Foundation/Foundation.h>
 #import "KSCrashReportFilter.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 /** Pops up a standard alert window and awaits a user response before continuing.
  *
@@ -39,6 +40,7 @@
  * Input: Any
  * Output: Same as input (passthrough)
  */
+NS_SWIFT_NAME(CrashReportFilterAlert)
 @interface KSCrashReportFilterAlert : NSObject <KSCrashReportFilter>
 
 /**
@@ -49,9 +51,9 @@
  *                 proceed unconditionally.
  */
 + (KSCrashReportFilterAlert*) filterWithTitle:(NSString*) title
-                                      message:(NSString*) message
+                                      message:(nullable NSString*) message
                                     yesAnswer:(NSString*) yesAnswer
-                                     noAnswer:(NSString*) noAnswer;
+                                     noAnswer:(nullable NSString*) noAnswer;
 
 /**
  * @param title The title of the alert.
@@ -60,9 +62,11 @@
  * @param noAnswer The text to put in the "no" button. If nil, the filter will
  *                 proceed unconditionally.
  */
-- (id) initWithTitle:(NSString*) title
-             message:(NSString*) message
-           yesAnswer:(NSString*) yesAnswer
-            noAnswer:(NSString*) noAnswer;
+- (instancetype) initWithTitle:(NSString*) title
+                       message:(nullable NSString*) message
+                     yesAnswer:(NSString*) yesAnswer
+                      noAnswer:(nullable NSString*) noAnswer;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterAlert.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterAlert.h
@@ -50,10 +50,10 @@ NS_SWIFT_NAME(CrashReportFilterAlert)
  * @param noAnswer The text to put in the "no" button. If nil, the filter will
  *                 proceed unconditionally.
  */
-+ (KSCrashReportFilterAlert*) filterWithTitle:(NSString*) title
-                                      message:(nullable NSString*) message
-                                    yesAnswer:(NSString*) yesAnswer
-                                     noAnswer:(nullable NSString*) noAnswer;
++ (instancetype) filterWithTitle:(NSString*) title
+                         message:(nullable NSString*) message
+                       yesAnswer:(NSString*) yesAnswer
+                        noAnswer:(nullable NSString*) noAnswer;
 
 /**
  * @param title The title of the alert.

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterAppleFmt.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterAppleFmt.h
@@ -110,7 +110,7 @@ typedef NS_ENUM(NSInteger, KSAppleReportStyle)
 NS_SWIFT_NAME(CrashReportFilterAppleFmt)
 @interface KSCrashReportFilterAppleFmt : NSObject <KSCrashReportFilter>
 
-+ (KSCrashReportFilterAppleFmt*) filterWithReportStyle:(KSAppleReportStyle) reportStyle;
++ (instancetype) filterWithReportStyle:(KSAppleReportStyle) reportStyle;
 
 - (instancetype) initWithReportStyle:(KSAppleReportStyle) reportStyle;
 

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterAppleFmt.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterAppleFmt.h
@@ -27,6 +27,9 @@
 
 #import "KSCrashReportFilter.h"
 
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
 
 /** Affects how an Apple-style crash report is generated.
  *
@@ -79,7 +82,7 @@
  * If you DO care about line numbers, have the dsym file handy, and will be
  * symbolicating offline, use KSAppleReportStyleSymbolicatedSideBySide.
  */
-typedef enum
+typedef NS_ENUM(NSInteger, KSAppleReportStyle)
 {
     /** Leave all stack trace entries unsymbolicated. */
     KSAppleReportStyleUnsymbolicated,
@@ -95,8 +98,8 @@ typedef enum
     KSAppleReportStyleSymbolicatedSideBySide,
 
     /** Symbolicate everything. */
-    KSAppleReportStyleSymbolicated,
-} KSAppleReportStyle;
+    KSAppleReportStyleSymbolicated
+} NS_SWIFT_NAME(AppleReportStyle);
 
 
 /** Converts to Apple format.
@@ -104,12 +107,17 @@ typedef enum
  * Input: NSDictionary
  * Output: NSString
  */
+NS_SWIFT_NAME(CrashReportFilterAppleFmt)
 @interface KSCrashReportFilterAppleFmt : NSObject <KSCrashReportFilter>
 
 + (KSCrashReportFilterAppleFmt*) filterWithReportStyle:(KSAppleReportStyle) reportStyle;
 
-- (id) initWithReportStyle:(KSAppleReportStyle) reportStyle;
+- (instancetype) initWithReportStyle:(KSAppleReportStyle) reportStyle;
 
-- (NSString*)headerStringForSystemInfo:(NSDictionary*)system reportID:(NSString*)reportID crashTime:(NSDate*)crashTime;
+- (NSString*)headerStringForSystemInfo:(NSDictionary<NSString*, id>*)system
+                              reportID:(nullable NSString*)reportID
+                             crashTime:(nullable NSDate*)crashTime;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(CrashReportFilterPassthrough)
 @interface KSCrashReportFilterPassthrough : NSObject <KSCrashReportFilter>
 
-+ (KSCrashReportFilterPassthrough*) filter;
++ (instancetype) filter;
 
 @end
 
@@ -61,7 +61,7 @@ NS_SWIFT_NAME(CrashReportFilterCombine)
  *                    Each "filter" can be id<KSCrashReportFilter> or an NSArray
  *                    of filters (which gets wrapped in a pipeline filter).
  */
-+ (KSCrashReportFilterCombine*) filterWithFiltersAndKeys:(nullable id) firstFilter, ... NS_REQUIRES_NIL_TERMINATION;
++ (instancetype) filterWithFiltersAndKeys:(nullable id) firstFilter, ... NS_REQUIRES_NIL_TERMINATION;
 
 /** Constructor.
  *
@@ -72,7 +72,7 @@ NS_SWIFT_NAME(CrashReportFilterCombine)
  *                used to store the output of its respective filter in the final
  *                report dictionary.
  */
-+ (KSCrashReportFilterCombine*) filterWithFilters:(NSArray*) filters keys:(NSArray<NSString*>*) keys;
++ (instancetype) filterWithFilters:(NSArray*) filters keys:(NSArray<NSString*>*) keys;
 
 /** Initializer.
  *
@@ -106,7 +106,7 @@ NS_SWIFT_NAME(CrashReportFilterPipeline)
 @interface KSCrashReportFilterPipeline : NSObject <KSCrashReportFilter>
 
 /** The filters in this pipeline. */
-@property(nonatomic,readonly,retain) NSArray<id<KSCrashReportFilter>>* filters;
+@property(nonatomic,readonly,copy) NSArray<id<KSCrashReportFilter>>* filters;
 
 /** Constructor.
  *
@@ -114,7 +114,7 @@ NS_SWIFT_NAME(CrashReportFilterPipeline)
  *                    Each "filter" can be an id<KSCrashReportFilter> or an NSArray
  *                    containing filters or locations of filters (which get wrapped in a pipeline filter).
  */
-+ (KSCrashReportFilterPipeline*) filterWithFilters:(nullable id) firstFilter, ... NS_REQUIRES_NIL_TERMINATION;
++ (instancetype) filterWithFilters:(nullable id) firstFilter, ... NS_REQUIRES_NIL_TERMINATION;
 
 /** Constructor using an array of filters.
  *
@@ -122,7 +122,7 @@ NS_SWIFT_NAME(CrashReportFilterPipeline)
  *                the KSCrashReportFilter protocol or a location of filters.
  *                Arrays of filters will be wrapped in a pipeline filter.
  */
-+ (KSCrashReportFilterPipeline*) filterWithFiltersArray:(NSArray*) filters;
++ (instancetype) filterWithFiltersArray:(NSArray*) filters;
 
 /** Initializer.
  *
@@ -164,8 +164,7 @@ NS_SWIFT_NAME(CrashReportFilterObjectForKey)
  * @param allowNotFound If NO, filtering will stop with an error if the key
  *                      was not found in a report.
  */
-+ (KSCrashReportFilterObjectForKey*) filterWithKey:(id) key
-                                     allowNotFound:(BOOL) allowNotFound;
++ (instancetype) filterWithKey:(id) key allowNotFound:(BOOL) allowNotFound;
 
 /** Initializer.
  *
@@ -174,8 +173,7 @@ NS_SWIFT_NAME(CrashReportFilterObjectForKey)
  * @param allowNotFound If NO, filtering will stop with an error if the key
  *                      was not found in a report.
  */
-- (instancetype) initWithKey:(id) key
-               allowNotFound:(BOOL) allowNotFound;
+- (instancetype) initWithKey:(id) key allowNotFound:(BOOL) allowNotFound;
 
 @end
 
@@ -195,8 +193,8 @@ NS_SWIFT_NAME(CrashReportFilterConcatenate)
  *                     %@ in the formatting text to include the key name as well.
  * @param firstKey Series of keys to extract from the source report.
  */
-+ (KSCrashReportFilterConcatenate*) filterWithSeparatorFmt:(NSString*) separatorFmt
-                                                      keys:(id) firstKey, ... NS_REQUIRES_NIL_TERMINATION;
++ (instancetype) filterWithSeparatorFmt:(NSString*) separatorFmt
+                                   keys:(id) firstKey, ... NS_REQUIRES_NIL_TERMINATION;
 
 /** Constructor using an array of keys.
  *
@@ -205,8 +203,8 @@ NS_SWIFT_NAME(CrashReportFilterConcatenate)
  * @param keys         An array of keys whose corresponding values will be concatenated
  *                     from the source report.
  */
-+ (KSCrashReportFilterConcatenate*) filterWithSeparatorFmt:(NSString*) separatorFmt
-                                                 keysArray:(NSArray<NSString*>*) keys;
++ (instancetype) filterWithSeparatorFmt:(NSString*) separatorFmt
+                              keysArray:(NSArray<NSString*>*) keys;
 
 /** Initializer.
  *
@@ -243,14 +241,14 @@ NS_SWIFT_NAME(CrashReportFilterSubset)
  *
  * @param firstKeyPath Series of key paths to search in the source reports.
  */
-+ (KSCrashReportFilterSubset*) filterWithKeys:(id) firstKeyPath, ... NS_REQUIRES_NIL_TERMINATION;
++ (instancetype) filterWithKeys:(id) firstKeyPath, ... NS_REQUIRES_NIL_TERMINATION;
 
 /** Constructor using an array of key paths.
  *
  * @param keyPaths An array of key paths to search for in the source reports.
  *                 Each key path will extract a subset of data from the reports.
  */
-+ (KSCrashReportFilterSubset*) filterWithKeysArray:(NSArray<NSString*>*) keyPaths;
++ (instancetype) filterWithKeysArray:(NSArray<NSString*>*) keyPaths;
 
 /** Initializer.
  *
@@ -277,7 +275,7 @@ NS_SWIFT_NAME(CrashReportFilterSubset)
 NS_SWIFT_NAME(CrashReportFilterDataToString)
 @interface KSCrashReportFilterDataToString : NSObject <KSCrashReportFilter>
 
-+ (KSCrashReportFilterDataToString*) filter;
++ (instancetype) filter;
 
 @end
 
@@ -291,7 +289,7 @@ NS_SWIFT_NAME(CrashReportFilterDataToString)
 NS_SWIFT_NAME(CrashReportFilterStringToData)
 @interface KSCrashReportFilterStringToData : NSObject <KSCrashReportFilter>
 
-+ (KSCrashReportFilterStringToData*) filter;
++ (instancetype) filter;
 
 @end
 

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterGZip.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterGZip.h
@@ -27,21 +27,58 @@
 
 #import "KSCrashReportFilter.h"
 
+#import <Foundation/Foundation.h>
 
-/** Gzip compresses reports.
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * An enumeration defining the levels of Gzip compression for crash reports.
+ *
+ * Compression levels range from 0 to 9, where:
+ * - 0: No compression.
+ * - 9: Best compression.
+ * - -1: Default compression level.
+ *
+ * You can initialize this with any integer value between 0 and 9.
+ */
+typedef NSInteger KSCrashReportCompressionLevel NS_TYPED_EXTENSIBLE_ENUM NS_SWIFT_NAME(CrashReportCompressionLevel);
+/** No compression level. */
+static KSCrashReportCompressionLevel const KSCrashReportCompressionLevelNone = 0;
+/** Best compression level. */
+static KSCrashReportCompressionLevel const KSCrashReportCompressionLevelBest = 9;
+/** Default compression level. */
+static KSCrashReportCompressionLevel const KSCrashReportCompressionLevelDefault = -1;
+
+/**
+ * Gzip compresses reports.
  *
  * Input: NSData
  * Output: NSData
  */
+NS_SWIFT_NAME(CrashReportFilterGZipCompress)
 @interface KSCrashReportFilterGZipCompress : NSObject <KSCrashReportFilter>
 
 /** Constructor.
  *
- * @param compressionLevel 0 = none, 9 = best, -1 = default
+ * @param compressionLevel Compression level for Gzip compression. It can be
+ *                         one of the following `KSCrashReportCompressionLevel` values:
+ *                         - `KSCrashReportCompressionLevelNone` (0): No compression.
+ *                         - `KSCrashReportCompressionLevelBest` (9): Best compression.
+ *                         - `KSCrashReportCompressionLevelDefault` (-1): Default compression level.
+ *                         The compression level can be any integer value between 0 and 9.
  */
-+ (KSCrashReportFilterGZipCompress*) filterWithCompressionLevel:(int) compressionLevel;
++ (KSCrashReportFilterGZipCompress*) filterWithCompressionLevel:(KSCrashReportCompressionLevel) compressionLevel;
 
-- (id) initWithCompressionLevel:(int) compressionLevel;
+/** Initializer.
+ *
+ * @param compressionLevel Compression level for Gzip compression. It can be
+ *                         one of the following `KSCrashReportCompressionLevel` values:
+ *                         - `KSCrashReportCompressionLevelNone` (0): No compression.
+ *                         - `KSCrashReportCompressionLevelBest` (9): Best compression.
+ *                         - `KSCrashReportCompressionLevelDefault` (-1): Default compression level.
+ *                         The compression level can be any integer value between 0 and 9.
+ */
+- (instancetype) initWithCompressionLevel:(KSCrashReportCompressionLevel) compressionLevel;
 
 @end
 
@@ -50,8 +87,15 @@
  * Input: NSData
  * Output: NSData
  */
+NS_SWIFT_NAME(CrashReportFilterGZipDecompress)
 @interface KSCrashReportFilterGZipDecompress : NSObject <KSCrashReportFilter>
 
+/** Constructor.
+ *
+ * Creates an instance of the filter for Gzip decompression.
+ */
 + (KSCrashReportFilterGZipDecompress*) filter;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterGZip.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterGZip.h
@@ -67,7 +67,7 @@ NS_SWIFT_NAME(CrashReportFilterGZipCompress)
  *                         - `KSCrashReportCompressionLevelDefault` (-1): Default compression level.
  *                         The compression level can be any integer value between 0 and 9.
  */
-+ (KSCrashReportFilterGZipCompress*) filterWithCompressionLevel:(KSCrashReportCompressionLevel) compressionLevel;
++ (instancetype) filterWithCompressionLevel:(KSCrashReportCompressionLevel) compressionLevel;
 
 /** Initializer.
  *
@@ -94,7 +94,7 @@ NS_SWIFT_NAME(CrashReportFilterGZipDecompress)
  *
  * Creates an instance of the filter for Gzip decompression.
  */
-+ (KSCrashReportFilterGZipDecompress*) filter;
++ (instancetype) filter;
 
 @end
 

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterJSON.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterJSON.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(CrashReportFilterJSONEncode)
 @interface KSCrashReportFilterJSONEncode : NSObject <KSCrashReportFilter>
 
-+ (KSCrashReportFilterJSONEncode*) filterWithOptions:(KSJSONEncodeOption) options;
++ (instancetype) filterWithOptions:(KSJSONEncodeOption) options;
 
 - (instancetype) initWithOptions:(KSJSONEncodeOption) options;
 
@@ -55,7 +55,7 @@ NS_SWIFT_NAME(CrashReportFilterJSONEncode)
 NS_SWIFT_NAME(CrashReportFilterJSONDecode)
 @interface KSCrashReportFilterJSONDecode : NSObject <KSCrashReportFilter>
 
-+ (KSCrashReportFilterJSONDecode*) filterWithOptions:(KSJSONDecodeOption) options;
++ (instancetype) filterWithOptions:(KSJSONDecodeOption) options;
 
 - (instancetype) initWithOptions:(KSJSONDecodeOption) options;
 

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterJSON.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterJSON.h
@@ -28,17 +28,21 @@
 #import "KSCrashReportFilter.h"
 #import "KSJSONCodecObjC.h"
 
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
 
 /** Converts reports from dict to JSON.
  *
  * Input: NSDictionary
  * Output: NSData
  */
+NS_SWIFT_NAME(CrashReportFilterJSONEncode)
 @interface KSCrashReportFilterJSONEncode : NSObject <KSCrashReportFilter>
 
 + (KSCrashReportFilterJSONEncode*) filterWithOptions:(KSJSONEncodeOption) options;
 
-- (id) initWithOptions:(KSJSONEncodeOption) options;
+- (instancetype) initWithOptions:(KSJSONEncodeOption) options;
 
 @end
 
@@ -48,10 +52,13 @@
  * Input: NSData
  * Output: NSDictionary
  */
+NS_SWIFT_NAME(CrashReportFilterJSONDecode)
 @interface KSCrashReportFilterJSONDecode : NSObject <KSCrashReportFilter>
 
 + (KSCrashReportFilterJSONDecode*) filterWithOptions:(KSJSONDecodeOption) options;
 
-- (id) initWithOptions:(KSJSONDecodeOption) options;
+- (instancetype) initWithOptions:(KSJSONDecodeOption) options;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterSets.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterSets.h
@@ -28,10 +28,14 @@
 #import "KSCrashReportFilter.h"
 #import "KSCrashReportFilterAppleFmt.h"
 
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Common filter sets.
  */
+NS_SWIFT_NAME(CrashFilterSets)
 @interface KSCrashFilterSets : NSObject
 
 /** Create an Apple format filter that includes system and user data in JSON format.
@@ -40,3 +44,5 @@
                                                compressed:(BOOL) compressed;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterStringify.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterStringify.h
@@ -25,10 +25,17 @@
 
 #import "KSCrashReportFilter.h"
 
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
 /** Converts objects into strings.
  */
+NS_SWIFT_NAME(CrashReportFilterStringify)
 @interface KSCrashReportFilterStringify : NSObject <KSCrashReportFilter>
 
 + (KSCrashReportFilterStringify*) filter;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterStringify.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterStringify.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(CrashReportFilterStringify)
 @interface KSCrashReportFilterStringify : NSObject <KSCrashReportFilter>
 
-+ (KSCrashReportFilterStringify*) filter;
++ (instancetype) filter;
 
 @end
 

--- a/Sources/KSCrashInstallations/KSCrashInstallationQuincyHockey.m
+++ b/Sources/KSCrashInstallations/KSCrashInstallationQuincyHockey.m
@@ -37,7 +37,7 @@
 #define kQuincyDefaultKeyUserName @"user_name"
 #define kQuincyDefaultKeyContactEmail @"contact_email"
 #define kQuincyDefaultKeyDescription @"crash_description"
-#define kQuincyDefaultKeysExtraDescription [NSArray arrayWithObjects:@"/" @KSCrashField_System, @"/" @KSCrashField_User, nil]
+#define kQuincyDefaultKeysExtraDescription [NSArray arrayWithObjects:@"/", KSCrashField_System, @"/", KSCrashField_User, nil]
 
 
 @implementation KSCrashInstallationBaseQuincyHockey

--- a/Sources/KSCrashInstallations/include/KSCrashInstallation+Alert.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallation+Alert.h
@@ -24,6 +24,10 @@
 
 #import "KSCrashInstallation.h"
 
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
 @interface KSCrashInstallation (Alert)
 
 /** Show an alert before sending any reports. Reports will only be sent if the user
@@ -35,9 +39,9 @@
  * @param noAnswer The text to display in the "no" box.
  */
 - (void) addConditionalAlertWithTitle:(NSString*) title
-                              message:(NSString*) message
+                              message:(nullable NSString*) message
                             yesAnswer:(NSString*) yesAnswer
-                             noAnswer:(NSString*) noAnswer;
+                             noAnswer:(nullable NSString*) noAnswer;
 
 /** Show an alert before sending any reports. Reports will be unconditionally sent
  * when the alert is dismissed.
@@ -47,7 +51,9 @@
  * @param dismissButtonText The text to display in the dismiss button.
  */
 - (void) addUnconditionalAlertWithTitle:(NSString*) title
-                                message:(NSString*) message
+                                message:(nullable NSString*) message
                       dismissButtonText:(NSString*) dismissButtonText;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashInstallations/include/KSCrashInstallation.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallation.h
@@ -29,6 +29,8 @@
 #import "KSCrashReportFilter.h"
 #import "KSCrashReportWriter.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class KSCrashConfiguration;
 
 /**
@@ -38,15 +40,16 @@
  *
  * This is an abstract class.
  */
+NS_SWIFT_NAME(Installation)
 @interface KSCrashInstallation : NSObject
 
 /** C Function to call during a crash report to give the callee an opportunity to
  * add to the report. NULL = ignore.
  *
  * WARNING: Only call async-safe functions from this function! DO NOT call
- * Objective-C methods!!!
+ * Swift/Objective-C methods!!!
  */
-@property(atomic,readwrite,assign) KSReportWriteCallback onCrash;
+@property(atomic,readwrite,assign,nullable) KSReportWriteCallback onCrash;
 
 /** Install this crash handler with a specific configuration.
  * Call this method instead of `-[KSCrash installWithConfiguration:]` to set up the crash handler
@@ -68,7 +71,7 @@
  *
  * @param onCompletion Called when sending is complete (nil = ignore).
  */
-- (void) sendAllReportsWithCompletion:(KSCrashReportFilterCompletion) onCompletion;
+- (void) sendAllReportsWithCompletion:(nullable KSCrashReportFilterCompletion) onCompletion;
 
 /** Add a filter that gets executed before all normal filters.
  * Prepended filters will be executed in the order in which they were added.
@@ -78,3 +81,5 @@
 - (void) addPreFilter:(id<KSCrashReportFilter>) filter;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashInstallations/include/KSCrashInstallation.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallation.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * This is an abstract class.
  */
-NS_SWIFT_NAME(Installation)
+NS_SWIFT_NAME(CrashInstallation)
 @interface KSCrashInstallation : NSObject
 
 /** C Function to call during a crash report to give the callee an opportunity to

--- a/Sources/KSCrashInstallations/include/KSCrashInstallation.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallation.h
@@ -62,7 +62,7 @@ NS_SWIFT_NAME(Installation)
  *       when using this method. The callback will be internally managed to ensure proper integration
  *       with the backend.
  */
-- (void) installWithConfiguration:(KSCrashConfiguration*) configuration;
+- (void) installWithConfiguration:(nullable KSCrashConfiguration*) configuration;
 
 /** Convenience method to call -[KSCrash sendAllReportsWithCompletion:].
  * This method will set the KSCrash sink and then send all outstanding reports.

--- a/Sources/KSCrashInstallations/include/KSCrashInstallationConsole.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallationConsole.h
@@ -25,13 +25,20 @@
 
 #import "KSCrashInstallation.h"
 
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
 /** Prints all reports to the console.
  * This class is intended for testing purposes.
  */
+NS_SWIFT_NAME(InstallationConsole)
 @interface KSCrashInstallationConsole : KSCrashInstallation
 
 @property(nonatomic,readwrite) BOOL printAppleFormat;
 
-+ (instancetype) sharedInstance;
++ (instancetype) sharedInstance NS_SWIFT_NAME(shared());
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashInstallations/include/KSCrashInstallationConsole.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallationConsole.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** Prints all reports to the console.
  * This class is intended for testing purposes.
  */
-NS_SWIFT_NAME(InstallationConsole)
+NS_SWIFT_NAME(CrashInstallationConsole)
 @interface KSCrashInstallationConsole : KSCrashInstallation
 
 @property(nonatomic,readwrite) BOOL printAppleFormat;

--- a/Sources/KSCrashInstallations/include/KSCrashInstallationEmail.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallationEmail.h
@@ -39,7 +39,7 @@ typedef NS_ENUM(NSUInteger, KSCrashEmailReportStyle) {
  * Email installation.
  * Sends reports via email.
  */
-NS_SWIFT_NAME(InstallationEmail)
+NS_SWIFT_NAME(CrashInstallationEmail)
 @interface KSCrashInstallationEmail : KSCrashInstallation
 
 /** List of email addresses to send to (mandatory) */

--- a/Sources/KSCrashInstallations/include/KSCrashInstallationEmail.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallationEmail.h
@@ -24,23 +24,26 @@
 // THE SOFTWARE.
 //
 
-
 #import "KSCrashInstallation.h"
 
-typedef enum
-{
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSUInteger, KSCrashEmailReportStyle) {
     KSCrashEmailReportStyleJSON,
     KSCrashEmailReportStyleApple,
-} KSCrashEmailReportStyle;
+} NS_SWIFT_NAME(EmailReportStyle);
 
 /**
  * Email installation.
  * Sends reports via email.
  */
+NS_SWIFT_NAME(InstallationEmail)
 @interface KSCrashInstallationEmail : KSCrashInstallation
 
 /** List of email addresses to send to (mandatory) */
-@property(nonatomic,readwrite,retain) NSArray* recipients;
+@property(nonatomic,readwrite,retain) NSArray<NSString *> *recipients;
 
 /** Email subject (mandatory).
  *
@@ -52,7 +55,7 @@ typedef enum
  *
  * Default: nil
  */
-@property(nonatomic,readwrite,retain) NSString* message;
+@property(nonatomic,readwrite,retain,nullable) NSString* message;
 
 /** How to name the attachments (mandatory)
  *
@@ -76,6 +79,8 @@ typedef enum
 - (void) setReportStyle:(KSCrashEmailReportStyle)reportStyle
 useDefaultFilenameFormat:(BOOL) useDefaultFilenameFormat;
 
-+ (instancetype) sharedInstance;
++ (instancetype) sharedInstance NS_SWIFT_NAME(shared());
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashInstallations/include/KSCrashInstallationEmail.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallationEmail.h
@@ -43,19 +43,19 @@ NS_SWIFT_NAME(InstallationEmail)
 @interface KSCrashInstallationEmail : KSCrashInstallation
 
 /** List of email addresses to send to (mandatory) */
-@property(nonatomic,readwrite,retain) NSArray<NSString *> *recipients;
+@property(nonatomic,readwrite,copy) NSArray<NSString *> *recipients;
 
 /** Email subject (mandatory).
  *
  * Default: "Crash Report (YourBundleID)"
  */
-@property(nonatomic,readwrite,retain) NSString* subject;
+@property(nonatomic,readwrite,copy) NSString* subject;
 
 /** Message to accompany the reports (optional).
  *
  * Default: nil
  */
-@property(nonatomic,readwrite,retain,nullable) NSString* message;
+@property(nonatomic,readwrite,copy,nullable) NSString* message;
 
 /** How to name the attachments (mandatory)
  *
@@ -65,7 +65,7 @@ NS_SWIFT_NAME(InstallationEmail)
  *
  * Default: "crash-report-YourBundleID-%d.txt.gz"
  */
-@property(nonatomic,readwrite,retain) NSString* filenameFmt;
+@property(nonatomic,readwrite,copy) NSString* filenameFmt;
 
 /** Which report style to use.
  */

--- a/Sources/KSCrashInstallations/include/KSCrashInstallationQuincyHockey.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallationQuincyHockey.h
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * This is an abstract class.
  */
-NS_SWIFT_NAME(InstallationBaseQuincyHockey)
+NS_SWIFT_NAME(CrashInstallationBaseQuincyHockey)
 @interface KSCrashInstallationBaseQuincyHockey : KSCrashInstallation
 
 // ======================================================================
@@ -108,7 +108,7 @@ NS_SWIFT_NAME(InstallationBaseQuincyHockey)
 /**
  * Quincy installation.
  */
-NS_SWIFT_NAME(InstallationQuincy)
+NS_SWIFT_NAME(CrashInstallationQuincy)
 @interface KSCrashInstallationQuincy : KSCrashInstallationBaseQuincyHockey
 
 /** URL to send reports to (mandatory) */
@@ -122,7 +122,7 @@ NS_SWIFT_NAME(InstallationQuincy)
 /**
  * Hockey installation.
  */
-NS_SWIFT_NAME(InstallationHockey)
+NS_SWIFT_NAME(CrashInstallationHockey)
 @interface KSCrashInstallationHockey: KSCrashInstallationBaseQuincyHockey
 
 /** App identifier you received from Hockey (mandatory) */

--- a/Sources/KSCrashInstallations/include/KSCrashInstallationQuincyHockey.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallationQuincyHockey.h
@@ -29,6 +29,7 @@
 #import "KSCrashInstallation.h"
 #import "KSCrashReportWriter.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Common properties to both Quincy and Hockey.
@@ -62,6 +63,7 @@
  *
  * This is an abstract class.
  */
+NS_SWIFT_NAME(InstallationBaseQuincyHockey)
 @interface KSCrashInstallationBaseQuincyHockey : KSCrashInstallation
 
 // ======================================================================
@@ -70,10 +72,10 @@
 
 // The values of these properties will be written to the next crash report.
 
-@property(nonatomic,readwrite,retain) NSString* userID;
-@property(nonatomic,readwrite,retain) NSString* userName;
-@property(nonatomic,readwrite,retain) NSString* contactEmail;
-@property(nonatomic,readwrite,retain) NSString* crashDescription;
+@property(nonatomic,readwrite,copy,nullable) NSString* userID;
+@property(nonatomic,readwrite,copy,nullable) NSString* userName;
+@property(nonatomic,readwrite,copy,nullable) NSString* contactEmail;
+@property(nonatomic,readwrite,copy,nullable) NSString* crashDescription;
 
 
 // ======================================================================
@@ -83,15 +85,15 @@
 // The above properties will be written to the user section report using the
 // following keys.
 
-@property(nonatomic,readwrite,retain) NSString* userIDKey;
-@property(nonatomic,readwrite,retain) NSString* userNameKey;
-@property(nonatomic,readwrite,retain) NSString* contactEmailKey;
-@property(nonatomic,readwrite,retain) NSString* crashDescriptionKey;
+@property(nonatomic,readwrite,copy) NSString* userIDKey;
+@property(nonatomic,readwrite,copy) NSString* userNameKey;
+@property(nonatomic,readwrite,copy) NSString* contactEmailKey;
+@property(nonatomic,readwrite,copy) NSString* crashDescriptionKey;
 
 /** Data stored under these keys will be appended to the description
  * (in JSON format) before sending to Quincy/Hockey.
  */
-@property(nonatomic,readwrite,retain) NSArray* extraDescriptionKeys;
+@property(nonatomic,readwrite,copy) NSArray<NSString *>* extraDescriptionKeys;
 
 /** If YES, wait until the host becomes reachable before trying to send.
  * If NO, it will attempt to send right away, and either succeed or fail.
@@ -106,12 +108,13 @@
 /**
  * Quincy installation.
  */
+NS_SWIFT_NAME(InstallationQuincy)
 @interface KSCrashInstallationQuincy : KSCrashInstallationBaseQuincyHockey
 
 /** URL to send reports to (mandatory) */
-@property(nonatomic, readwrite, retain) NSURL* url;
+@property(nonatomic, readwrite, strong) NSURL* url;
 
-+ (KSCrashInstallationQuincy*) sharedInstance;
++ (instancetype) sharedInstance NS_SWIFT_NAME(shared());
 
 @end
 
@@ -119,11 +122,14 @@
 /**
  * Hockey installation.
  */
+NS_SWIFT_NAME(InstallationHockey)
 @interface KSCrashInstallationHockey: KSCrashInstallationBaseQuincyHockey
 
 /** App identifier you received from Hockey (mandatory) */
-@property(nonatomic, readwrite, retain) NSString* appIdentifier;
+@property(nonatomic, readwrite, copy) NSString* appIdentifier;
 
-+ (instancetype) sharedInstance;
++ (instancetype) sharedInstance NS_SWIFT_NAME(shared());
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashInstallations/include/KSCrashInstallationQuincyHockey.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallationQuincyHockey.h
@@ -85,10 +85,10 @@ NS_SWIFT_NAME(InstallationBaseQuincyHockey)
 // The above properties will be written to the user section report using the
 // following keys.
 
-@property(nonatomic,readwrite,copy) NSString* userIDKey;
-@property(nonatomic,readwrite,copy) NSString* userNameKey;
-@property(nonatomic,readwrite,copy) NSString* contactEmailKey;
-@property(nonatomic,readwrite,copy) NSString* crashDescriptionKey;
+@property(nonatomic,readwrite,copy,nullable) NSString* userIDKey;
+@property(nonatomic,readwrite,copy,nullable) NSString* userNameKey;
+@property(nonatomic,readwrite,copy,nullable) NSString* contactEmailKey;
+@property(nonatomic,readwrite,copy,nullable) NSString* crashDescriptionKey;
 
 /** Data stored under these keys will be appended to the description
  * (in JSON format) before sending to Quincy/Hockey.

--- a/Sources/KSCrashInstallations/include/KSCrashInstallationStandard.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallationStandard.h
@@ -31,7 +31,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NS_SWIFT_NAME(InstallationStandard)
+NS_SWIFT_NAME(CrashInstallationStandard)
 @interface KSCrashInstallationStandard : KSCrashInstallation
 
 /** The URL to connect to. */

--- a/Sources/KSCrashInstallations/include/KSCrashInstallationStandard.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallationStandard.h
@@ -27,12 +27,18 @@
 
 #import "KSCrashInstallation.h"
 
+#import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(InstallationStandard)
 @interface KSCrashInstallationStandard : KSCrashInstallation
 
 /** The URL to connect to. */
-@property(nonatomic,readwrite,retain) NSURL* url;
+@property(nonatomic,readwrite,strong) NSURL* url;
 
-+ (instancetype) sharedInstance;
++ (instancetype) sharedInstance NS_SWIFT_NAME(shared());
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashInstallations/include/KSCrashInstallationVictory.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallationVictory.h
@@ -45,7 +45,7 @@ NS_SWIFT_NAME(InstallationVictory)
 /** The URL to connect to. */
 @property(nonatomic,readwrite,strong) NSURL* url;
 /** The user name of crash information *required*. If value is nil it will be replaced with UIDevice.currentDevice.name */
-@property(nonatomic,readwrite,copy) NSString* userName;
+@property(nonatomic,readwrite,copy,nullable) NSString* userName;
 /** The user email of crash information *optional* */
 @property(nonatomic,readwrite,copy,nullable) NSString* userEmail;
 

--- a/Sources/KSCrashInstallations/include/KSCrashInstallationVictory.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallationVictory.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  Your app could send error information to Victory with RESTful API.
  This is a demo site: https://victory-demo.appspot.com/
  */
-NS_SWIFT_NAME(InstallationVictory)
+NS_SWIFT_NAME(CrashInstallationVictory)
 @interface KSCrashInstallationVictory : KSCrashInstallation
 
 /** The URL to connect to. */

--- a/Sources/KSCrashInstallations/include/KSCrashInstallationVictory.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallationVictory.h
@@ -27,6 +27,9 @@
 
 #import "KSCrashInstallation.h"
 
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  Victory is an error reporting server in Python. It runs on Google App Engine.
@@ -36,15 +39,18 @@
  Your app could send error information to Victory with RESTful API.
  This is a demo site: https://victory-demo.appspot.com/
  */
+NS_SWIFT_NAME(InstallationVictory)
 @interface KSCrashInstallationVictory : KSCrashInstallation
 
 /** The URL to connect to. */
-@property(nonatomic,readwrite,retain) NSURL* url;
-/** The user name of crash information *required. If value is nil it will be replaced with UIDevice.currentDevice.name */
-@property(nonatomic,readwrite,retain) NSString* userName;
-/** The user email of crash information *optional */
-@property(nonatomic,readwrite,retain) NSString* userEmail;
+@property(nonatomic,readwrite,strong) NSURL* url;
+/** The user name of crash information *required*. If value is nil it will be replaced with UIDevice.currentDevice.name */
+@property(nonatomic,readwrite,copy) NSString* userName;
+/** The user email of crash information *optional* */
+@property(nonatomic,readwrite,copy,nullable) NSString* userEmail;
 
-+ (instancetype) sharedInstance;
++ (instancetype) sharedInstance NS_SWIFT_NAME(shared());
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashRecording/KSCrash.m
+++ b/Sources/KSCrashRecording/KSCrash.m
@@ -246,7 +246,7 @@ static NSString* getBasePath(void)
     COPY_PRIMITIVE(freeMemory);
     COPY_PRIMITIVE(usableMemory);
 
-    return dict;
+    return [dict copy];
 }
 
 - (BOOL) installWithConfiguration:(KSCrashConfiguration*) configuration
@@ -285,9 +285,9 @@ static NSString* getBasePath(void)
     kscrash_deleteAllReports();
 }
 
-- (void) deleteReportWithID:(NSNumber*) reportID
+- (void) deleteReportWithID:(NSInteger) reportID
 {
-    kscrash_deleteReportWithID([reportID longLongValue]);
+    kscrash_deleteReportWithID(reportID);
 }
 
 - (void) reportUserException:(NSString*) name
@@ -398,7 +398,7 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     }
 }
 
-- (NSArray*)reportIDs
+- (NSArray<NSNumber*>*)reportIDs
 {
     int reportCount = kscrash_getReportCount();
     int64_t reportIDsC[reportCount];
@@ -408,15 +408,10 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     {
         [reportIDs addObject:[NSNumber numberWithLongLong:reportIDsC[i]]];
     }
-    return reportIDs;
+    return [reportIDs copy];
 }
 
-- (NSDictionary*) reportWithID:(NSNumber*) reportID
-{
-    return [self reportWithIntID:[reportID longLongValue]];
-}
-
-- (NSDictionary*) reportWithIntID:(int64_t) reportID
+- (NSDictionary*) reportWithID:(NSInteger) reportID
 {
     NSData* jsonData = [self loadCrashReportJSONWithID:reportID];
     if(jsonData == nil)
@@ -441,7 +436,7 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     }
     [self doctorReport:crashReport];
 
-    return crashReport;
+    return [crashReport copy];
 }
 
 - (NSArray*) allReports
@@ -452,7 +447,7 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     NSMutableArray* reports = [NSMutableArray arrayWithCapacity:(NSUInteger)reportCount];
     for(int i = 0; i < reportCount; i++)
     {
-        NSDictionary* report = [self reportWithIntID:reportIDs[i]];
+        NSDictionary* report = [self reportWithID:reportIDs[i]];
         if(report != nil)
         {
             [reports addObject:report];

--- a/Sources/KSCrashRecording/KSCrash.m
+++ b/Sources/KSCrashRecording/KSCrash.m
@@ -386,15 +386,15 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
 
 - (void) doctorReport:(NSMutableDictionary*) report
 {
-    NSMutableDictionary* crashReport = report[@KSCrashField_Crash];
+    NSMutableDictionary* crashReport = report[KSCrashField_Crash];
     if(crashReport != nil)
     {
-        crashReport[@KSCrashField_Diagnosis] = [[KSCrashDoctor doctor] diagnoseCrash:report];
+        crashReport[KSCrashField_Diagnosis] = [[KSCrashDoctor doctor] diagnoseCrash:report];
     }
-    crashReport = report[@KSCrashField_RecrashReport][@KSCrashField_Crash];
+    crashReport = report[KSCrashField_RecrashReport][KSCrashField_Crash];
     if(crashReport != nil)
     {
-        crashReport[@KSCrashField_Diagnosis] = [[KSCrashDoctor doctor] diagnoseCrash:report];
+        crashReport[KSCrashField_Diagnosis] = [[KSCrashDoctor doctor] diagnoseCrash:report];
     }
 }
 

--- a/Sources/KSCrashRecording/KSCrash.m
+++ b/Sources/KSCrashRecording/KSCrash.m
@@ -132,7 +132,7 @@ static NSString* getBasePath(void)
     return sharedInstance;
 }
 
-- (id) init
+- (instancetype) init
 {
     return [self initWithBasePath:getBasePath()];
 }

--- a/Sources/KSCrashRecording/KSCrash.m
+++ b/Sources/KSCrashRecording/KSCrash.m
@@ -411,7 +411,7 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     return [reportIDs copy];
 }
 
-- (NSDictionary*) reportWithID:(NSInteger) reportID
+- (NSDictionary*) reportForID:(NSInteger) reportID
 {
     NSData* jsonData = [self loadCrashReportJSONWithID:reportID];
     if(jsonData == nil)
@@ -447,7 +447,7 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     NSMutableArray* reports = [NSMutableArray arrayWithCapacity:(NSUInteger)reportCount];
     for(int i = 0; i < reportCount; i++)
     {
-        NSDictionary* report = [self reportWithID:reportIDs[i]];
+        NSDictionary* report = [self reportForID:reportIDs[i]];
         if(report != nil)
         {
             [reports addObject:report];

--- a/Sources/KSCrashRecording/KSCrash.m
+++ b/Sources/KSCrashRecording/KSCrash.m
@@ -285,7 +285,7 @@ static NSString* getBasePath(void)
     kscrash_deleteAllReports();
 }
 
-- (void) deleteReportWithID:(NSInteger) reportID
+- (void) deleteReportWithID:(int64_t) reportID
 {
     kscrash_deleteReportWithID(reportID);
 }
@@ -338,14 +338,14 @@ static NSString* getBasePath(void)
 
 SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, activeDurationSinceLastCrash)
 SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, backgroundDurationSinceLastCrash)
-SYNTHESIZE_CRASH_STATE_PROPERTY(int, launchesSinceLastCrash)
-SYNTHESIZE_CRASH_STATE_PROPERTY(int, sessionsSinceLastCrash)
+SYNTHESIZE_CRASH_STATE_PROPERTY(NSInteger, launchesSinceLastCrash)
+SYNTHESIZE_CRASH_STATE_PROPERTY(NSInteger, sessionsSinceLastCrash)
 SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, activeDurationSinceLaunch)
 SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, backgroundDurationSinceLaunch)
-SYNTHESIZE_CRASH_STATE_PROPERTY(int, sessionsSinceLaunch)
+SYNTHESIZE_CRASH_STATE_PROPERTY(NSInteger, sessionsSinceLaunch)
 SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
 
-- (int) reportCount
+- (NSInteger) reportCount
 {
     return kscrash_getReportCount();
 }
@@ -411,7 +411,7 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     return [reportIDs copy];
 }
 
-- (NSDictionary*) reportForID:(NSInteger) reportID
+- (NSDictionary*) reportForID:(int64_t) reportID
 {
     NSData* jsonData = [self loadCrashReportJSONWithID:reportID];
     if(jsonData == nil)

--- a/Sources/KSCrashRecording/KSCrashAppMemory.m
+++ b/Sources/KSCrashRecording/KSCrashAppMemory.m
@@ -63,24 +63,24 @@ const char *KSCrashAppMemoryStateToString(KSCrashAppMemoryState state) {
     assert(state <= KSCrashAppMemoryStateTerminal);
 }
 
-KSCrashAppMemoryState KSCrashAppMemoryStateFromString(NSString *const state) {
-    if ([state isEqualToString:@"normal"]) {
+KSCrashAppMemoryState KSCrashAppMemoryStateFromString(NSString *const string) {
+    if ([string isEqualToString:@"normal"]) {
         return KSCrashAppMemoryStateNormal;
     }
     
-    if ([state isEqualToString:@"warn"]) {
+    if ([string isEqualToString:@"warn"]) {
         return KSCrashAppMemoryStateWarn;
     }
     
-    if ([state isEqualToString:@"urgent"]) {
+    if ([string isEqualToString:@"urgent"]) {
         return KSCrashAppMemoryStateUrgent;
     }
     
-    if ([state isEqualToString:@"critical"]) {
+    if ([string isEqualToString:@"critical"]) {
         return KSCrashAppMemoryStateCritical;
     }
     
-    if ([state isEqualToString:@"terminal"]) {
+    if ([string isEqualToString:@"terminal"]) {
         return KSCrashAppMemoryStateTerminal;
     }
     

--- a/Sources/KSCrashRecording/KSCrashAppStateTracker.m
+++ b/Sources/KSCrashRecording/KSCrashAppStateTracker.m
@@ -34,7 +34,7 @@
 #import <UIKit/UIKit.h>
 #endif
 
-const char *ksapp_transition_state_to_string(KSCrashAppTransitionState state) {
+const char *ksapp_transitionStateToString(KSCrashAppTransitionState state) {
     switch (state) {
         case KSCrashAppTransitionStateStartup: return "startup";
         case KSCrashAppTransitionStateStartupPrewarm: return "prewarm";
@@ -49,7 +49,7 @@ const char *ksapp_transition_state_to_string(KSCrashAppTransitionState state) {
     return "unknown";
 }
 
-bool ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionState state)
+bool ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionState state)
 {
     switch (state) {
         case KSCrashAppTransitionStateStartupPrewarm:

--- a/Sources/KSCrashRecording/KSCrashAppStateTracker.m
+++ b/Sources/KSCrashRecording/KSCrashAppStateTracker.m
@@ -118,10 +118,10 @@ bool ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionState state)
 + (void)load
 {
     // to work well, we need this to run as early as possible.
-    (void)[KSCrashAppStateTracker shared];
+    (void)[KSCrashAppStateTracker sharedInstance];
 }
 
-+ (instancetype)shared
++ (instancetype)sharedInstance
 {
     static KSCrashAppStateTracker *sTracker;
     static dispatch_once_t onceToken;

--- a/Sources/KSCrashRecording/KSCrashDoctor.m
+++ b/Sources/KSCrashRecording/KSCrashDoctor.m
@@ -71,7 +71,7 @@ typedef enum
     }
 
     KSCrashDoctorParam* selectorParam = [self.params objectAtIndex:1];
-    if(![selectorParam.type isEqualToString:@KSCrashMemType_String])
+    if(![selectorParam.type isEqualToString:KSCrashMemType_String])
     {
         return nil;
     }
@@ -87,7 +87,7 @@ typedef enum
             KSCrashDoctorParam* param = [self.params objectAtIndex:(NSUInteger)paramNum + 2];
             if(param.value != nil)
             {
-                if([param.type isEqualToString:@KSCrashMemType_String])
+                if([param.type isEqualToString:KSCrashMemType_String])
                 {
                     [string appendFormat:@"\"%@\"", param.value];
                 }
@@ -174,33 +174,33 @@ typedef enum
 
 - (NSDictionary*) recrashReport:(NSDictionary*) report
 {
-    return [report objectForKey:@KSCrashField_RecrashReport];
+    return [report objectForKey:KSCrashField_RecrashReport];
 }
 
 - (NSDictionary*) systemReport:(NSDictionary*) report
 {
-    return [report objectForKey:@KSCrashField_System];
+    return [report objectForKey:KSCrashField_System];
 }
 
 - (NSDictionary*) crashReport:(NSDictionary*) report
 {
-    return [report objectForKey:@KSCrashField_Crash];
+    return [report objectForKey:KSCrashField_Crash];
 }
 
 - (NSDictionary*) infoReport:(NSDictionary*) report
 {
-    return [report objectForKey:@KSCrashField_Report];
+    return [report objectForKey:KSCrashField_Report];
 }
 
 - (NSDictionary*) errorReport:(NSDictionary*) report
 {
-    return [[self crashReport:report] objectForKey:@KSCrashField_Error];
+    return [[self crashReport:report] objectForKey:KSCrashField_Error];
 }
 
 - (CPUFamily) cpuFamily:(NSDictionary*) report
 {
     NSDictionary* system = [self systemReport:report];
-    NSString* cpuArch = [system objectForKey:@KSCrashField_CPUArch];
+    NSString* cpuArch = [system objectForKey:KSCrashField_CPUArch];
     if([cpuArch rangeOfString:@"arm"].location == 0)
     {
         return CPUFamilyArm;
@@ -270,21 +270,21 @@ typedef enum
 - (NSString*) mainExecutableNameForReport:(NSDictionary*) report
 {
     NSDictionary* info = [self infoReport:report];
-    return [info objectForKey:@KSCrashField_ProcessName];
+    return [info objectForKey:KSCrashField_ProcessName];
 }
 
 - (NSDictionary*) crashedThreadReport:(NSDictionary*) report
 {
     NSDictionary* crashReport = [self crashReport:report];
-    NSDictionary* crashedThread = [crashReport objectForKey:@KSCrashField_CrashedThread];
+    NSDictionary* crashedThread = [crashReport objectForKey:KSCrashField_CrashedThread];
     if(crashedThread != nil)
     {
         return crashedThread;
     }
 
-    for(NSDictionary* thread in [crashReport objectForKey:@KSCrashField_Threads])
+    for(NSDictionary* thread in [crashReport objectForKey:KSCrashField_Threads])
     {
-        if([[thread objectForKey:@KSCrashField_Crashed] boolValue])
+        if([[thread objectForKey:KSCrashField_Crashed] boolValue])
         {
             return thread;
         }
@@ -294,14 +294,14 @@ typedef enum
 
 - (NSArray*) backtraceFromThreadReport:(NSDictionary*) threadReport
 {
-    NSDictionary* backtrace = [threadReport objectForKey:@KSCrashField_Backtrace];
-    return [backtrace objectForKey:@KSCrashField_Contents];
+    NSDictionary* backtrace = [threadReport objectForKey:KSCrashField_Backtrace];
+    return [backtrace objectForKey:KSCrashField_Contents];
 }
 
 - (NSDictionary*) basicRegistersFromThreadReport:(NSDictionary*) threadReport
 {
-    NSDictionary* registers = [threadReport objectForKey:@KSCrashField_Registers];
-    NSDictionary* basic = [registers objectForKey:@KSCrashField_Basic];
+    NSDictionary* registers = [threadReport objectForKey:KSCrashField_Registers];
+    NSDictionary* basic = [registers objectForKey:KSCrashField_Basic];
     return basic;
 }
 
@@ -312,7 +312,7 @@ typedef enum
     NSArray* backtrace = [self backtraceFromThreadReport:crashedThread];
     for(NSDictionary* entry in backtrace)
     {
-        NSString* objectName = [entry objectForKey:@KSCrashField_ObjectName];
+        NSString* objectName = [entry objectForKey:KSCrashField_ObjectName];
         if([objectName isEqualToString:executableName])
         {
             return entry;
@@ -334,40 +334,40 @@ typedef enum
 
 - (BOOL) isInvalidAddress:(NSDictionary*) errorReport
 {
-    NSDictionary* machError = [errorReport objectForKey:@KSCrashField_Mach];
+    NSDictionary* machError = [errorReport objectForKey:KSCrashField_Mach];
     if(machError != nil)
     {
-        NSString* exceptionName = [machError objectForKey:@KSCrashField_ExceptionName];
+        NSString* exceptionName = [machError objectForKey:KSCrashField_ExceptionName];
         return [exceptionName isEqualToString:@"EXC_BAD_ACCESS"];
     }
-    NSDictionary* signal = [errorReport objectForKey:@KSCrashField_Signal];
-    NSString* sigName = [signal objectForKey:@KSCrashField_Name];
+    NSDictionary* signal = [errorReport objectForKey:KSCrashField_Signal];
+    NSString* sigName = [signal objectForKey:KSCrashField_Name];
     return [sigName isEqualToString:@"SIGSEGV"];
 }
 
 - (BOOL) isMathError:(NSDictionary*) errorReport
 {
-    NSDictionary* machError = [errorReport objectForKey:@KSCrashField_Mach];
+    NSDictionary* machError = [errorReport objectForKey:KSCrashField_Mach];
     if(machError != nil)
     {
-        NSString* exceptionName = [machError objectForKey:@KSCrashField_ExceptionName];
+        NSString* exceptionName = [machError objectForKey:KSCrashField_ExceptionName];
         return [exceptionName isEqualToString:@"EXC_ARITHMETIC"];
     }
-    NSDictionary* signal = [errorReport objectForKey:@KSCrashField_Signal];
-    NSString* sigName = [signal objectForKey:@KSCrashField_Name];
+    NSDictionary* signal = [errorReport objectForKey:KSCrashField_Signal];
+    NSString* sigName = [signal objectForKey:KSCrashField_Name];
     return [sigName isEqualToString:@"SIGFPE"];
 }
 
 - (BOOL) isMemoryCorruption:(NSDictionary*) report
 {
     NSDictionary* crashedThread = [self crashedThreadReport:report];
-    NSArray* notableAddresses = [crashedThread objectForKey:@KSCrashField_NotableAddresses];
+    NSArray* notableAddresses = [crashedThread objectForKey:KSCrashField_NotableAddresses];
     for(NSDictionary* address in [notableAddresses objectEnumerator])
     {
-        NSString* type = [address objectForKey:@KSCrashField_Type];
+        NSString* type = [address objectForKey:KSCrashField_Type];
         if([type isEqualToString:@"string"])
         {
-            NSString* value = [address objectForKey:@KSCrashField_Value];
+            NSString* value = [address objectForKey:KSCrashField_Value];
             if([value rangeOfString:@"autorelease pool page"].location != NSNotFound &&
                [value rangeOfString:@"corrupted"].location != NSNotFound)
             {
@@ -383,8 +383,8 @@ typedef enum
     NSArray* backtrace = [self backtraceFromThreadReport:crashedThread];
     for(NSDictionary* entry in backtrace)
     {
-        NSString* objectName = [entry objectForKey:@KSCrashField_ObjectName];
-        NSString* symbolName = [entry objectForKey:@KSCrashField_SymbolName];
+        NSString* objectName = [entry objectForKey:KSCrashField_ObjectName];
+        NSString* symbolName = [entry objectForKey:KSCrashField_SymbolName];
         if([symbolName isEqualToString:@"objc_autoreleasePoolPush"])
         {
             return YES;
@@ -410,10 +410,10 @@ typedef enum
 {
     KSCrashDoctorFunctionCall* function = [[KSCrashDoctorFunctionCall alloc] init];
     NSDictionary* lastStackEntry = [self lastStackEntry:report];
-    function.name = [lastStackEntry objectForKey:@KSCrashField_SymbolName];
+    function.name = [lastStackEntry objectForKey:KSCrashField_SymbolName];
 
     NSDictionary* crashedThread = [self crashedThreadReport:report];
-    NSDictionary* notableAddresses = [crashedThread objectForKey:@KSCrashField_NotableAddresses];
+    NSDictionary* notableAddresses = [crashedThread objectForKey:KSCrashField_NotableAddresses];
     CPUFamily family = [self cpuFamily:report];
     NSDictionary* registers = [self basicRegistersFromThreadReport:crashedThread];
     NSArray* regNames = [NSArray arrayWithObjects:
@@ -434,21 +434,21 @@ typedef enum
         }
         else
         {
-            param.type = [notableAddress objectForKey:@KSCrashField_Type];
-            NSString* className = [notableAddress objectForKey:@KSCrashField_Class];
-            NSString* previousClass = [notableAddress objectForKey:@KSCrashField_LastDeallocObject];
-            NSString* value = [notableAddress objectForKey:@KSCrashField_Value];
+            param.type = [notableAddress objectForKey:KSCrashField_Type];
+            NSString* className = [notableAddress objectForKey:KSCrashField_Class];
+            NSString* previousClass = [notableAddress objectForKey:KSCrashField_LastDeallocObject];
+            NSString* value = [notableAddress objectForKey:KSCrashField_Value];
 
-            if([param.type isEqualToString:@KSCrashMemType_String])
+            if([param.type isEqualToString:KSCrashMemType_String])
             {
                 param.value = value;
             }
-            else if([param.type isEqualToString:@KSCrashMemType_Object])
+            else if([param.type isEqualToString:KSCrashMemType_Object])
             {
                 param.className = className;
                 param.isInstance = YES;
             }
-            else if([param.type isEqualToString:@KSCrashMemType_Class])
+            else if([param.type isEqualToString:KSCrashMemType_Class])
             {
                 param.className = className;
                 param.isInstance = NO;
@@ -478,15 +478,15 @@ typedef enum
 
 - (BOOL) isStackOverflow:(NSDictionary*) crashedThreadReport
 {
-    NSDictionary* stack = [crashedThreadReport objectForKey:@KSCrashField_Stack];
-    return [[stack objectForKey:@KSCrashField_Overflow] boolValue];
+    NSDictionary* stack = [crashedThreadReport objectForKey:KSCrashField_Stack];
+    return [[stack objectForKey:KSCrashField_Overflow] boolValue];
 }
 
 - (BOOL) isDeadlock:(NSDictionary*) report
 {
     NSDictionary* errorReport = [self errorReport:report];
-    NSString* crashType = [errorReport objectForKey:@KSCrashField_Type];
-    return [@KSCrashExcType_Deadlock isEqualToString:crashType];
+    NSString* crashType = [errorReport objectForKey:KSCrashField_Type];
+    return [KSCrashExcType_Deadlock isEqualToString:crashType];
 }
 
 - (NSString*) appendOriginatingCall:(NSString*) string callName:(NSString*) callName
@@ -500,19 +500,19 @@ typedef enum
 
 - (BOOL) isGracefulTerminationRequest:(NSDictionary *)report
 {
-    return [report[@KSCrashField_Signal][@KSCrashField_Signal] integerValue] == SIGTERM;
+    return [report[KSCrashField_Signal][KSCrashField_Signal] integerValue] == SIGTERM;
 }
 
 - (BOOL)isMemoryTermination:(NSDictionary *)report
 {
-    return [report[@KSCrashField_Type] isEqualToString:@KSCrashExcType_MemoryTermination];
+    return [report[KSCrashField_Type] isEqualToString:KSCrashExcType_MemoryTermination];
 }
 
 - (NSString*) diagnoseCrash:(NSDictionary*) report
 {
     @try
     {
-        NSString* lastFunctionName = [[self lastInAppStackEntry:report] objectForKey:@KSCrashField_SymbolName];
+        NSString* lastFunctionName = [[self lastInAppStackEntry:report] objectForKey:KSCrashField_SymbolName];
         NSDictionary* crashedThreadReport = [self crashedThreadReport:report];
         NSDictionary* errorReport = [self errorReport:report];
 
@@ -526,12 +526,12 @@ typedef enum
             return [NSString stringWithFormat:@"Stack overflow in %@", lastFunctionName];
         }
 
-        NSString* crashType = [errorReport objectForKey:@KSCrashField_Type];
-        if([crashType isEqualToString:@KSCrashExcType_NSException])
+        NSString* crashType = [errorReport objectForKey:KSCrashField_Type];
+        if([crashType isEqualToString:KSCrashExcType_NSException])
         {
-            NSDictionary* exception = [errorReport objectForKey:@KSCrashField_NSException];
-            NSString* name = [exception objectForKey:@KSCrashField_Name];
-            NSString* reason = [exception objectForKey:@KSCrashField_Reason]? [exception objectForKey:@KSCrashField_Reason]:[errorReport objectForKey:@KSCrashField_Reason];
+            NSDictionary* exception = [errorReport objectForKey:KSCrashField_NSException];
+            NSString* name = [exception objectForKey:KSCrashField_Name];
+            NSString* reason = [exception objectForKey:KSCrashField_Reason]? [exception objectForKey:KSCrashField_Reason]:[errorReport objectForKey:KSCrashField_Reason];
             return [self appendOriginatingCall:[NSString stringWithFormat:@"Application threw exception %@: %@",
                                                 name, reason]
                                       callName:lastFunctionName];
@@ -558,7 +558,7 @@ typedef enum
 
         if([self isInvalidAddress:errorReport])
         {
-            uintptr_t address = (uintptr_t)[[errorReport objectForKey:@KSCrashField_Address] unsignedLongLongValue];
+            uintptr_t address = (uintptr_t)[[errorReport objectForKey:KSCrashField_Address] unsignedLongLongValue];
             if(address == 0)
             {
                 return [self appendOriginatingCall:@"Attempted to dereference null pointer."

--- a/Sources/KSCrashRecording/KSCrashReportFixer.c
+++ b/Sources/KSCrashRecording/KSCrashReportFixer.c
@@ -41,14 +41,14 @@
 #define MAX_NAME_LENGTH 100
 #define REPORT_VERSION_COMPONENTS_COUNT 3
 
-static char* datePaths[][MAX_DEPTH] =
+static const char* datePaths[][MAX_DEPTH] =
 {
     {"", KSCrashField_Report, KSCrashField_Timestamp},
     {"", KSCrashField_RecrashReport, KSCrashField_Report, KSCrashField_Timestamp},
 };
 static int datePathsCount = sizeof(datePaths) / sizeof(*datePaths);
 
-static char* demanglePaths[][MAX_DEPTH] =
+static const char* demanglePaths[][MAX_DEPTH] =
 {
     {"", KSCrashField_Crash, KSCrashField_Threads, "", KSCrashField_Backtrace, KSCrashField_Contents, "", KSCrashField_SymbolName},
     {"", KSCrashField_RecrashReport, KSCrashField_Crash, KSCrashField_Threads, "", KSCrashField_Backtrace, KSCrashField_Contents, "", KSCrashField_SymbolName},
@@ -57,7 +57,7 @@ static char* demanglePaths[][MAX_DEPTH] =
 };
 static int demanglePathsCount = sizeof(demanglePaths) / sizeof(*demanglePaths);
 
-static char* versionPaths[][MAX_DEPTH] =
+static const char* versionPaths[][MAX_DEPTH] =
 {
     {"", KSCrashField_Report, KSCrashField_Version},
     {"", KSCrashField_RecrashReport, KSCrashField_Report, KSCrashField_Version},
@@ -102,7 +102,7 @@ static bool decreaseDepth(FixupContext* context)
     return true;
 }
 
-static bool matchesPath(FixupContext* context, char** path, const char* finalName)
+static bool matchesPath(FixupContext* context, const char** path, const char* finalName)
 {
     if(finalName == NULL)
     {
@@ -123,7 +123,7 @@ static bool matchesPath(FixupContext* context, char** path, const char* finalNam
     return true;
 }
 
-static bool matchesAPath(FixupContext* context, const char* name, char* paths[][MAX_DEPTH], int pathsCount)
+static bool matchesAPath(FixupContext* context, const char* name, const char* paths[][MAX_DEPTH], int pathsCount)
 {
     for(int i = 0; i < pathsCount; i++)
     {

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
@@ -293,7 +293,7 @@ static void addContextualInfoToEvent(KSCrash_MonitorContext* eventContext)
         eventContext->AppMemory.limit = memCopy.limit;
         eventContext->AppMemory.level = KSCrashAppMemoryStateToString((KSCrashAppMemoryState)memCopy.level);
         eventContext->AppMemory.timestamp = memCopy.timestamp;
-        eventContext->AppMemory.state = ksapp_transition_state_to_string(memCopy.state);
+        eventContext->AppMemory.state = ksapp_transitionStateToString(memCopy.state);
     }
 }
 
@@ -306,7 +306,7 @@ static NSDictionary<NSString *, id> *kscm_memory_serialize(KSCrash_Memory *const
         @KSCrashField_MemoryPressure: @(KSCrashAppMemoryStateToString((KSCrashAppMemoryState)memory->pressure)),
         @KSCrashField_MemoryLevel: @(KSCrashAppMemoryStateToString((KSCrashAppMemoryState)memory->level)),
         @KSCrashField_Timestamp: @(memory->timestamp),
-        @KSCrashField_AppTransitionState: @(ksapp_transition_state_to_string(memory->state)),
+        @KSCrashField_AppTransitionState: @(ksapp_transitionStateToString(memory->state)),
     };
 }
 
@@ -564,7 +564,7 @@ bool ksmemory_previous_session_was_terminated_due_to_memory(bool *userPerceptibl
     
     // We might care if the user might have seen the OOM
     if (userPerceptible) {
-        *userPerceptible = ksapp_transition_state_is_user_perceptible(g_previousSessionMemory.state);
+        *userPerceptible = ksapp_transitionStateIsUserPerceptible(g_previousSessionMemory.state);
     }
     
     // level or pressure is critical++

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
@@ -300,13 +300,13 @@ static void addContextualInfoToEvent(KSCrash_MonitorContext* eventContext)
 static NSDictionary<NSString *, id> *kscm_memory_serialize(KSCrash_Memory *const memory)
 {
     return @{
-        @KSCrashField_MemoryFootprint: @(memory->footprint),
-        @KSCrashField_MemoryRemaining: @(memory->remaining),
-        @KSCrashField_MemoryLimit: @(memory->limit),
-        @KSCrashField_MemoryPressure: @(KSCrashAppMemoryStateToString((KSCrashAppMemoryState)memory->pressure)),
-        @KSCrashField_MemoryLevel: @(KSCrashAppMemoryStateToString((KSCrashAppMemoryState)memory->level)),
-        @KSCrashField_Timestamp: @(memory->timestamp),
-        @KSCrashField_AppTransitionState: @(ksapp_transitionStateToString(memory->state)),
+        KSCrashField_MemoryFootprint: @(memory->footprint),
+        KSCrashField_MemoryRemaining: @(memory->remaining),
+        KSCrashField_MemoryLimit: @(memory->limit),
+        KSCrashField_MemoryPressure: @(KSCrashAppMemoryStateToString((KSCrashAppMemoryState)memory->pressure)),
+        KSCrashField_MemoryLevel: @(KSCrashAppMemoryStateToString((KSCrashAppMemoryState)memory->level)),
+        KSCrashField_Timestamp: @(memory->timestamp),
+        KSCrashField_AppTransitionState: @(ksapp_transitionStateToString(memory->state)),
     };
 }
 
@@ -339,13 +339,13 @@ static void kscm_memory_check_for_oom_in_previous_session(void)
                 NSMutableDictionary *json = [[NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers|NSJSONReadingMutableLeaves error:nil] mutableCopy];
                 
                 if (json) {
-                    json[@KSCrashField_System][@KSCrashField_AppMemory] = kscm_memory_serialize(&g_previousSessionMemory);
-                    json[@KSCrashField_Report][@KSCrashField_Timestamp] = @(g_previousSessionMemory.timestamp);
-                    json[@KSCrashField_Crash][@KSCrashField_Error][@KSCrashExcType_MemoryTermination] =kscm_memory_serialize(&g_previousSessionMemory);
-                    json[@KSCrashField_Crash][@KSCrashField_Error][@KSCrashExcType_Mach] = nil;
-                    json[@KSCrashField_Crash][@KSCrashField_Error][@KSCrashExcType_Signal] = @{
-                        @KSCrashField_Signal: @(SIGKILL),
-                        @KSCrashField_Name: @"SIGKILL",
+                    json[KSCrashField_System][KSCrashField_AppMemory] = kscm_memory_serialize(&g_previousSessionMemory);
+                    json[KSCrashField_Report][KSCrashField_Timestamp] = @(g_previousSessionMemory.timestamp);
+                    json[KSCrashField_Crash][KSCrashField_Error][KSCrashExcType_MemoryTermination] =kscm_memory_serialize(&g_previousSessionMemory);
+                    json[KSCrashField_Crash][KSCrashField_Error][KSCrashExcType_Mach] = nil;
+                    json[KSCrashField_Crash][KSCrashField_Error][KSCrashExcType_Signal] = @{
+                        KSCrashField_Signal: @(SIGKILL),
+                        KSCrashField_Name: @"SIGKILL",
                     };
                     
                     data = [NSJSONSerialization dataWithJSONObject:json options:NSJSONWritingPrettyPrinted error:nil];

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
@@ -141,7 +141,7 @@ static void _ks_memory_update_from_app_memory(KSCrashAppMemory *const memory) {
             .pressure = (uint8_t)memory.pressure,
             .level = (uint8_t)memory.level,
             .timestamp = ksdate_microseconds(),
-            .state = KSCrashAppStateTracker.shared.transitionState,
+            .state = KSCrashAppStateTracker.sharedInstance.transitionState,
         };
     });
 }
@@ -245,7 +245,7 @@ static void setEnabled(bool isEnabled)
             
             ksmemory_map(g_memoryURL.path.UTF8String);
 
-            g_appStateObserver = [KSCrashAppStateTracker.shared addObserverWithBlock:^(KSCrashAppTransitionState transitionState) {
+            g_appStateObserver = [KSCrashAppStateTracker.sharedInstance addObserverWithBlock:^(KSCrashAppTransitionState transitionState) {
                 _ks_memory_update(^(KSCrash_Memory *mem) {
                     mem->state = transitionState;
                 });
@@ -255,7 +255,7 @@ static void setEnabled(bool isEnabled)
         else
         {
             g_memoryTracker = nil;
-            [KSCrashAppStateTracker.shared removeObserver:g_appStateObserver];
+            [KSCrashAppStateTracker.sharedInstance removeObserver:g_appStateObserver];
             g_appStateObserver = nil;
         }
     }

--- a/Sources/KSCrashRecording/include/KSCrash.h
+++ b/Sources/KSCrashRecording/include/KSCrash.h
@@ -30,6 +30,8 @@
 #import "KSCrashReportFilter.h"
 #import "KSCrashReportWriter.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class KSCrashConfiguration;
 
 /**
@@ -47,7 +49,7 @@
  *
  * Default: nil
  */
-@property (atomic, readwrite, retain) NSDictionary* userInfo;
+@property (atomic, readwrite, strong, nullable) NSDictionary<NSString*, id>* userInfo;
 
 /** The report sink where reports get sent.
  * This MUST be set or else the reporter will not send reports (although it will
@@ -56,7 +58,7 @@
  * Note: If you use an installation, it will automatically set this property.
  *       Do not modify it in such a case.
  */
-@property (nonatomic, readwrite, retain) id<KSCrashReportFilter> sink;
+@property (nonatomic, readwrite, strong, nullable) id<KSCrashReportFilter> sink;
 
 #pragma mark - Information -
 
@@ -128,13 +130,10 @@
  *
  * @param onCompletion Called when sending is complete (nil = ignore).
  */
-- (void) sendAllReportsWithCompletion:(KSCrashReportFilterCompletion) onCompletion;
+- (void) sendAllReportsWithCompletion:(nullable KSCrashReportFilterCompletion) onCompletion;
 
-/** Get all unsent report IDs.
- *
- * @return An array with report IDs.
- */
-- (NSArray*) reportIDs;
+/** Get all unsent report IDs. */
+@property(nonatomic,readonly,strong) NSArray<NSNumber*>* reportIDs;
 
 /** Get report.
  *
@@ -142,7 +141,7 @@
  *
  * @return A dictionary with report fields. See KSCrashReportFields.h for available fields.
  */
-- (NSDictionary*) reportWithID:(NSNumber*) reportID;
+- (nullable NSDictionary<NSString*, id>*) reportWithID:(NSInteger) reportID;
 
 /** Delete all unsent reports.
  */
@@ -152,7 +151,7 @@
  *
  * @param reportID An ID of report to delete.
  */
-- (void) deleteReportWithID:(NSNumber*) reportID;
+- (void) deleteReportWithID:(NSInteger) reportID;
 
 /** Report a custom, user defined exception.
  * This can be useful when dealing with scripting languages.
@@ -176,10 +175,10 @@
  * @param terminateProgram If true, do not return from this function call. Terminate the program instead.
  */
 - (void)reportUserException:(NSString*)name
-                     reason:(NSString*)reason
-                   language:(NSString*)language
-                 lineOfCode:(NSString*)lineOfCode
-                 stackTrace:(NSArray*)stackTrace
+                     reason:(nullable NSString*)reason
+                   language:(nullable NSString*)language
+                 lineOfCode:(nullable NSString*)lineOfCode
+                 stackTrace:(nullable NSArray*)stackTrace
               logAllThreads:(BOOL)logAllThreads
            terminateProgram:(BOOL)terminateProgram;
 
@@ -190,3 +189,5 @@ FOUNDATION_EXPORT const double KSCrashFrameworkVersionNumber;
 
 //! Project version string for KSCrashFramework.
 FOUNDATION_EXPORT const unsigned char KSCrashFrameworkVersionString[];
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashRecording/include/KSCrash.h
+++ b/Sources/KSCrashRecording/include/KSCrash.h
@@ -75,10 +75,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic,readonly,assign) NSTimeInterval backgroundDurationSinceLastCrash;
 
 /** Number of app launches since the last crash. */
-@property(nonatomic,readonly,assign) int launchesSinceLastCrash;
+@property(nonatomic,readonly,assign) NSInteger launchesSinceLastCrash;
 
 /** Number of sessions (launch, resume from suspend) since last crash. */
-@property(nonatomic,readonly,assign) int sessionsSinceLastCrash;
+@property(nonatomic,readonly,assign) NSInteger sessionsSinceLastCrash;
 
 /** Total active time elapsed since launch. */
 @property(nonatomic,readonly,assign) NSTimeInterval activeDurationSinceLaunch;
@@ -87,13 +87,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic,readonly,assign) NSTimeInterval backgroundDurationSinceLaunch;
 
 /** Number of sessions (launch, resume from suspend) since app launch. */
-@property(nonatomic,readonly,assign) int sessionsSinceLaunch;
+@property(nonatomic,readonly,assign) NSInteger sessionsSinceLaunch;
 
 /** If true, the application crashed on the previous launch. */
 @property(nonatomic,readonly,assign) BOOL crashedLastLaunch;
 
 /** The total number of unsent reports. Note: This is an expensive operation. */
-@property(nonatomic,readonly,assign) int reportCount;
+@property(nonatomic,readonly,assign) NSInteger reportCount;
 
 /** Information about the operating system and environment.
  *
@@ -141,7 +141,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A dictionary with report fields. See KSCrashReportFields.h for available fields.
  */
-- (nullable NSDictionary<NSString*, id>*) reportForID:(NSInteger) reportID NS_SWIFT_NAME(report(for:));
+- (nullable NSDictionary<NSString*, id>*) reportForID:(int64_t) reportID NS_SWIFT_NAME(report(for:));
 
 /** Delete all unsent reports.
  */
@@ -151,7 +151,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param reportID An ID of report to delete.
  */
-- (void) deleteReportWithID:(NSInteger) reportID NS_SWIFT_NAME(deleteReport(with:));
+- (void) deleteReportWithID:(int64_t) reportID NS_SWIFT_NAME(deleteReport(with:));
 
 /** Report a custom, user defined exception.
  * This can be useful when dealing with scripting languages.

--- a/Sources/KSCrashRecording/include/KSCrash.h
+++ b/Sources/KSCrashRecording/include/KSCrash.h
@@ -110,7 +110,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Get the singleton instance of the crash reporter.
  */
-+ (KSCrash*) sharedInstance NS_SWIFT_NAME(shared());
++ (instancetype) sharedInstance NS_SWIFT_NAME(shared());
 
 /** Install the crash reporter.
  * The reporter will record crashes, but will not send any crash reports unless

--- a/Sources/KSCrashRecording/include/KSCrash.h
+++ b/Sources/KSCrashRecording/include/KSCrash.h
@@ -101,7 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
  * To access these values, refer to the optional
  * `KSCrashBootTimeMonitor` and `KSCrashDiscSpaceMonitor` modules.
  */
-@property(nonatomic,readonly,strong) NSDictionary* systemInfo;
+@property(nonatomic,readonly,strong) NSDictionary<NSString*, id>* systemInfo;
 
 #pragma mark - API -
 
@@ -110,7 +110,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Get the singleton instance of the crash reporter.
  */
-+ (KSCrash*) sharedInstance;
++ (KSCrash*) sharedInstance NS_SWIFT_NAME(shared());
 
 /** Install the crash reporter.
  * The reporter will record crashes, but will not send any crash reports unless
@@ -141,7 +141,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A dictionary with report fields. See KSCrashReportFields.h for available fields.
  */
-- (nullable NSDictionary<NSString*, id>*) reportWithID:(NSInteger) reportID;
+- (nullable NSDictionary<NSString*, id>*) reportForID:(NSInteger) reportID NS_SWIFT_NAME(report(for:));
 
 /** Delete all unsent reports.
  */
@@ -151,7 +151,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param reportID An ID of report to delete.
  */
-- (void) deleteReportWithID:(NSInteger) reportID;
+- (void) deleteReportWithID:(NSInteger) reportID NS_SWIFT_NAME(deleteReport(with:));
 
 /** Report a custom, user defined exception.
  * This can be useful when dealing with scripting languages.

--- a/Sources/KSCrashRecording/include/KSCrashAppMemory.h
+++ b/Sources/KSCrashRecording/include/KSCrashAppMemory.h
@@ -59,14 +59,17 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** Notification sent when the memory level changes. */
-FOUNDATION_EXPORT NSNotificationName const KSCrashAppMemoryLevelChangedNotification;
+FOUNDATION_EXPORT NSNotificationName const KSCrashAppMemoryLevelChangedNotification 
+NS_SWIFT_NAME(AppMemoryLevelChangedNotification);
 
 /** Notification sent when the memory pressure changes. */
-FOUNDATION_EXPORT NSNotificationName const KSCrashAppMemoryPressureChangedNotification;
+FOUNDATION_EXPORT NSNotificationName const KSCrashAppMemoryPressureChangedNotification 
+NS_SWIFT_NAME(AppMemoryPressureChangedNotification);
 
 /** Notification keys that hold new and old values in the _userInfo_ dictionary. */
-FOUNDATION_EXPORT NSString *const KSCrashAppMemoryNewValueKey;
-FOUNDATION_EXPORT NSString *const KSCrashAppMemoryOldValueKey;
+typedef NSString *KSCrashAppMemoryKeys NS_TYPED_ENUM NS_SWIFT_NAME(AppMemoryKeys);
+FOUNDATION_EXPORT KSCrashAppMemoryKeys const KSCrashAppMemoryNewValueKey NS_SWIFT_NAME(newValue);
+FOUNDATION_EXPORT KSCrashAppMemoryKeys const KSCrashAppMemoryOldValueKey NS_SWIFT_NAME(oldValue); 
 
 /** The memory state for level and pressure. */
 typedef NS_ENUM(NSUInteger, KSCrashAppMemoryState) {
@@ -88,12 +91,13 @@ typedef NS_ENUM(NSUInteger, KSCrashAppMemoryState) {
 
     /** You have been or will be terminated. Out-Of-Memory. SIGKILL. */
     KSCrashAppMemoryStateTerminal
-};
+} NS_SWIFT_NAME(AppMemoryState);
 
 /**
  * AppMemory is a simple container object for everything important on Apple platforms
  * surrounding memory.
  */
+NS_SWIFT_NAME(AppMemory)
 @interface KSCrashAppMemory : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -122,7 +126,7 @@ typedef NS_ENUM(NSUInteger, KSCrashAppMemoryState) {
 @property(readonly, nonatomic, assign) KSCrashAppMemoryState pressure;
 
 /** True when the app is totally out of memory. */
-- (BOOL)isOutOfMemory;
+@property(readonly, nonatomic, assign) BOOL isOutOfMemory;
 
 @end
 
@@ -131,7 +135,9 @@ typedef NS_ENUM(NSUInteger, KSCrashAppMemoryState) {
  * `KSCrashAppMemoryStateToString` returns a `const char*`
  * because it needs to be async safe.
  */
-FOUNDATION_EXPORT const char *KSCrashAppMemoryStateToString(KSCrashAppMemoryState state);
-FOUNDATION_EXPORT KSCrashAppMemoryState KSCrashAppMemoryStateFromString(NSString *const state);
+FOUNDATION_EXPORT const char *KSCrashAppMemoryStateToString(KSCrashAppMemoryState state) 
+NS_SWIFT_NAME(string(from:));
+FOUNDATION_EXPORT KSCrashAppMemoryState KSCrashAppMemoryStateFromString(NSString *const string)
+NS_SWIFT_NAME(memoryState(from:));
 
 NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashRecording/include/KSCrashAppMemory.h
+++ b/Sources/KSCrashRecording/include/KSCrashAppMemory.h
@@ -137,6 +137,7 @@ NS_SWIFT_NAME(AppMemory)
  */
 FOUNDATION_EXPORT const char *KSCrashAppMemoryStateToString(KSCrashAppMemoryState state) 
 NS_SWIFT_NAME(string(from:));
+
 FOUNDATION_EXPORT KSCrashAppMemoryState KSCrashAppMemoryStateFromString(NSString *const string)
 NS_SWIFT_NAME(memoryState(from:));
 

--- a/Sources/KSCrashRecording/include/KSCrashAppMemoryTracker.h
+++ b/Sources/KSCrashRecording/include/KSCrashAppMemoryTracker.h
@@ -34,9 +34,11 @@ typedef NS_OPTIONS(NSUInteger, KSCrashAppMemoryTrackerChangeType) {
     KSCrashAppMemoryTrackerChangeTypeLevel      = 1 << 0,
     KSCrashAppMemoryTrackerChangeTypePressure   = 1 << 1,
     KSCrashAppMemoryTrackerChangeTypeFootprint  = 1 << 2,
-};
+} NS_SWIFT_NAME(AppMemoryTrackerChangeType);
 
 @protocol KSCrashAppMemoryTrackerDelegate;
+
+NS_SWIFT_NAME(AppMemoryTracker)
 @interface KSCrashAppMemoryTracker : NSObject
 
 @property(atomic, readonly) KSCrashAppMemoryState pressure;
@@ -44,13 +46,14 @@ typedef NS_OPTIONS(NSUInteger, KSCrashAppMemoryTrackerChangeType) {
 
 @property(nonatomic, weak) id<KSCrashAppMemoryTrackerDelegate> delegate;
 
+@property(nonatomic, readonly, nullable) KSCrashAppMemory *currentAppMemory;
+
 - (void)start;
 - (void)stop;
 
-- (nullable KSCrashAppMemory *)currentAppMemory;
-
 @end
 
+NS_SWIFT_NAME(AppMemoryTrackerDelegate)
 @protocol KSCrashAppMemoryTrackerDelegate <NSObject>
 
 - (void)appMemoryTracker:(KSCrashAppMemoryTracker *)tracker

--- a/Sources/KSCrashRecording/include/KSCrashAppStateTracker.h
+++ b/Sources/KSCrashRecording/include/KSCrashAppStateTracker.h
@@ -45,16 +45,19 @@ NS_ASSUME_NONNULL_BEGIN
  * We'll keep it private for now until it is integrated with `KSCrashMonitor_AppState`.
  */
 
-typedef void (^KSCrashAppStateTrackerObserverBlock)(KSCrashAppTransitionState transitionState);
+typedef void (^KSCrashAppStateTrackerObserverBlock)(KSCrashAppTransitionState transitionState)
+NS_SWIFT_UNAVAILABLE("Use Swift closures instead!");
 
 @protocol KSCrashAppStateTrackerObserving;
+
+NS_SWIFT_NAME(AppStateTracker)
 @interface KSCrashAppStateTracker : NSObject
 
 /**
  * The shared tracker. Use this unless you absolutely need your own tracker,
  * at which point you can simply allocate your own.
  */
-+ (instancetype)sharedInstance;
++ (instancetype)sharedInstance NS_SWIFT_NAME(shared());
 
 - (instancetype)initWithNotificationCenter:(NSNotificationCenter *)notificationCenter NS_DESIGNATED_INITIALIZER;
 
@@ -87,8 +90,9 @@ typedef void (^KSCrashAppStateTrackerObserverBlock)(KSCrashAppTransitionState tr
 @end
 
 /** Implement this and add yourself to a tracker to observer transitions */
+NS_SWIFT_NAME(AppStateTrackerObserving)
 @protocol KSCrashAppStateTrackerObserving <NSObject>
-- (void)appStateTracker:(KSCrashAppStateTracker *)tracker didTransitionToState:(KSCrashAppTransitionState)transitionState;
+- (void)appStateTracker:(KSCrashAppStateTracker *)tracker didTransitionToState:(KSCrashAppTransitionState)state;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashRecording/include/KSCrashAppStateTracker.h
+++ b/Sources/KSCrashRecording/include/KSCrashAppStateTracker.h
@@ -54,7 +54,7 @@ typedef void (^KSCrashAppStateTrackerObserverBlock)(KSCrashAppTransitionState tr
  * The shared tracker. Use this unless you absolutely need your own tracker,
  * at which point you can simply allocate your own.
  */
-+ (instancetype)shared;
++ (instancetype)sharedInstance;
 
 - (instancetype)initWithNotificationCenter:(NSNotificationCenter *)notificationCenter NS_DESIGNATED_INITIALIZER;
 

--- a/Sources/KSCrashRecording/include/KSCrashAppTransitionState.h
+++ b/Sources/KSCrashRecording/include/KSCrashAppTransitionState.h
@@ -52,11 +52,10 @@ enum
     KSCrashAppTransitionStateBackground,
     KSCrashAppTransitionStateTerminating,
     KSCrashAppTransitionStateExiting,
-}
-#ifndef __OBJC__ 
-typedef uint8_t KSCrashAppTransitionState
+};
+#ifndef __OBJC__
+typedef uint8_t KSCrashAppTransitionState;
 #endif
-;
 
 /**
  * Returns true if the transition state is user perceptible.

--- a/Sources/KSCrashRecording/include/KSCrashAppTransitionState.h
+++ b/Sources/KSCrashRecording/include/KSCrashAppTransitionState.h
@@ -28,13 +28,21 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#ifdef __OBJC__
+#include <Foundation/Foundation.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /** States of transition for the application */
-enum {
+#ifdef __OBJC__
+typedef NS_ENUM(uint8_t, KSCrashAppTransitionState)
+#else
+enum
+#endif
+{
     KSCrashAppTransitionStateStartup = 0,
     KSCrashAppTransitionStateStartupPrewarm,
     KSCrashAppTransitionStateLaunching,
@@ -44,18 +52,21 @@ enum {
     KSCrashAppTransitionStateBackground,
     KSCrashAppTransitionStateTerminating,
     KSCrashAppTransitionStateExiting,
-};
-typedef uint8_t KSCrashAppTransitionState;
+}
+#ifndef __OBJC__ 
+typedef uint8_t KSCrashAppTransitionState
+#endif
+;
 
 /**
  * Returns true if the transition state is user perceptible.
  */
-bool ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionState state);
+bool ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionState state);
 
 /**
  * Returns a string for the app state passed in.
  */
-const char *ksapp_transition_state_to_string(KSCrashAppTransitionState state);
+const char *ksapp_transitionStateToString(KSCrashAppTransitionState state);
 
 #ifdef __cplusplus
 }

--- a/Sources/KSCrashRecording/include/KSCrashAppTransitionState.h
+++ b/Sources/KSCrashRecording/include/KSCrashAppTransitionState.h
@@ -36,6 +36,10 @@
 extern "C" {
 #endif
 
+#ifndef NS_SWIFT_NAME
+#define NS_SWIFT_NAME(_name)
+#endif
+
 /** States of transition for the application */
 #ifdef __OBJC__
 typedef NS_ENUM(uint8_t, KSCrashAppTransitionState)
@@ -52,7 +56,7 @@ enum
     KSCrashAppTransitionStateBackground,
     KSCrashAppTransitionStateTerminating,
     KSCrashAppTransitionStateExiting,
-};
+} NS_SWIFT_NAME(AppTransitionState);
 #ifndef __OBJC__
 typedef uint8_t KSCrashAppTransitionState;
 #endif
@@ -60,12 +64,14 @@ typedef uint8_t KSCrashAppTransitionState;
 /**
  * Returns true if the transition state is user perceptible.
  */
-bool ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionState state);
+bool ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionState state)
+NS_SWIFT_NAME(isUserPerceptible(transitionState:));
 
 /**
  * Returns a string for the app state passed in.
  */
-const char *ksapp_transitionStateToString(KSCrashAppTransitionState state);
+const char *ksapp_transitionStateToString(KSCrashAppTransitionState state)
+NS_SWIFT_NAME(string(for:));
 
 #ifdef __cplusplus
 }

--- a/Sources/KSCrashRecording/include/KSCrashConfiguration.h
+++ b/Sources/KSCrashRecording/include/KSCrashConfiguration.h
@@ -34,7 +34,7 @@ typedef NS_ENUM(NSUInteger, KSCDeleteBehavior) {
     KSCDeleteNever,
     KSCDeleteOnSucess,
     KSCDeleteAlways
-};
+} NS_SWIFT_NAME(DeleteBehavior);
 
 @interface KSCrashConfiguration : NSObject <NSCopying>
 
@@ -99,7 +99,7 @@ typedef NS_ENUM(NSUInteger, KSCDeleteBehavior) {
  *
  * This function is called during the crash reporting process, providing an opportunity
  * to add additional information to the crash report. Only async-safe functions should
- * be called from this function. Avoid calling Objective-C methods.
+ * be called from this function. Avoid calling Objective-C/Swift methods.
  *
  * **Default**: NULL
  */

--- a/Sources/KSCrashRecording/include/KSCrashMonitorType.h
+++ b/Sources/KSCrashRecording/include/KSCrashMonitorType.h
@@ -33,6 +33,9 @@
 extern "C" {
 #endif
 
+#ifndef NS_SWIFT_NAME
+#define NS_SWIFT_NAME(_name)
+#endif
 
 /** Various aspects of the system that can be monitored:
  * - Mach kernel exception
@@ -138,7 +141,7 @@ enum
 
     /** Disable automatic reporting; only manual reports are allowed. */
     KSCrashMonitorTypeManual = (KSCrashMonitorTypeRequired | KSCrashMonitorTypeUserReported)
-}
+} NS_SWIFT_NAME(MonitorType)
 #ifndef __OBJC__
 KSCrashMonitorType
 #endif

--- a/Sources/KSCrashRecording/include/KSCrashReportFields.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportFields.h
@@ -24,16 +24,17 @@
 // THE SOFTWARE.
 //
 
-
 #ifndef HDR_KSCrashReportFields_h
 #define HDR_KSCrashReportFields_h
 
 #ifdef __OBJC__
 #include <Foundation/Foundation.h>
 typedef NSString* KSCrashReportField;
-#else
+#define KSCRF_CONVERT_STRING(str) @str
+#else /* __OBJC__ */
 typedef const char* KSCrashReportField;
-#endif
+#define KSCRF_CONVERT_STRING(str) str
+#endif /* __OBJC__ */
 
 #ifndef NS_TYPED_ENUM
 #define NS_TYPED_ENUM
@@ -43,200 +44,200 @@ typedef const char* KSCrashReportField;
 #define NS_SWIFT_NAME(_name)
 #endif
 
-#ifdef __OBJC__
-#define CONVERT_STRING(str) @str
-#else
-#define CONVERT_STRING(str) str
-#endif
+#define KSCRF_DEFINE_CONSTANT(type, name, swift_name, string) \
+    static type const type##_##name NS_SWIFT_NAME(swift_name) = KSCRF_CONVERT_STRING(string);
 
 #pragma mark - Report Types -
 
 typedef KSCrashReportField KSCrashReportType NS_TYPED_ENUM;
-static KSCrashReportType const KSCrashReportType_Minimal NS_SWIFT_NAME(minimal) = CONVERT_STRING("minimal");
-static KSCrashReportType const KSCrashReportType_Standard NS_SWIFT_NAME(standard) = CONVERT_STRING("standard");
-static KSCrashReportType const KSCrashReportType_Custom NS_SWIFT_NAME(custom) = CONVERT_STRING("custom");
+
+KSCRF_DEFINE_CONSTANT(KSCrashReportType, Minimal, minimal, "minimal")
+KSCRF_DEFINE_CONSTANT(KSCrashReportType, Standard, standard, "standard")
+KSCRF_DEFINE_CONSTANT(KSCrashReportType, Custom, custom, "custom")
 
 #pragma mark - Memory Types -
 
 typedef KSCrashReportField KSCrashMemType NS_TYPED_ENUM;
-static KSCrashMemType const KSCrashMemType_Block NS_SWIFT_NAME(block) = CONVERT_STRING("objc_block");
-static KSCrashMemType const KSCrashMemType_Class NS_SWIFT_NAME(class) = CONVERT_STRING("objc_class");
-static KSCrashMemType const KSCrashMemType_NullPointer NS_SWIFT_NAME(nullPointer) = CONVERT_STRING("null_pointer");
-static KSCrashMemType const KSCrashMemType_Object NS_SWIFT_NAME(object) = CONVERT_STRING("objc_object");
-static KSCrashMemType const KSCrashMemType_String NS_SWIFT_NAME(string) = CONVERT_STRING("string");
-static KSCrashMemType const KSCrashMemType_Unknown NS_SWIFT_NAME(unknown) = CONVERT_STRING("unknown");
 
+KSCRF_DEFINE_CONSTANT(KSCrashMemType, Block, block, "objc_block")
+KSCRF_DEFINE_CONSTANT(KSCrashMemType, Class, class, "objc_class")
+KSCRF_DEFINE_CONSTANT(KSCrashMemType, NullPointer, nullPointer, "null_pointer")
+KSCRF_DEFINE_CONSTANT(KSCrashMemType, Object, object, "objc_object")
+KSCRF_DEFINE_CONSTANT(KSCrashMemType, String, string, "string")
+KSCRF_DEFINE_CONSTANT(KSCrashMemType, Unknown, unknown, "unknown")
 
 #pragma mark - Exception Types -
 
 typedef KSCrashReportField KSCrashExcType NS_TYPED_ENUM;
-static KSCrashExcType const KSCrashExcType_CPPException NS_SWIFT_NAME(cppException) = CONVERT_STRING("cpp_exception");
-static KSCrashExcType const KSCrashExcType_Deadlock NS_SWIFT_NAME(deadlock) = CONVERT_STRING("deadlock");
-static KSCrashExcType const KSCrashExcType_Mach NS_SWIFT_NAME(mach) = CONVERT_STRING("mach");
-static KSCrashExcType const KSCrashExcType_NSException NS_SWIFT_NAME(nsException) = CONVERT_STRING("nsexception");
-static KSCrashExcType const KSCrashExcType_Signal NS_SWIFT_NAME(signal) = CONVERT_STRING("signal");
-static KSCrashExcType const KSCrashExcType_User NS_SWIFT_NAME(user) = CONVERT_STRING("user");
-static KSCrashExcType const KSCrashExcType_MemoryTermination NS_SWIFT_NAME(memoryTermination) = CONVERT_STRING("memory_termination");
+
+KSCRF_DEFINE_CONSTANT(KSCrashExcType, CPPException, cppException, "cpp_exception")
+KSCRF_DEFINE_CONSTANT(KSCrashExcType, Deadlock, deadlock, "deadlock")
+KSCRF_DEFINE_CONSTANT(KSCrashExcType, Mach, mach, "mach")
+KSCRF_DEFINE_CONSTANT(KSCrashExcType, NSException, nsException, "nsexception")
+KSCRF_DEFINE_CONSTANT(KSCrashExcType, Signal, signal, "signal")
+KSCRF_DEFINE_CONSTANT(KSCrashExcType, User, user, "user")
+KSCRF_DEFINE_CONSTANT(KSCrashExcType, MemoryTermination, memoryTermination, "memory_termination")
 
 #pragma mark - Common -
 
 typedef KSCrashReportField KSCrashField NS_TYPED_ENUM;
-static KSCrashField const KSCrashField_Address NS_SWIFT_NAME(address) = CONVERT_STRING("address");
-static KSCrashField const KSCrashField_Contents NS_SWIFT_NAME(contents) = CONVERT_STRING("contents");
-static KSCrashField const KSCrashField_Exception NS_SWIFT_NAME(exception) = CONVERT_STRING("exception");
-static KSCrashField const KSCrashField_FirstObject NS_SWIFT_NAME(firstObject) = CONVERT_STRING("first_object");
-static KSCrashField const KSCrashField_Index NS_SWIFT_NAME(index) = CONVERT_STRING("index");
-static KSCrashField const KSCrashField_Ivars NS_SWIFT_NAME(ivars) = CONVERT_STRING("ivars");
-static KSCrashField const KSCrashField_Language NS_SWIFT_NAME(language) = CONVERT_STRING("language");
-static KSCrashField const KSCrashField_Name NS_SWIFT_NAME(name) = CONVERT_STRING("name");
-static KSCrashField const KSCrashField_UserInfo NS_SWIFT_NAME(userInfo) = CONVERT_STRING("userInfo");
-static KSCrashField const KSCrashField_ReferencedObject NS_SWIFT_NAME(referencedObject) = CONVERT_STRING("referenced_object");
-static KSCrashField const KSCrashField_Type NS_SWIFT_NAME(type) = CONVERT_STRING("type");
-static KSCrashField const KSCrashField_UUID NS_SWIFT_NAME(uuid) = CONVERT_STRING("uuid");
-static KSCrashField const KSCrashField_Value NS_SWIFT_NAME(value) = CONVERT_STRING("value");
-static KSCrashField const KSCrashField_MemoryLimit NS_SWIFT_NAME(memoryLimit) = CONVERT_STRING("memory_limit");
-static KSCrashField const KSCrashField_Error NS_SWIFT_NAME(error) = CONVERT_STRING("error");
-static KSCrashField const KSCrashField_JSONData NS_SWIFT_NAME(jsonData) = CONVERT_STRING("json_data");
+
+KSCRF_DEFINE_CONSTANT(KSCrashField, Address, address, "address")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Contents, contents, "contents")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Exception, exception, "exception")
+KSCRF_DEFINE_CONSTANT(KSCrashField, FirstObject, firstObject, "first_object")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Index, index, "index")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Ivars, ivars, "ivars")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Language, language, "language")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Name, name, "name")
+KSCRF_DEFINE_CONSTANT(KSCrashField, UserInfo, userInfo, "userInfo")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ReferencedObject, referencedObject, "referenced_object")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Type, type, "type")
+KSCRF_DEFINE_CONSTANT(KSCrashField, UUID, uuid, "uuid")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Value, value, "value")
+KSCRF_DEFINE_CONSTANT(KSCrashField, MemoryLimit, memoryLimit, "memory_limit")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Error, error, "error")
+KSCRF_DEFINE_CONSTANT(KSCrashField, JSONData, jsonData, "json_data")
 
 #pragma mark - Notable Address -
 
-static KSCrashField const KSCrashField_Class NS_SWIFT_NAME(class) = CONVERT_STRING("class");
-static KSCrashField const KSCrashField_LastDeallocObject NS_SWIFT_NAME(lastDeallocObject) = CONVERT_STRING("last_deallocated_obj");
+KSCRF_DEFINE_CONSTANT(KSCrashField, Class, class, "class")
+KSCRF_DEFINE_CONSTANT(KSCrashField, LastDeallocObject, lastDeallocObject, "last_deallocated_obj")
 
 #pragma mark - Backtrace -
 
-static KSCrashField const KSCrashField_InstructionAddr NS_SWIFT_NAME(instructionAddr) = CONVERT_STRING("instruction_addr");
-static KSCrashField const KSCrashField_LineOfCode NS_SWIFT_NAME(lineOfCode) = CONVERT_STRING("line_of_code");
-static KSCrashField const KSCrashField_ObjectAddr NS_SWIFT_NAME(objectAddr) = CONVERT_STRING("object_addr");
-static KSCrashField const KSCrashField_ObjectName NS_SWIFT_NAME(objectName) = CONVERT_STRING("object_name");
-static KSCrashField const KSCrashField_SymbolAddr NS_SWIFT_NAME(symbolAddr) = CONVERT_STRING("symbol_addr");
-static KSCrashField const KSCrashField_SymbolName NS_SWIFT_NAME(symbolName) = CONVERT_STRING("symbol_name");
+KSCRF_DEFINE_CONSTANT(KSCrashField, InstructionAddr, instructionAddr, "instruction_addr")
+KSCRF_DEFINE_CONSTANT(KSCrashField, LineOfCode, lineOfCode, "line_of_code")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ObjectAddr, objectAddr, "object_addr")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ObjectName, objectName, "object_name")
+KSCRF_DEFINE_CONSTANT(KSCrashField, SymbolAddr, symbolAddr, "symbol_addr")
+KSCRF_DEFINE_CONSTANT(KSCrashField, SymbolName, symbolName, "symbol_name")
 
 #pragma mark - Stack Dump -
 
-static KSCrashField const KSCrashField_DumpEnd NS_SWIFT_NAME(dumpEnd) = CONVERT_STRING("dump_end");
-static KSCrashField const KSCrashField_DumpStart NS_SWIFT_NAME(dumpStart) = CONVERT_STRING("dump_start");
-static KSCrashField const KSCrashField_GrowDirection NS_SWIFT_NAME(growDirection) = CONVERT_STRING("grow_direction");
-static KSCrashField const KSCrashField_Overflow NS_SWIFT_NAME(overflow) = CONVERT_STRING("overflow");
-static KSCrashField const KSCrashField_StackPtr NS_SWIFT_NAME(stackPtr) = CONVERT_STRING("stack_pointer");
+KSCRF_DEFINE_CONSTANT(KSCrashField, DumpEnd, dumpEnd, "dump_end")
+KSCRF_DEFINE_CONSTANT(KSCrashField, DumpStart, dumpStart, "dump_start")
+KSCRF_DEFINE_CONSTANT(KSCrashField, GrowDirection, growDirection, "grow_direction")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Overflow, overflow, "overflow")
+KSCRF_DEFINE_CONSTANT(KSCrashField, StackPtr, stackPtr, "stack_pointer")
 
 #pragma mark - Thread Dump -
 
-static KSCrashField const KSCrashField_Backtrace NS_SWIFT_NAME(backtrace) = CONVERT_STRING("backtrace");
-static KSCrashField const KSCrashField_Basic NS_SWIFT_NAME(basic) = CONVERT_STRING("basic");
-static KSCrashField const KSCrashField_Crashed NS_SWIFT_NAME(crashed) = CONVERT_STRING("crashed");
-static KSCrashField const KSCrashField_CurrentThread NS_SWIFT_NAME(currentThread) = CONVERT_STRING("current_thread");
-static KSCrashField const KSCrashField_DispatchQueue NS_SWIFT_NAME(dispatchQueue) = CONVERT_STRING("dispatch_queue");
-static KSCrashField const KSCrashField_NotableAddresses NS_SWIFT_NAME(notableAddresses) = CONVERT_STRING("notable_addresses");
-static KSCrashField const KSCrashField_Registers NS_SWIFT_NAME(registers) = CONVERT_STRING("registers");
-static KSCrashField const KSCrashField_Skipped NS_SWIFT_NAME(skipped) = CONVERT_STRING("skipped");
-static KSCrashField const KSCrashField_Stack NS_SWIFT_NAME(stack) = CONVERT_STRING("stack");
+KSCRF_DEFINE_CONSTANT(KSCrashField, Backtrace, backtrace, "backtrace")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Basic, basic, "basic")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Crashed, crashed, "crashed")
+KSCRF_DEFINE_CONSTANT(KSCrashField, CurrentThread, currentThread, "current_thread")
+KSCRF_DEFINE_CONSTANT(KSCrashField, DispatchQueue, dispatchQueue, "dispatch_queue")
+KSCRF_DEFINE_CONSTANT(KSCrashField, NotableAddresses, notableAddresses, "notable_addresses")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Registers, registers, "registers")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Skipped, skipped, "skipped")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Stack, stack, "stack")
 
 #pragma mark - Binary Image -
 
-static KSCrashField const KSCrashField_CPUSubType NS_SWIFT_NAME(cpuSubType) = CONVERT_STRING("cpu_subtype");
-static KSCrashField const KSCrashField_CPUType NS_SWIFT_NAME(cpuType) = CONVERT_STRING("cpu_type");
-static KSCrashField const KSCrashField_ImageAddress NS_SWIFT_NAME(imageAddress) = CONVERT_STRING("image_addr");
-static KSCrashField const KSCrashField_ImageVmAddress NS_SWIFT_NAME(imageVmAddress) = CONVERT_STRING("image_vmaddr");
-static KSCrashField const KSCrashField_ImageSize NS_SWIFT_NAME(imageSize) = CONVERT_STRING("image_size");
-static KSCrashField const KSCrashField_ImageMajorVersion NS_SWIFT_NAME(imageMajorVersion) = CONVERT_STRING("major_version");
-static KSCrashField const KSCrashField_ImageMinorVersion NS_SWIFT_NAME(imageMinorVersion) = CONVERT_STRING("minor_version");
-static KSCrashField const KSCrashField_ImageRevisionVersion NS_SWIFT_NAME(imageRevisionVersion) = CONVERT_STRING("revision_version");
-static KSCrashField const KSCrashField_ImageCrashInfoMessage NS_SWIFT_NAME(imageCrashInfoMessage) = CONVERT_STRING("crash_info_message");
-static KSCrashField const KSCrashField_ImageCrashInfoMessage2 NS_SWIFT_NAME(imageCrashInfoMessage2) = CONVERT_STRING("crash_info_message2");
-static KSCrashField const KSCrashField_ImageCrashInfoBacktrace NS_SWIFT_NAME(imageCrashInfoBacktrace) = CONVERT_STRING("crash_info_backtrace");
-static KSCrashField const KSCrashField_ImageCrashInfoSignature NS_SWIFT_NAME(imageCrashInfoSignature) = CONVERT_STRING("crash_info_signature");
+KSCRF_DEFINE_CONSTANT(KSCrashField, CPUSubType, cpuSubType, "cpu_subtype")
+KSCRF_DEFINE_CONSTANT(KSCrashField, CPUType, cpuType, "cpu_type")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ImageAddress, imageAddress, "image_addr")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ImageVmAddress, imageVmAddress, "image_vmaddr")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ImageSize, imageSize, "image_size")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ImageMajorVersion, imageMajorVersion, "major_version")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ImageMinorVersion, imageMinorVersion, "minor_version")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ImageRevisionVersion, imageRevisionVersion, "revision_version")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ImageCrashInfoMessage, imageCrashInfoMessage, "crash_info_message")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ImageCrashInfoMessage2, imageCrashInfoMessage2, "crash_info_message2")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ImageCrashInfoBacktrace, imageCrashInfoBacktrace, "crash_info_backtrace")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ImageCrashInfoSignature, imageCrashInfoSignature, "crash_info_signature")
 
 #pragma mark - Memory -
 
-static KSCrashField const KSCrashField_Free NS_SWIFT_NAME(free) = CONVERT_STRING("free");
-static KSCrashField const KSCrashField_Usable NS_SWIFT_NAME(usable) = CONVERT_STRING("usable");
+KSCRF_DEFINE_CONSTANT(KSCrashField, Free, free, "free")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Usable, usable, "usable")
 
 #pragma mark - Error -
 
-static KSCrashField const KSCrashField_Code NS_SWIFT_NAME(code) = CONVERT_STRING("code");
-static KSCrashField const KSCrashField_CodeName NS_SWIFT_NAME(codeName) = CONVERT_STRING("code_name");
-static KSCrashField const KSCrashField_CPPException NS_SWIFT_NAME(cppException) = CONVERT_STRING("cpp_exception");
-static KSCrashField const KSCrashField_ExceptionName NS_SWIFT_NAME(exceptionName) = CONVERT_STRING("exception_name");
-static KSCrashField const KSCrashField_Mach NS_SWIFT_NAME(mach) = CONVERT_STRING("mach");
-static KSCrashField const KSCrashField_NSException NS_SWIFT_NAME(nsException) = CONVERT_STRING("nsexception");
-static KSCrashField const KSCrashField_Reason NS_SWIFT_NAME(reason) = CONVERT_STRING("reason");
-static KSCrashField const KSCrashField_Signal NS_SWIFT_NAME(signal) = CONVERT_STRING("signal");
-static KSCrashField const KSCrashField_Subcode NS_SWIFT_NAME(subcode) = CONVERT_STRING("subcode");
-static KSCrashField const KSCrashField_UserReported NS_SWIFT_NAME(userReported) = CONVERT_STRING("user_reported");
+KSCRF_DEFINE_CONSTANT(KSCrashField, Code, code, "code")
+KSCRF_DEFINE_CONSTANT(KSCrashField, CodeName, codeName, "code_name")
+KSCRF_DEFINE_CONSTANT(KSCrashField, CPPException, cppException, "cpp_exception")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ExceptionName, exceptionName, "exception_name")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Mach, mach, "mach")
+KSCRF_DEFINE_CONSTANT(KSCrashField, NSException, nsException, "nsexception")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Reason, reason, "reason")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Signal, signal, "signal")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Subcode, subcode, "subcode")
+KSCRF_DEFINE_CONSTANT(KSCrashField, UserReported, userReported, "user_reported")
 
 #pragma mark - Process State -
 
-static KSCrashField const KSCrashField_LastDeallocedNSException NS_SWIFT_NAME(lastDeallocedNSException) = CONVERT_STRING("last_dealloced_nsexception");
-static KSCrashField const KSCrashField_ProcessState NS_SWIFT_NAME(processState) = CONVERT_STRING("process");
+KSCRF_DEFINE_CONSTANT(KSCrashField, LastDeallocedNSException, lastDeallocedNSException, "last_dealloced_nsexception")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ProcessState, processState, "process")
 
 #pragma mark - App Stats -
 
-static KSCrashField const KSCrashField_ActiveTimeSinceCrash NS_SWIFT_NAME(activeTimeSinceCrash) = CONVERT_STRING("active_time_since_last_crash");
-static KSCrashField const KSCrashField_ActiveTimeSinceLaunch NS_SWIFT_NAME(activeTimeSinceLaunch) = CONVERT_STRING("active_time_since_launch");
-static KSCrashField const KSCrashField_AppActive NS_SWIFT_NAME(appActive) = CONVERT_STRING("application_active");
-static KSCrashField const KSCrashField_AppInFG NS_SWIFT_NAME(appInFG) = CONVERT_STRING("application_in_foreground");
-static KSCrashField const KSCrashField_BGTimeSinceCrash NS_SWIFT_NAME(bgTimeSinceCrash) = CONVERT_STRING("background_time_since_last_crash");
-static KSCrashField const KSCrashField_BGTimeSinceLaunch NS_SWIFT_NAME(bgTimeSinceLaunch) = CONVERT_STRING("background_time_since_launch");
-static KSCrashField const KSCrashField_LaunchesSinceCrash NS_SWIFT_NAME(launchesSinceCrash) = CONVERT_STRING("launches_since_last_crash");
-static KSCrashField const KSCrashField_SessionsSinceCrash NS_SWIFT_NAME(sessionsSinceCrash) = CONVERT_STRING("sessions_since_last_crash");
-static KSCrashField const KSCrashField_SessionsSinceLaunch NS_SWIFT_NAME(sessionsSinceLaunch) = CONVERT_STRING("sessions_since_launch");
+KSCRF_DEFINE_CONSTANT(KSCrashField, ActiveTimeSinceCrash, activeTimeSinceCrash, "active_time_since_last_crash")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ActiveTimeSinceLaunch, activeTimeSinceLaunch, "active_time_since_launch")
+KSCRF_DEFINE_CONSTANT(KSCrashField, AppActive, appActive, "application_active")
+KSCRF_DEFINE_CONSTANT(KSCrashField, AppInFG, appInFG, "application_in_foreground")
+KSCRF_DEFINE_CONSTANT(KSCrashField, BGTimeSinceCrash, bgTimeSinceCrash, "background_time_since_last_crash")
+KSCRF_DEFINE_CONSTANT(KSCrashField, BGTimeSinceLaunch, bgTimeSinceLaunch, "background_time_since_launch")
+KSCRF_DEFINE_CONSTANT(KSCrashField, LaunchesSinceCrash, launchesSinceCrash, "launches_since_last_crash")
+KSCRF_DEFINE_CONSTANT(KSCrashField, SessionsSinceCrash, sessionsSinceCrash, "sessions_since_last_crash")
+KSCRF_DEFINE_CONSTANT(KSCrashField, SessionsSinceLaunch, sessionsSinceLaunch, "sessions_since_launch")
 
 #pragma mark - Report -
 
-static KSCrashField const KSCrashField_Crash NS_SWIFT_NAME(crash) = CONVERT_STRING("crash");
-static KSCrashField const KSCrashField_Debug NS_SWIFT_NAME(debug) = CONVERT_STRING("debug");
-static KSCrashField const KSCrashField_Diagnosis NS_SWIFT_NAME(diagnosis) = CONVERT_STRING("diagnosis");
-static KSCrashField const KSCrashField_ID NS_SWIFT_NAME(id) = CONVERT_STRING("id");
-static KSCrashField const KSCrashField_ProcessName NS_SWIFT_NAME(processName) = CONVERT_STRING("process_name");
-static KSCrashField const KSCrashField_Report NS_SWIFT_NAME(report) = CONVERT_STRING("report");
-static KSCrashField const KSCrashField_Timestamp NS_SWIFT_NAME(timestamp) = CONVERT_STRING("timestamp");
-static KSCrashField const KSCrashField_Version NS_SWIFT_NAME(version) = CONVERT_STRING("version");
-static KSCrashField const KSCrashField_AppMemory NS_SWIFT_NAME(appMemory) = CONVERT_STRING("app_memory");
-static KSCrashField const KSCrashField_MemoryTermination NS_SWIFT_NAME(memoryTermination) = CONVERT_STRING("memory_termination");
+KSCRF_DEFINE_CONSTANT(KSCrashField, Crash, crash, "crash")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Debug, debug, "debug")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Diagnosis, diagnosis, "diagnosis")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ID, id, "id")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ProcessName, processName, "process_name")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Report, report, "report")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Timestamp, timestamp, "timestamp")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Version, version, "version")
+KSCRF_DEFINE_CONSTANT(KSCrashField, AppMemory, appMemory, "app_memory")
+KSCRF_DEFINE_CONSTANT(KSCrashField, MemoryTermination, memoryTermination, "memory_termination")
 
-static KSCrashField const KSCrashField_CrashedThread NS_SWIFT_NAME(crashedThread) = CONVERT_STRING("crashed_thread");
-static KSCrashField const KSCrashField_AppStats NS_SWIFT_NAME(appStats) = CONVERT_STRING("application_stats");
-static KSCrashField const KSCrashField_BinaryImages NS_SWIFT_NAME(binaryImages) = CONVERT_STRING("binary_images");
-static KSCrashField const KSCrashField_System NS_SWIFT_NAME(system) = CONVERT_STRING("system");
-static KSCrashField const KSCrashField_Memory NS_SWIFT_NAME(memory) = CONVERT_STRING("memory");
-static KSCrashField const KSCrashField_Threads NS_SWIFT_NAME(threads) = CONVERT_STRING("threads");
-static KSCrashField const KSCrashField_User NS_SWIFT_NAME(user) = CONVERT_STRING("user");
-static KSCrashField const KSCrashField_ConsoleLog NS_SWIFT_NAME(consoleLog) = CONVERT_STRING("console_log");
-static KSCrashField const KSCrashField_Incomplete NS_SWIFT_NAME(incomplete) = CONVERT_STRING("incomplete");
-static KSCrashField const KSCrashField_RecrashReport NS_SWIFT_NAME(recrashReport) = CONVERT_STRING("recrash_report");
+KSCRF_DEFINE_CONSTANT(KSCrashField, CrashedThread, crashedThread, "crashed_thread")
+KSCRF_DEFINE_CONSTANT(KSCrashField, AppStats, appStats, "application_stats")
+KSCRF_DEFINE_CONSTANT(KSCrashField, BinaryImages, binaryImages, "binary_images")
+KSCRF_DEFINE_CONSTANT(KSCrashField, System, system, "system")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Memory, memory, "memory")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Threads, threads, "threads")
+KSCRF_DEFINE_CONSTANT(KSCrashField, User, user, "user")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ConsoleLog, consoleLog, "console_log")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Incomplete, incomplete, "incomplete")
+KSCRF_DEFINE_CONSTANT(KSCrashField, RecrashReport, recrashReport, "recrash_report")
 
-static KSCrashField const KSCrashField_AppStartTime NS_SWIFT_NAME(appStartTime) = CONVERT_STRING("app_start_time");
-static KSCrashField const KSCrashField_AppUUID NS_SWIFT_NAME(appUUID) = CONVERT_STRING("app_uuid");
-static KSCrashField const KSCrashField_BootTime NS_SWIFT_NAME(bootTime) = CONVERT_STRING("boot_time");
-static KSCrashField const KSCrashField_BundleID NS_SWIFT_NAME(bundleID) = CONVERT_STRING("CFBundleIdentifier");
-static KSCrashField const KSCrashField_BundleName NS_SWIFT_NAME(bundleName) = CONVERT_STRING("CFBundleName");
-static KSCrashField const KSCrashField_BundleShortVersion NS_SWIFT_NAME(bundleShortVersion) = CONVERT_STRING("CFBundleShortVersionString");
-static KSCrashField const KSCrashField_BundleVersion NS_SWIFT_NAME(bundleVersion) = CONVERT_STRING("CFBundleVersion");
-static KSCrashField const KSCrashField_CPUArch NS_SWIFT_NAME(cpuArch) = CONVERT_STRING("cpu_arch");
-static KSCrashField const KSCrashField_BinaryCPUType NS_SWIFT_NAME(binaryCPUType) = CONVERT_STRING("binary_cpu_type");
-static KSCrashField const KSCrashField_BinaryCPUSubType NS_SWIFT_NAME(binaryCPUSubType) = CONVERT_STRING("binary_cpu_subtype");
-static KSCrashField const KSCrashField_DeviceAppHash NS_SWIFT_NAME(deviceAppHash) = CONVERT_STRING("device_app_hash");
-static KSCrashField const KSCrashField_Executable NS_SWIFT_NAME(executable) = CONVERT_STRING("CFBundleExecutable");
-static KSCrashField const KSCrashField_ExecutablePath NS_SWIFT_NAME(executablePath) = CONVERT_STRING("CFBundleExecutablePath");
-static KSCrashField const KSCrashField_Jailbroken NS_SWIFT_NAME(jailbroken) = CONVERT_STRING("jailbroken");
-static KSCrashField const KSCrashField_KernelVersion NS_SWIFT_NAME(kernelVersion) = CONVERT_STRING("kernel_version");
-static KSCrashField const KSCrashField_Machine NS_SWIFT_NAME(machine) = CONVERT_STRING("machine");
-static KSCrashField const KSCrashField_Model NS_SWIFT_NAME(model) = CONVERT_STRING("model");
-static KSCrashField const KSCrashField_OSVersion NS_SWIFT_NAME(osVersion) = CONVERT_STRING("os_version");
-static KSCrashField const KSCrashField_ParentProcessID NS_SWIFT_NAME(parentProcessID) = CONVERT_STRING("parent_process_id");
-static KSCrashField const KSCrashField_ProcessID NS_SWIFT_NAME(processID) = CONVERT_STRING("process_id");
-static KSCrashField const KSCrashField_Size NS_SWIFT_NAME(size) = CONVERT_STRING("size");
-static KSCrashField const KSCrashField_Storage NS_SWIFT_NAME(storage) = CONVERT_STRING("storage");
-static KSCrashField const KSCrashField_SystemName NS_SWIFT_NAME(systemName) = CONVERT_STRING("system_name");
-static KSCrashField const KSCrashField_SystemVersion NS_SWIFT_NAME(systemVersion) = CONVERT_STRING("system_version");
-static KSCrashField const KSCrashField_TimeZone NS_SWIFT_NAME(timeZone) = CONVERT_STRING("time_zone");
-static KSCrashField const KSCrashField_BuildType NS_SWIFT_NAME(buildType) = CONVERT_STRING("build_type");
+KSCRF_DEFINE_CONSTANT(KSCrashField, AppStartTime, appStartTime, "app_start_time")
+KSCRF_DEFINE_CONSTANT(KSCrashField, AppUUID, appUUID, "app_uuid")
+KSCRF_DEFINE_CONSTANT(KSCrashField, BootTime, bootTime, "boot_time")
+KSCRF_DEFINE_CONSTANT(KSCrashField, BundleID, bundleID, "CFBundleIdentifier")
+KSCRF_DEFINE_CONSTANT(KSCrashField, BundleName, bundleName, "CFBundleName")
+KSCRF_DEFINE_CONSTANT(KSCrashField, BundleShortVersion, bundleShortVersion, "CFBundleShortVersionString")
+KSCRF_DEFINE_CONSTANT(KSCrashField, BundleVersion, bundleVersion, "CFBundleVersion")
+KSCRF_DEFINE_CONSTANT(KSCrashField, CPUArch, cpuArch, "cpu_arch")
+KSCRF_DEFINE_CONSTANT(KSCrashField, BinaryCPUType, binaryCPUType, "binary_cpu_type")
+KSCRF_DEFINE_CONSTANT(KSCrashField, BinaryCPUSubType, binaryCPUSubType, "binary_cpu_subtype")
+KSCRF_DEFINE_CONSTANT(KSCrashField, DeviceAppHash, deviceAppHash, "device_app_hash")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Executable, executable, "CFBundleExecutable")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ExecutablePath, executablePath, "CFBundleExecutablePath")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Jailbroken, jailbroken, "jailbroken")
+KSCRF_DEFINE_CONSTANT(KSCrashField, KernelVersion, kernelVersion, "kernel_version")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Machine, machine, "machine")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Model, model, "model")
+KSCRF_DEFINE_CONSTANT(KSCrashField, OSVersion, osVersion, "os_version")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ParentProcessID, parentProcessID, "parent_process_id")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ProcessID, processID, "process_id")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Size, size, "size")
+KSCRF_DEFINE_CONSTANT(KSCrashField, Storage, storage, "storage")
+KSCRF_DEFINE_CONSTANT(KSCrashField, SystemName, systemName, "system_name")
+KSCRF_DEFINE_CONSTANT(KSCrashField, SystemVersion, systemVersion, "system_version")
+KSCRF_DEFINE_CONSTANT(KSCrashField, TimeZone, timeZone, "time_zone")
+KSCRF_DEFINE_CONSTANT(KSCrashField, BuildType, buildType, "build_type")
 
-static KSCrashField const KSCrashField_MemoryFootprint NS_SWIFT_NAME(memoryFootprint) = CONVERT_STRING("memory_footprint");
-static KSCrashField const KSCrashField_MemoryRemaining NS_SWIFT_NAME(memoryRemaining) = CONVERT_STRING("memory_remaining");
-static KSCrashField const KSCrashField_MemoryPressure NS_SWIFT_NAME(memoryPressure) = CONVERT_STRING("memory_pressure");
-static KSCrashField const KSCrashField_MemoryLevel NS_SWIFT_NAME(memoryLevel) = CONVERT_STRING("memory_level");
-static KSCrashField const KSCrashField_AppTransitionState NS_SWIFT_NAME(appTransitionState) = CONVERT_STRING("app_transition_state");
+KSCRF_DEFINE_CONSTANT(KSCrashField, MemoryFootprint, memoryFootprint, "memory_footprint")
+KSCRF_DEFINE_CONSTANT(KSCrashField, MemoryRemaining, memoryRemaining, "memory_remaining")
+KSCRF_DEFINE_CONSTANT(KSCrashField, MemoryPressure, memoryPressure, "memory_pressure")
+KSCRF_DEFINE_CONSTANT(KSCrashField, MemoryLevel, memoryLevel, "memory_level")
+KSCRF_DEFINE_CONSTANT(KSCrashField, AppTransitionState, appTransitionState, "app_transition_state")
 
 #endif

--- a/Sources/KSCrashRecording/include/KSCrashReportFields.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportFields.h
@@ -28,215 +28,215 @@
 #ifndef HDR_KSCrashReportFields_h
 #define HDR_KSCrashReportFields_h
 
+#ifdef __OBJC__
+#include <Foundation/Foundation.h>
+typedef NSString* KSCrashReportField;
+#else
+typedef const char* KSCrashReportField;
+#endif
+
+#ifndef NS_TYPED_ENUM
+#define NS_TYPED_ENUM
+#endif
+
+#ifndef NS_SWIFT_NAME
+#define NS_SWIFT_NAME(_name)
+#endif
+
+#ifdef __OBJC__
+#define CONVERT_STRING(str) @str
+#else
+#define CONVERT_STRING(str) str
+#endif
 
 #pragma mark - Report Types -
 
-#define KSCrashReportType_Minimal          "minimal"
-#define KSCrashReportType_Standard         "standard"
-#define KSCrashReportType_Custom           "custom"
-
+typedef KSCrashReportField KSCrashReportType NS_TYPED_ENUM;
+static KSCrashReportType const KSCrashReportType_Minimal NS_SWIFT_NAME(minimal) = CONVERT_STRING("minimal");
+static KSCrashReportType const KSCrashReportType_Standard NS_SWIFT_NAME(standard) = CONVERT_STRING("standard");
+static KSCrashReportType const KSCrashReportType_Custom NS_SWIFT_NAME(custom) = CONVERT_STRING("custom");
 
 #pragma mark - Memory Types -
 
-#define KSCrashMemType_Block               "objc_block"
-#define KSCrashMemType_Class               "objc_class"
-#define KSCrashMemType_NullPointer         "null_pointer"
-#define KSCrashMemType_Object              "objc_object"
-#define KSCrashMemType_String              "string"
-#define KSCrashMemType_Unknown             "unknown"
+typedef KSCrashReportField KSCrashMemType NS_TYPED_ENUM;
+static KSCrashMemType const KSCrashMemType_Block NS_SWIFT_NAME(block) = CONVERT_STRING("objc_block");
+static KSCrashMemType const KSCrashMemType_Class NS_SWIFT_NAME(class) = CONVERT_STRING("objc_class");
+static KSCrashMemType const KSCrashMemType_NullPointer NS_SWIFT_NAME(nullPointer) = CONVERT_STRING("null_pointer");
+static KSCrashMemType const KSCrashMemType_Object NS_SWIFT_NAME(object) = CONVERT_STRING("objc_object");
+static KSCrashMemType const KSCrashMemType_String NS_SWIFT_NAME(string) = CONVERT_STRING("string");
+static KSCrashMemType const KSCrashMemType_Unknown NS_SWIFT_NAME(unknown) = CONVERT_STRING("unknown");
 
 
 #pragma mark - Exception Types -
 
-#define KSCrashExcType_CPPException        "cpp_exception"
-#define KSCrashExcType_Deadlock            "deadlock"
-#define KSCrashExcType_Mach                "mach"
-#define KSCrashExcType_NSException         "nsexception"
-#define KSCrashExcType_Signal              "signal"
-#define KSCrashExcType_User                "user"
-#define KSCrashExcType_MemoryTermination   "memory_termination"
+typedef KSCrashReportField KSCrashExcType NS_TYPED_ENUM;
+static KSCrashExcType const KSCrashExcType_CPPException NS_SWIFT_NAME(cppException) = CONVERT_STRING("cpp_exception");
+static KSCrashExcType const KSCrashExcType_Deadlock NS_SWIFT_NAME(deadlock) = CONVERT_STRING("deadlock");
+static KSCrashExcType const KSCrashExcType_Mach NS_SWIFT_NAME(mach) = CONVERT_STRING("mach");
+static KSCrashExcType const KSCrashExcType_NSException NS_SWIFT_NAME(nsException) = CONVERT_STRING("nsexception");
+static KSCrashExcType const KSCrashExcType_Signal NS_SWIFT_NAME(signal) = CONVERT_STRING("signal");
+static KSCrashExcType const KSCrashExcType_User NS_SWIFT_NAME(user) = CONVERT_STRING("user");
+static KSCrashExcType const KSCrashExcType_MemoryTermination NS_SWIFT_NAME(memoryTermination) = CONVERT_STRING("memory_termination");
 
 #pragma mark - Common -
 
-#define KSCrashField_Address               "address"
-#define KSCrashField_Contents              "contents"
-#define KSCrashField_Exception             "exception"
-#define KSCrashField_FirstObject           "first_object"
-#define KSCrashField_Index                 "index"
-#define KSCrashField_Ivars                 "ivars"
-#define KSCrashField_Language              "language"
-#define KSCrashField_Name                  "name"
-#define KSCrashField_UserInfo              "userInfo"
-#define KSCrashField_ReferencedObject      "referenced_object"
-#define KSCrashField_Type                  "type"
-#define KSCrashField_UUID                  "uuid"
-#define KSCrashField_Value                 "value"
-#define KSCrashField_MemoryLimit           "memory_limit"
-#define KSCrashField_MemoryPressure        "memory_pressure"
-
-#define KSCrashField_Error                 "error"
-#define KSCrashField_JSONData              "json_data"
-
+typedef KSCrashReportField KSCrashField NS_TYPED_ENUM;
+static KSCrashField const KSCrashField_Address NS_SWIFT_NAME(address) = CONVERT_STRING("address");
+static KSCrashField const KSCrashField_Contents NS_SWIFT_NAME(contents) = CONVERT_STRING("contents");
+static KSCrashField const KSCrashField_Exception NS_SWIFT_NAME(exception) = CONVERT_STRING("exception");
+static KSCrashField const KSCrashField_FirstObject NS_SWIFT_NAME(firstObject) = CONVERT_STRING("first_object");
+static KSCrashField const KSCrashField_Index NS_SWIFT_NAME(index) = CONVERT_STRING("index");
+static KSCrashField const KSCrashField_Ivars NS_SWIFT_NAME(ivars) = CONVERT_STRING("ivars");
+static KSCrashField const KSCrashField_Language NS_SWIFT_NAME(language) = CONVERT_STRING("language");
+static KSCrashField const KSCrashField_Name NS_SWIFT_NAME(name) = CONVERT_STRING("name");
+static KSCrashField const KSCrashField_UserInfo NS_SWIFT_NAME(userInfo) = CONVERT_STRING("userInfo");
+static KSCrashField const KSCrashField_ReferencedObject NS_SWIFT_NAME(referencedObject) = CONVERT_STRING("referenced_object");
+static KSCrashField const KSCrashField_Type NS_SWIFT_NAME(type) = CONVERT_STRING("type");
+static KSCrashField const KSCrashField_UUID NS_SWIFT_NAME(uuid) = CONVERT_STRING("uuid");
+static KSCrashField const KSCrashField_Value NS_SWIFT_NAME(value) = CONVERT_STRING("value");
+static KSCrashField const KSCrashField_MemoryLimit NS_SWIFT_NAME(memoryLimit) = CONVERT_STRING("memory_limit");
+static KSCrashField const KSCrashField_Error NS_SWIFT_NAME(error) = CONVERT_STRING("error");
+static KSCrashField const KSCrashField_JSONData NS_SWIFT_NAME(jsonData) = CONVERT_STRING("json_data");
 
 #pragma mark - Notable Address -
 
-#define KSCrashField_Class                 "class"
-#define KSCrashField_LastDeallocObject     "last_deallocated_obj"
-
+static KSCrashField const KSCrashField_Class NS_SWIFT_NAME(class) = CONVERT_STRING("class");
+static KSCrashField const KSCrashField_LastDeallocObject NS_SWIFT_NAME(lastDeallocObject) = CONVERT_STRING("last_deallocated_obj");
 
 #pragma mark - Backtrace -
 
-#define KSCrashField_InstructionAddr       "instruction_addr"
-#define KSCrashField_LineOfCode            "line_of_code"
-#define KSCrashField_ObjectAddr            "object_addr"
-#define KSCrashField_ObjectName            "object_name"
-#define KSCrashField_SymbolAddr            "symbol_addr"
-#define KSCrashField_SymbolName            "symbol_name"
-
+static KSCrashField const KSCrashField_InstructionAddr NS_SWIFT_NAME(instructionAddr) = CONVERT_STRING("instruction_addr");
+static KSCrashField const KSCrashField_LineOfCode NS_SWIFT_NAME(lineOfCode) = CONVERT_STRING("line_of_code");
+static KSCrashField const KSCrashField_ObjectAddr NS_SWIFT_NAME(objectAddr) = CONVERT_STRING("object_addr");
+static KSCrashField const KSCrashField_ObjectName NS_SWIFT_NAME(objectName) = CONVERT_STRING("object_name");
+static KSCrashField const KSCrashField_SymbolAddr NS_SWIFT_NAME(symbolAddr) = CONVERT_STRING("symbol_addr");
+static KSCrashField const KSCrashField_SymbolName NS_SWIFT_NAME(symbolName) = CONVERT_STRING("symbol_name");
 
 #pragma mark - Stack Dump -
 
-#define KSCrashField_DumpEnd               "dump_end"
-#define KSCrashField_DumpStart             "dump_start"
-#define KSCrashField_GrowDirection         "grow_direction"
-#define KSCrashField_Overflow              "overflow"
-#define KSCrashField_StackPtr              "stack_pointer"
-
+static KSCrashField const KSCrashField_DumpEnd NS_SWIFT_NAME(dumpEnd) = CONVERT_STRING("dump_end");
+static KSCrashField const KSCrashField_DumpStart NS_SWIFT_NAME(dumpStart) = CONVERT_STRING("dump_start");
+static KSCrashField const KSCrashField_GrowDirection NS_SWIFT_NAME(growDirection) = CONVERT_STRING("grow_direction");
+static KSCrashField const KSCrashField_Overflow NS_SWIFT_NAME(overflow) = CONVERT_STRING("overflow");
+static KSCrashField const KSCrashField_StackPtr NS_SWIFT_NAME(stackPtr) = CONVERT_STRING("stack_pointer");
 
 #pragma mark - Thread Dump -
 
-#define KSCrashField_Backtrace             "backtrace"
-#define KSCrashField_Basic                 "basic"
-#define KSCrashField_Crashed               "crashed"
-#define KSCrashField_CurrentThread         "current_thread"
-#define KSCrashField_DispatchQueue         "dispatch_queue"
-#define KSCrashField_NotableAddresses      "notable_addresses"
-#define KSCrashField_Registers             "registers"
-#define KSCrashField_Skipped               "skipped"
-#define KSCrashField_Stack                 "stack"
-
+static KSCrashField const KSCrashField_Backtrace NS_SWIFT_NAME(backtrace) = CONVERT_STRING("backtrace");
+static KSCrashField const KSCrashField_Basic NS_SWIFT_NAME(basic) = CONVERT_STRING("basic");
+static KSCrashField const KSCrashField_Crashed NS_SWIFT_NAME(crashed) = CONVERT_STRING("crashed");
+static KSCrashField const KSCrashField_CurrentThread NS_SWIFT_NAME(currentThread) = CONVERT_STRING("current_thread");
+static KSCrashField const KSCrashField_DispatchQueue NS_SWIFT_NAME(dispatchQueue) = CONVERT_STRING("dispatch_queue");
+static KSCrashField const KSCrashField_NotableAddresses NS_SWIFT_NAME(notableAddresses) = CONVERT_STRING("notable_addresses");
+static KSCrashField const KSCrashField_Registers NS_SWIFT_NAME(registers) = CONVERT_STRING("registers");
+static KSCrashField const KSCrashField_Skipped NS_SWIFT_NAME(skipped) = CONVERT_STRING("skipped");
+static KSCrashField const KSCrashField_Stack NS_SWIFT_NAME(stack) = CONVERT_STRING("stack");
 
 #pragma mark - Binary Image -
 
-#define KSCrashField_CPUSubType            "cpu_subtype"
-#define KSCrashField_CPUType               "cpu_type"
-#define KSCrashField_ImageAddress          "image_addr"
-#define KSCrashField_ImageVmAddress        "image_vmaddr"
-#define KSCrashField_ImageSize             "image_size"
-#define KSCrashField_ImageMajorVersion     "major_version"
-#define KSCrashField_ImageMinorVersion     "minor_version"
-#define KSCrashField_ImageRevisionVersion  "revision_version"
-#define KSCrashField_ImageCrashInfoMessage    "crash_info_message"
-#define KSCrashField_ImageCrashInfoMessage2   "crash_info_message2"
-#define KSCrashField_ImageCrashInfoBacktrace  "crash_info_backtrace"
-#define KSCrashField_ImageCrashInfoSignature  "crash_info_signature"
-
+static KSCrashField const KSCrashField_CPUSubType NS_SWIFT_NAME(cpuSubType) = CONVERT_STRING("cpu_subtype");
+static KSCrashField const KSCrashField_CPUType NS_SWIFT_NAME(cpuType) = CONVERT_STRING("cpu_type");
+static KSCrashField const KSCrashField_ImageAddress NS_SWIFT_NAME(imageAddress) = CONVERT_STRING("image_addr");
+static KSCrashField const KSCrashField_ImageVmAddress NS_SWIFT_NAME(imageVmAddress) = CONVERT_STRING("image_vmaddr");
+static KSCrashField const KSCrashField_ImageSize NS_SWIFT_NAME(imageSize) = CONVERT_STRING("image_size");
+static KSCrashField const KSCrashField_ImageMajorVersion NS_SWIFT_NAME(imageMajorVersion) = CONVERT_STRING("major_version");
+static KSCrashField const KSCrashField_ImageMinorVersion NS_SWIFT_NAME(imageMinorVersion) = CONVERT_STRING("minor_version");
+static KSCrashField const KSCrashField_ImageRevisionVersion NS_SWIFT_NAME(imageRevisionVersion) = CONVERT_STRING("revision_version");
+static KSCrashField const KSCrashField_ImageCrashInfoMessage NS_SWIFT_NAME(imageCrashInfoMessage) = CONVERT_STRING("crash_info_message");
+static KSCrashField const KSCrashField_ImageCrashInfoMessage2 NS_SWIFT_NAME(imageCrashInfoMessage2) = CONVERT_STRING("crash_info_message2");
+static KSCrashField const KSCrashField_ImageCrashInfoBacktrace NS_SWIFT_NAME(imageCrashInfoBacktrace) = CONVERT_STRING("crash_info_backtrace");
+static KSCrashField const KSCrashField_ImageCrashInfoSignature NS_SWIFT_NAME(imageCrashInfoSignature) = CONVERT_STRING("crash_info_signature");
 
 #pragma mark - Memory -
 
-#define KSCrashField_Free                  "free"
-#define KSCrashField_Usable                "usable"
-
+static KSCrashField const KSCrashField_Free NS_SWIFT_NAME(free) = CONVERT_STRING("free");
+static KSCrashField const KSCrashField_Usable NS_SWIFT_NAME(usable) = CONVERT_STRING("usable");
 
 #pragma mark - Error -
 
-#define KSCrashField_Backtrace             "backtrace"
-#define KSCrashField_Code                  "code"
-#define KSCrashField_CodeName              "code_name"
-#define KSCrashField_CPPException          "cpp_exception"
-#define KSCrashField_ExceptionName         "exception_name"
-#define KSCrashField_Mach                  "mach"
-#define KSCrashField_NSException           "nsexception"
-#define KSCrashField_Reason                "reason"
-#define KSCrashField_Signal                "signal"
-#define KSCrashField_Subcode               "subcode"
-#define KSCrashField_UserReported          "user_reported"
-
+static KSCrashField const KSCrashField_Code NS_SWIFT_NAME(code) = CONVERT_STRING("code");
+static KSCrashField const KSCrashField_CodeName NS_SWIFT_NAME(codeName) = CONVERT_STRING("code_name");
+static KSCrashField const KSCrashField_CPPException NS_SWIFT_NAME(cppException) = CONVERT_STRING("cpp_exception");
+static KSCrashField const KSCrashField_ExceptionName NS_SWIFT_NAME(exceptionName) = CONVERT_STRING("exception_name");
+static KSCrashField const KSCrashField_Mach NS_SWIFT_NAME(mach) = CONVERT_STRING("mach");
+static KSCrashField const KSCrashField_NSException NS_SWIFT_NAME(nsException) = CONVERT_STRING("nsexception");
+static KSCrashField const KSCrashField_Reason NS_SWIFT_NAME(reason) = CONVERT_STRING("reason");
+static KSCrashField const KSCrashField_Signal NS_SWIFT_NAME(signal) = CONVERT_STRING("signal");
+static KSCrashField const KSCrashField_Subcode NS_SWIFT_NAME(subcode) = CONVERT_STRING("subcode");
+static KSCrashField const KSCrashField_UserReported NS_SWIFT_NAME(userReported) = CONVERT_STRING("user_reported");
 
 #pragma mark - Process State -
 
-#define KSCrashField_LastDeallocedNSException "last_dealloced_nsexception"
-#define KSCrashField_ProcessState             "process"
-
+static KSCrashField const KSCrashField_LastDeallocedNSException NS_SWIFT_NAME(lastDeallocedNSException) = CONVERT_STRING("last_dealloced_nsexception");
+static KSCrashField const KSCrashField_ProcessState NS_SWIFT_NAME(processState) = CONVERT_STRING("process");
 
 #pragma mark - App Stats -
 
-#define KSCrashField_ActiveTimeSinceCrash  "active_time_since_last_crash"
-#define KSCrashField_ActiveTimeSinceLaunch "active_time_since_launch"
-#define KSCrashField_AppActive             "application_active"
-#define KSCrashField_AppInFG               "application_in_foreground"
-#define KSCrashField_BGTimeSinceCrash      "background_time_since_last_crash"
-#define KSCrashField_BGTimeSinceLaunch     "background_time_since_launch"
-#define KSCrashField_LaunchesSinceCrash    "launches_since_last_crash"
-#define KSCrashField_SessionsSinceCrash    "sessions_since_last_crash"
-#define KSCrashField_SessionsSinceLaunch   "sessions_since_launch"
-
+static KSCrashField const KSCrashField_ActiveTimeSinceCrash NS_SWIFT_NAME(activeTimeSinceCrash) = CONVERT_STRING("active_time_since_last_crash");
+static KSCrashField const KSCrashField_ActiveTimeSinceLaunch NS_SWIFT_NAME(activeTimeSinceLaunch) = CONVERT_STRING("active_time_since_launch");
+static KSCrashField const KSCrashField_AppActive NS_SWIFT_NAME(appActive) = CONVERT_STRING("application_active");
+static KSCrashField const KSCrashField_AppInFG NS_SWIFT_NAME(appInFG) = CONVERT_STRING("application_in_foreground");
+static KSCrashField const KSCrashField_BGTimeSinceCrash NS_SWIFT_NAME(bgTimeSinceCrash) = CONVERT_STRING("background_time_since_last_crash");
+static KSCrashField const KSCrashField_BGTimeSinceLaunch NS_SWIFT_NAME(bgTimeSinceLaunch) = CONVERT_STRING("background_time_since_launch");
+static KSCrashField const KSCrashField_LaunchesSinceCrash NS_SWIFT_NAME(launchesSinceCrash) = CONVERT_STRING("launches_since_last_crash");
+static KSCrashField const KSCrashField_SessionsSinceCrash NS_SWIFT_NAME(sessionsSinceCrash) = CONVERT_STRING("sessions_since_last_crash");
+static KSCrashField const KSCrashField_SessionsSinceLaunch NS_SWIFT_NAME(sessionsSinceLaunch) = CONVERT_STRING("sessions_since_launch");
 
 #pragma mark - Report -
 
-#define KSCrashField_Crash                 "crash"
-#define KSCrashField_Debug                 "debug"
-#define KSCrashField_Diagnosis             "diagnosis"
-#define KSCrashField_ID                    "id"
-#define KSCrashField_ProcessName           "process_name"
-#define KSCrashField_Report                "report"
-#define KSCrashField_Timestamp             "timestamp"
-#define KSCrashField_Version               "version"
-#define KSCrashField_AppMemory             "app_memory"
-#define KSCrashField_MemoryTermination     "memory_termination"
+static KSCrashField const KSCrashField_Crash NS_SWIFT_NAME(crash) = CONVERT_STRING("crash");
+static KSCrashField const KSCrashField_Debug NS_SWIFT_NAME(debug) = CONVERT_STRING("debug");
+static KSCrashField const KSCrashField_Diagnosis NS_SWIFT_NAME(diagnosis) = CONVERT_STRING("diagnosis");
+static KSCrashField const KSCrashField_ID NS_SWIFT_NAME(id) = CONVERT_STRING("id");
+static KSCrashField const KSCrashField_ProcessName NS_SWIFT_NAME(processName) = CONVERT_STRING("process_name");
+static KSCrashField const KSCrashField_Report NS_SWIFT_NAME(report) = CONVERT_STRING("report");
+static KSCrashField const KSCrashField_Timestamp NS_SWIFT_NAME(timestamp) = CONVERT_STRING("timestamp");
+static KSCrashField const KSCrashField_Version NS_SWIFT_NAME(version) = CONVERT_STRING("version");
+static KSCrashField const KSCrashField_AppMemory NS_SWIFT_NAME(appMemory) = CONVERT_STRING("app_memory");
+static KSCrashField const KSCrashField_MemoryTermination NS_SWIFT_NAME(memoryTermination) = CONVERT_STRING("memory_termination");
 
-#pragma mark Minimal
-#define KSCrashField_CrashedThread         "crashed_thread"
+static KSCrashField const KSCrashField_CrashedThread NS_SWIFT_NAME(crashedThread) = CONVERT_STRING("crashed_thread");
+static KSCrashField const KSCrashField_AppStats NS_SWIFT_NAME(appStats) = CONVERT_STRING("application_stats");
+static KSCrashField const KSCrashField_BinaryImages NS_SWIFT_NAME(binaryImages) = CONVERT_STRING("binary_images");
+static KSCrashField const KSCrashField_System NS_SWIFT_NAME(system) = CONVERT_STRING("system");
+static KSCrashField const KSCrashField_Memory NS_SWIFT_NAME(memory) = CONVERT_STRING("memory");
+static KSCrashField const KSCrashField_Threads NS_SWIFT_NAME(threads) = CONVERT_STRING("threads");
+static KSCrashField const KSCrashField_User NS_SWIFT_NAME(user) = CONVERT_STRING("user");
+static KSCrashField const KSCrashField_ConsoleLog NS_SWIFT_NAME(consoleLog) = CONVERT_STRING("console_log");
+static KSCrashField const KSCrashField_Incomplete NS_SWIFT_NAME(incomplete) = CONVERT_STRING("incomplete");
+static KSCrashField const KSCrashField_RecrashReport NS_SWIFT_NAME(recrashReport) = CONVERT_STRING("recrash_report");
 
-#pragma mark Standard
-#define KSCrashField_AppStats              "application_stats"
-#define KSCrashField_BinaryImages          "binary_images"
-#define KSCrashField_System                "system"
-#define KSCrashField_Memory                "memory"
-#define KSCrashField_Threads               "threads"
-#define KSCrashField_User                  "user"
-#define KSCrashField_ConsoleLog            "console_log"
+static KSCrashField const KSCrashField_AppStartTime NS_SWIFT_NAME(appStartTime) = CONVERT_STRING("app_start_time");
+static KSCrashField const KSCrashField_AppUUID NS_SWIFT_NAME(appUUID) = CONVERT_STRING("app_uuid");
+static KSCrashField const KSCrashField_BootTime NS_SWIFT_NAME(bootTime) = CONVERT_STRING("boot_time");
+static KSCrashField const KSCrashField_BundleID NS_SWIFT_NAME(bundleID) = CONVERT_STRING("CFBundleIdentifier");
+static KSCrashField const KSCrashField_BundleName NS_SWIFT_NAME(bundleName) = CONVERT_STRING("CFBundleName");
+static KSCrashField const KSCrashField_BundleShortVersion NS_SWIFT_NAME(bundleShortVersion) = CONVERT_STRING("CFBundleShortVersionString");
+static KSCrashField const KSCrashField_BundleVersion NS_SWIFT_NAME(bundleVersion) = CONVERT_STRING("CFBundleVersion");
+static KSCrashField const KSCrashField_CPUArch NS_SWIFT_NAME(cpuArch) = CONVERT_STRING("cpu_arch");
+static KSCrashField const KSCrashField_BinaryCPUType NS_SWIFT_NAME(binaryCPUType) = CONVERT_STRING("binary_cpu_type");
+static KSCrashField const KSCrashField_BinaryCPUSubType NS_SWIFT_NAME(binaryCPUSubType) = CONVERT_STRING("binary_cpu_subtype");
+static KSCrashField const KSCrashField_DeviceAppHash NS_SWIFT_NAME(deviceAppHash) = CONVERT_STRING("device_app_hash");
+static KSCrashField const KSCrashField_Executable NS_SWIFT_NAME(executable) = CONVERT_STRING("CFBundleExecutable");
+static KSCrashField const KSCrashField_ExecutablePath NS_SWIFT_NAME(executablePath) = CONVERT_STRING("CFBundleExecutablePath");
+static KSCrashField const KSCrashField_Jailbroken NS_SWIFT_NAME(jailbroken) = CONVERT_STRING("jailbroken");
+static KSCrashField const KSCrashField_KernelVersion NS_SWIFT_NAME(kernelVersion) = CONVERT_STRING("kernel_version");
+static KSCrashField const KSCrashField_Machine NS_SWIFT_NAME(machine) = CONVERT_STRING("machine");
+static KSCrashField const KSCrashField_Model NS_SWIFT_NAME(model) = CONVERT_STRING("model");
+static KSCrashField const KSCrashField_OSVersion NS_SWIFT_NAME(osVersion) = CONVERT_STRING("os_version");
+static KSCrashField const KSCrashField_ParentProcessID NS_SWIFT_NAME(parentProcessID) = CONVERT_STRING("parent_process_id");
+static KSCrashField const KSCrashField_ProcessID NS_SWIFT_NAME(processID) = CONVERT_STRING("process_id");
+static KSCrashField const KSCrashField_Size NS_SWIFT_NAME(size) = CONVERT_STRING("size");
+static KSCrashField const KSCrashField_Storage NS_SWIFT_NAME(storage) = CONVERT_STRING("storage");
+static KSCrashField const KSCrashField_SystemName NS_SWIFT_NAME(systemName) = CONVERT_STRING("system_name");
+static KSCrashField const KSCrashField_SystemVersion NS_SWIFT_NAME(systemVersion) = CONVERT_STRING("system_version");
+static KSCrashField const KSCrashField_TimeZone NS_SWIFT_NAME(timeZone) = CONVERT_STRING("time_zone");
+static KSCrashField const KSCrashField_BuildType NS_SWIFT_NAME(buildType) = CONVERT_STRING("build_type");
 
-#pragma mark Incomplete
-#define KSCrashField_Incomplete            "incomplete"
-#define KSCrashField_RecrashReport         "recrash_report"
-
-#pragma mark System
-#define KSCrashField_AppStartTime          "app_start_time"
-#define KSCrashField_AppUUID               "app_uuid"
-#define KSCrashField_BootTime              "boot_time"
-#define KSCrashField_BundleID              "CFBundleIdentifier"
-#define KSCrashField_BundleName            "CFBundleName"
-#define KSCrashField_BundleShortVersion    "CFBundleShortVersionString"
-#define KSCrashField_BundleVersion         "CFBundleVersion"
-#define KSCrashField_CPUArch               "cpu_arch"
-#define KSCrashField_CPUType               "cpu_type"
-#define KSCrashField_CPUSubType            "cpu_subtype"
-#define KSCrashField_BinaryCPUType         "binary_cpu_type"
-#define KSCrashField_BinaryCPUSubType      "binary_cpu_subtype"
-#define KSCrashField_DeviceAppHash         "device_app_hash"
-#define KSCrashField_Executable            "CFBundleExecutable"
-#define KSCrashField_ExecutablePath        "CFBundleExecutablePath"
-#define KSCrashField_Jailbroken            "jailbroken"
-#define KSCrashField_KernelVersion         "kernel_version"
-#define KSCrashField_Machine               "machine"
-#define KSCrashField_Model                 "model"
-#define KSCrashField_OSVersion             "os_version"
-#define KSCrashField_ParentProcessID       "parent_process_id"
-#define KSCrashField_ProcessID             "process_id"
-#define KSCrashField_ProcessName           "process_name"
-#define KSCrashField_Size                  "size"
-#define KSCrashField_Storage               "storage"
-#define KSCrashField_SystemName            "system_name"
-#define KSCrashField_SystemVersion         "system_version"
-#define KSCrashField_TimeZone              "time_zone"
-#define KSCrashField_BuildType             "build_type"
-
-#pragma mark App Memory
-#define KSCrashField_MemoryFootprint        "memory_footprint"
-#define KSCrashField_MemoryRemaining        "memory_remaining"
-#define KSCrashField_MemoryPressure         "memory_pressure"
-#define KSCrashField_MemoryLevel            "memory_level"
-#define KSCrashField_AppTransitionState     "app_transition_state"
+static KSCrashField const KSCrashField_MemoryFootprint NS_SWIFT_NAME(memoryFootprint) = CONVERT_STRING("memory_footprint");
+static KSCrashField const KSCrashField_MemoryRemaining NS_SWIFT_NAME(memoryRemaining) = CONVERT_STRING("memory_remaining");
+static KSCrashField const KSCrashField_MemoryPressure NS_SWIFT_NAME(memoryPressure) = CONVERT_STRING("memory_pressure");
+static KSCrashField const KSCrashField_MemoryLevel NS_SWIFT_NAME(memoryLevel) = CONVERT_STRING("memory_level");
+static KSCrashField const KSCrashField_AppTransitionState NS_SWIFT_NAME(appTransitionState) = CONVERT_STRING("app_transition_state");
 
 #endif

--- a/Sources/KSCrashRecording/include/KSCrashReportFields.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportFields.h
@@ -47,9 +47,13 @@ typedef const char* KSCrashReportField;
 #define KSCRF_DEFINE_CONSTANT(type, name, swift_name, string) \
     static type const type##_##name NS_SWIFT_NAME(swift_name) = KSCRF_CONVERT_STRING(string);
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #pragma mark - Report Types -
 
-typedef KSCrashReportField KSCrashReportType NS_TYPED_ENUM;
+typedef KSCrashReportField KSCrashReportType NS_TYPED_ENUM NS_SWIFT_NAME(ReportType);
 
 KSCRF_DEFINE_CONSTANT(KSCrashReportType, Minimal, minimal, "minimal")
 KSCRF_DEFINE_CONSTANT(KSCrashReportType, Standard, standard, "standard")
@@ -57,7 +61,7 @@ KSCRF_DEFINE_CONSTANT(KSCrashReportType, Custom, custom, "custom")
 
 #pragma mark - Memory Types -
 
-typedef KSCrashReportField KSCrashMemType NS_TYPED_ENUM;
+typedef KSCrashReportField KSCrashMemType NS_TYPED_ENUM NS_SWIFT_NAME(MemoryType);
 
 KSCRF_DEFINE_CONSTANT(KSCrashMemType, Block, block, "objc_block")
 KSCRF_DEFINE_CONSTANT(KSCrashMemType, Class, class, "objc_class")
@@ -68,7 +72,7 @@ KSCRF_DEFINE_CONSTANT(KSCrashMemType, Unknown, unknown, "unknown")
 
 #pragma mark - Exception Types -
 
-typedef KSCrashReportField KSCrashExcType NS_TYPED_ENUM;
+typedef KSCrashReportField KSCrashExcType NS_TYPED_ENUM NS_SWIFT_NAME(ExceptionType);
 
 KSCRF_DEFINE_CONSTANT(KSCrashExcType, CPPException, cppException, "cpp_exception")
 KSCRF_DEFINE_CONSTANT(KSCrashExcType, Deadlock, deadlock, "deadlock")
@@ -80,7 +84,7 @@ KSCRF_DEFINE_CONSTANT(KSCrashExcType, MemoryTermination, memoryTermination, "mem
 
 #pragma mark - Common -
 
-typedef KSCrashReportField KSCrashField NS_TYPED_ENUM;
+typedef KSCrashReportField KSCrashField NS_TYPED_ENUM NS_SWIFT_NAME(CrashField);
 
 KSCRF_DEFINE_CONSTANT(KSCrashField, Address, address, "address")
 KSCRF_DEFINE_CONSTANT(KSCrashField, Contents, contents, "contents")
@@ -240,4 +244,8 @@ KSCRF_DEFINE_CONSTANT(KSCrashField, MemoryPressure, memoryPressure, "memory_pres
 KSCRF_DEFINE_CONSTANT(KSCrashField, MemoryLevel, memoryLevel, "memory_level")
 KSCRF_DEFINE_CONSTANT(KSCrashField, AppTransitionState, appTransitionState, "app_transition_state")
 
+#ifdef __cplusplus
+}
 #endif
+
+#endif // HDR_KSCrashReportFields_h

--- a/Sources/KSCrashRecording/include/KSCrashReportFilter.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportFilter.h
@@ -47,7 +47,7 @@ NS_SWIFT_UNAVAILABLE("Use Swift closures instead!");
  * A filter receives a set of reports, possibly transforms them, and then
  * calls a completion method.
  */
-NS_SWIFT_NAME(ReportFilter)
+NS_SWIFT_NAME(CrashReportFilter)
 @protocol KSCrashReportFilter <NSObject>
 
 /** Filter the specified reports.

--- a/Sources/KSCrashRecording/include/KSCrashReportFilter.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportFilter.h
@@ -26,6 +26,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** Callback for filter operations.
  *
  * @param filteredReports The filtered reports (may be incomplete if "completed"
@@ -35,13 +37,17 @@
  *                  user cancelling the operation).
  * @param error Non-nil if an error occurred.
  */
-typedef void(^KSCrashReportFilterCompletion)(NSArray* filteredReports, BOOL completed, NSError* error);
+typedef void(^KSCrashReportFilterCompletion)(NSArray<NSDictionary<NSString *,id> *>* _Nullable filteredReports,
+                                             BOOL completed,
+                                             NSError* _Nullable  error)
+NS_SWIFT_UNAVAILABLE("Use Swift closures instead!");
 
 
 /**
  * A filter receives a set of reports, possibly transforms them, and then
  * calls a completion method.
  */
+NS_SWIFT_NAME(ReportFilter)
 @protocol KSCrashReportFilter <NSObject>
 
 /** Filter the specified reports.
@@ -49,8 +55,8 @@ typedef void(^KSCrashReportFilterCompletion)(NSArray* filteredReports, BOOL comp
  * @param reports The reports to process.
  * @param onCompletion Block to call when processing is complete.
  */
-- (void) filterReports:(NSArray*) reports
-          onCompletion:(KSCrashReportFilterCompletion) onCompletion;
+- (void) filterReports:(NSArray<NSDictionary<NSString *,id> *>*) reports
+          onCompletion:(nullable KSCrashReportFilterCompletion) onCompletion;
 
 @end
 
@@ -62,13 +68,15 @@ typedef void(^KSCrashReportFilterCompletion)(NSArray* filteredReports, BOOL comp
  * @param completed The parameter to send as "completed".
  * @param error The parameter to send as "error".
  */
-static inline void kscrash_callCompletion(KSCrashReportFilterCompletion onCompletion,
-                                            NSArray* filteredReports,
-                                            BOOL completed,
-                                            NSError* error)
+static inline void kscrash_callCompletion(KSCrashReportFilterCompletion _Nullable onCompletion,
+                                          NSArray<NSDictionary<NSString *,id> *>* _Nullable filteredReports,
+                                          BOOL completed,
+                                          NSError* _Nullable error)
 {
     if(onCompletion)
     {
         onCompletion(filteredReports, completed, error);
     }
 }
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashRecording/include/KSCrashReportWriter.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportWriter.h
@@ -36,6 +36,18 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __OBJC__
+#include <Foundation/Foundation.h>
+#endif
+
+#ifndef NS_SWIFT_NAME
+#define NS_SWIFT_NAME(_name)
+#endif
+
+#ifndef NS_SWIFT_UNAVAILABLE
+#define NS_SWIFT_UNAVAILABLE(_msg)
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -241,9 +253,10 @@ typedef struct KSCrashReportWriter
     /** Internal contextual data for the writer */
     void* context;
 
-} KSCrashReportWriter;
+} NS_SWIFT_NAME(ReportWriter) KSCrashReportWriter;
 
-typedef void (*KSReportWriteCallback)(const KSCrashReportWriter* writer);
+typedef void (*KSReportWriteCallback)(const KSCrashReportWriter* writer)
+NS_SWIFT_UNAVAILABLE("Use Swift closures instead!");
 
 
 #ifdef __cplusplus

--- a/Sources/KSCrashRecordingCore/include/KSJSONCodecObjC.h
+++ b/Sources/KSCrashRecordingCore/include/KSJSONCodecObjC.h
@@ -29,8 +29,8 @@
 #import <Foundation/Foundation.h>
 
 /** Optional behavior when encoding JSON data */
-typedef enum
-{
+typedef NS_ENUM(NSInteger, KSJSONEncodeOption) {
+    /** No special encoding options */
     KSJSONEncodeOptionNone = 0,
 
     /** Indent 4 spaces per object/array level */
@@ -38,32 +38,25 @@ typedef enum
 
     /** Sort object contents by key name */
     KSJSONEncodeOptionSorted = 2,
-} KSJSONEncodeOption;
+} NS_SWIFT_NAME(JSONEncodeOption);
 
 /** Optional behavior when decoding JSON data */
-typedef enum
-{
+typedef NS_ENUM(NSInteger, KSJSONDecodeOption) {
+    /** No special decoding options */
     KSJSONDecodeOptionNone = 0,
 
-    /** Normally, null elements get stored as [NSNull null].
-     * If this option is set, do not store anything when a null element is
-     * encountered inside an array.
-     */
+    /** Do not store null elements when encountered inside an array */
     KSJSONDecodeOptionIgnoreNullInArray = 1,
 
-    /** Normally, null elements get stored as [NSNull null].
-     * If this option is set, do not store anything when a null element is
-     * encountered inside an object.
-     */
+    /** Do not store null elements when encountered inside an object */
     KSJSONDecodeOptionIgnoreNullInObject = 2,
 
-    /** Convenience enum to ignore nulls in arrays and objects. */
+    /** Ignore null elements in both arrays and objects */
     KSJSONDecodeOptionIgnoreAllNulls = 3,
 
-    /** If an error is encountered, return the partially decoded object. */
+    /** Return the partially decoded object if an error is encountered */
     KSJSONDecodeOptionKeepPartialObject = 4,
-} KSJSONDecodeOption;
-
+} NS_SWIFT_NAME(JSONDecodeOption);
 
 /**
  * Encodes and decodes UTF-8 JSON data.

--- a/Sources/KSCrashSinks/KSCrashReportSinkConsole.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkConsole.m
@@ -32,7 +32,7 @@
 
 @implementation KSCrashReportSinkConsole
 
-+ (KSCrashReportSinkConsole*) filter
++ (instancetype) filter
 {
     return [[self alloc] init];
 }

--- a/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
@@ -197,10 +197,10 @@
 @synthesize message = _message;
 @synthesize filenameFmt = _filenameFmt;
 
-+ (KSCrashReportSinkEMail*) sinkWithRecipients:(NSArray<NSString*>*) recipients
-                                       subject:(NSString*) subject
-                                       message:(nullable NSString*) message
-                                   filenameFmt:(NSString*) filenameFmt
++ (instancetype) sinkWithRecipients:(NSArray<NSString*>*) recipients
+                            subject:(NSString*) subject
+                            message:(nullable NSString*) message
+                        filenameFmt:(NSString*) filenameFmt
 {
     return [[self alloc] initWithRecipients:recipients
                                     subject:subject

--- a/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
@@ -197,9 +197,9 @@
 @synthesize message = _message;
 @synthesize filenameFmt = _filenameFmt;
 
-+ (KSCrashReportSinkEMail*) sinkWithRecipients:(NSArray*) recipients
++ (KSCrashReportSinkEMail*) sinkWithRecipients:(NSArray<NSString*>*) recipients
                                        subject:(NSString*) subject
-                                       message:(NSString*) message
+                                       message:(nullable NSString*) message
                                    filenameFmt:(NSString*) filenameFmt
 {
     return [[self alloc] initWithRecipients:recipients
@@ -208,10 +208,10 @@
                                 filenameFmt:filenameFmt];
 }
 
-- (id) initWithRecipients:(NSArray*) recipients
-                  subject:(NSString*) subject
-                  message:(NSString*) message
-              filenameFmt:(NSString*) filenameFmt
+- (instancetype) initWithRecipients:(NSArray<NSString*>*) recipients
+                            subject:(NSString*) subject
+                            message:(nullable NSString*) message
+                        filenameFmt:(NSString*) filenameFmt
 {
     if((self = [super init]))
     {

--- a/Sources/KSCrashSinks/KSCrashReportSinkQuincyHockey.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkQuincyHockey.m
@@ -267,19 +267,19 @@ crashDescriptionKeys:(NSArray*) crashDescriptionKeys
 - (NSString*) uuidsFromReport:(NSDictionary*) standardReport
 {
     NSMutableString* uuidString = [NSMutableString string];
-    NSArray* binaryImages = [standardReport objectForKey:@KSCrashField_BinaryImages];
+    NSArray* binaryImages = [standardReport objectForKey:KSCrashField_BinaryImages];
     if(binaryImages == nil)
     {
         return @"";
     }
     
-    NSDictionary* systemInfo = [standardReport objectForKey:@KSCrashField_System];
-    NSString* processPath = [systemInfo objectForKey:@KSCrashField_ExecutablePath];
+    NSDictionary* systemInfo = [standardReport objectForKey:KSCrashField_System];
+    NSString* processPath = [systemInfo objectForKey:KSCrashField_ExecutablePath];
     NSString* appContainerPath = [[processPath stringByDeletingLastPathComponent] stringByDeletingLastPathComponent];
     
     for(NSDictionary* image in binaryImages)
     {
-        NSString* imagePath = [[image objectForKey:@KSCrashField_Name] stringByStandardizingPath];
+        NSString* imagePath = [[image objectForKey:KSCrashField_Name] stringByStandardizingPath];
         NSString* imageType;
         if(processPath && [imagePath isEqualToString:processPath])
         {
@@ -296,7 +296,7 @@ crashDescriptionKeys:(NSArray*) crashDescriptionKeys
             continue;
         }
         
-        NSString* uuid = [image objectForKey:@KSCrashField_UUID];
+        NSString* uuid = [image objectForKey:KSCrashField_UUID];
         if(uuid == nil)
         {
             uuid = @"???";
@@ -305,8 +305,8 @@ crashDescriptionKeys:(NSArray*) crashDescriptionKeys
         {
             uuid = [[uuid lowercaseString] stringByReplacingOccurrencesOfString:@"-" withString:@""];
         }
-        cpu_type_t cpuType = [[image objectForKey:@KSCrashField_CPUType] intValue];
-        cpu_subtype_t cpuSubType = [[image objectForKey:@KSCrashField_CPUSubType] intValue];
+        cpu_type_t cpuType = [[image objectForKey:KSCrashField_CPUType] intValue];
+        cpu_subtype_t cpuSubType = [[image objectForKey:KSCrashField_CPUSubType] intValue];
         NSString* arch = [self quincyArchFromCpuType:cpuType cpuSubType:cpuSubType];
         [uuidString appendFormat:@"<uuid type=\"%@\" arch=\"%@\">%@</uuid>", imageType, arch, uuid];
     }
@@ -318,13 +318,13 @@ crashDescriptionKeys:(NSArray*) crashDescriptionKeys
 {
     NSDictionary* report = [reportTuple objectForKey:kFilterKeyStandard];
     NSString* appleReport = [reportTuple objectForKey:kFilterKeyApple];
-    NSDictionary* systemDict = [report objectForKey:@KSCrashField_System];
+    NSDictionary* systemDict = [report objectForKey:KSCrashField_System];
     NSString* userID = self.userIDKey == nil ? nil : [self blankForNil:[report objectForKeyPath:self.userIDKey]];
     NSString* userName = self.userNameKey == nil ? nil : [self blankForNil:[report objectForKeyPath:self.userNameKey]];
     NSString* contactEmail = self.contactEmailKey == nil ? nil : [self blankForNil:[report objectForKeyPath:self.contactEmailKey]];
     NSString* crashReportDescription = [self.crashDescriptionKeys count] == 0 ? nil : [self descriptionForReport:report keys:self.crashDescriptionKeys];
     NSString* uuids = [self uuidsFromReport:report];
-    NSDictionary* reportInfo = [report objectForKey:@KSCrashField_Report];
+    NSDictionary* reportInfo = [report objectForKey:KSCrashField_Report];
     
     NSString* result = [NSString stringWithFormat:
                         @"\n    <crash>\n"
@@ -352,7 +352,7 @@ crashDescriptionKeys:(NSArray*) crashDescriptionKeys
                         [systemDict objectForKey:@"machine"],
                         [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"],
                         [systemDict objectForKey:@"CFBundleVersion"],
-                        [reportInfo objectForKey:@KSCrashField_ID],
+                        [reportInfo objectForKey:KSCrashField_ID],
                         [self cdataEscaped:appleReport],
                         userID,
                         userName,

--- a/Sources/KSCrashSinks/KSCrashReportSinkQuincyHockey.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkQuincyHockey.m
@@ -71,7 +71,7 @@
 @synthesize reachableOperation = _reachableOperation;
 @synthesize waitUntilReachable = _waitUntilReachable;
 
-+ (KSCrashReportSinkQuincy*) sinkWithURL:(NSURL*) url
++ (instancetype) sinkWithURL:(NSURL*) url
                                userIDKey:(NSString*) userIDKey
                              userNameKey:(NSString*) userNameKey
                          contactEmailKey:(NSString*) contactEmailKey
@@ -474,11 +474,11 @@
 
 @synthesize appIdentifier = _appIdentifier;
 
-+ (KSCrashReportSinkHockey*) sinkWithAppIdentifier:(NSString*) appIdentifier
-                                         userIDKey:(NSString*) userIDKey
-                                       userNameKey:(NSString*) userNameKey
-                                   contactEmailKey:(NSString*) contactEmailKey
-                              crashDescriptionKeys:(NSArray*) crashDescriptionKeys
++ (instancetype) sinkWithAppIdentifier:(NSString*) appIdentifier
+                             userIDKey:(NSString*) userIDKey
+                           userNameKey:(NSString*) userNameKey
+                       contactEmailKey:(NSString*) contactEmailKey
+                  crashDescriptionKeys:(NSArray*) crashDescriptionKeys
 {
     return [[self alloc] initWithAppIdentifier:appIdentifier
                                      userIDKey:userIDKey

--- a/Sources/KSCrashSinks/KSCrashReportSinkQuincyHockey.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkQuincyHockey.m
@@ -51,12 +51,12 @@
 
 @interface KSCrashReportSinkQuincy ()
 
-@property(nonatomic, readwrite, retain, nullable) NSString* userIDKey;
-@property(nonatomic, readwrite, retain, nullable) NSString* userNameKey;
-@property(nonatomic, readwrite, retain, nullable) NSString* contactEmailKey;
-@property(nonatomic, readwrite, retain, nullable) NSArray* crashDescriptionKeys;
-@property(nonatomic, readwrite, retain) NSURL* url;
-@property(nonatomic, readwrite, retain) KSReachableOperationKSCrash* reachableOperation;
+@property(nonatomic, readwrite, copy, nullable) NSString* userIDKey;
+@property(nonatomic, readwrite, copy, nullable) NSString* userNameKey;
+@property(nonatomic, readwrite, copy, nullable) NSString* contactEmailKey;
+@property(nonatomic, readwrite, copy, nullable) NSArray* crashDescriptionKeys;
+@property(nonatomic, readwrite, strong) NSURL* url;
+@property(nonatomic, readwrite, strong) KSReachableOperationKSCrash* reachableOperation;
 
 @end
 

--- a/Sources/KSCrashSinks/KSCrashReportSinkQuincyHockey.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkQuincyHockey.m
@@ -72,10 +72,10 @@
 @synthesize waitUntilReachable = _waitUntilReachable;
 
 + (instancetype) sinkWithURL:(NSURL*) url
-                               userIDKey:(NSString*) userIDKey
-                             userNameKey:(NSString*) userNameKey
-                         contactEmailKey:(NSString*) contactEmailKey
-                    crashDescriptionKeys:(NSArray*) crashDescriptionKeys
+                   userIDKey:(NSString*) userIDKey
+                 userNameKey:(NSString*) userNameKey
+             contactEmailKey:(NSString*) contactEmailKey
+        crashDescriptionKeys:(NSArray*) crashDescriptionKeys
 {
     return [[self alloc] initWithURL:url
                            userIDKey:userIDKey

--- a/Sources/KSCrashSinks/KSCrashReportSinkQuincyHockey.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkQuincyHockey.m
@@ -51,12 +51,12 @@
 
 @interface KSCrashReportSinkQuincy ()
 
-@property(nonatomic, readwrite, retain) NSString* userIDKey;
-@property(nonatomic, readwrite, retain) NSString* userNameKey;
-@property(nonatomic, readwrite, retain) NSString* contactEmailKey;
-@property(nonatomic, readwrite, retain) NSArray* crashDescriptionKeys;
-@property(nonatomic,readwrite,retain) NSURL* url;
-@property(nonatomic,readwrite,retain) KSReachableOperationKSCrash* reachableOperation;
+@property(nonatomic, readwrite, retain, nullable) NSString* userIDKey;
+@property(nonatomic, readwrite, retain, nullable) NSString* userNameKey;
+@property(nonatomic, readwrite, retain, nullable) NSString* contactEmailKey;
+@property(nonatomic, readwrite, retain, nullable) NSArray* crashDescriptionKeys;
+@property(nonatomic, readwrite, retain) NSURL* url;
+@property(nonatomic, readwrite, retain) KSReachableOperationKSCrash* reachableOperation;
 
 @end
 
@@ -84,11 +84,11 @@
                 crashDescriptionKeys:crashDescriptionKeys];
 }
 
-- (id) initWithURL:(NSURL*) url
-         userIDKey:(NSString*) userIDKey
-       userNameKey:(NSString*) userNameKey
-   contactEmailKey:(NSString*) contactEmailKey
-crashDescriptionKeys:(NSArray*) crashDescriptionKeys
+- (instancetype) initWithURL:(NSURL*) url
+                   userIDKey:(NSString*) userIDKey
+                 userNameKey:(NSString*) userNameKey
+             contactEmailKey:(NSString*) contactEmailKey
+        crashDescriptionKeys:(NSArray*) crashDescriptionKeys
 {
     if((self = [super init]))
     {
@@ -487,11 +487,11 @@ crashDescriptionKeys:(NSArray*) crashDescriptionKeys
                           crashDescriptionKeys:crashDescriptionKeys];
 }
 
-- (id) initWithAppIdentifier:(NSString*) appIdentifier
-                   userIDKey:(NSString*) userIDKey
-                 userNameKey:(NSString*) userNameKey
-             contactEmailKey:(NSString*) contactEmailKey
-        crashDescriptionKeys:(NSArray*) crashDescriptionKeys
+- (instancetype) initWithAppIdentifier:(NSString*) appIdentifier
+                             userIDKey:(NSString*) userIDKey
+                           userNameKey:(NSString*) userNameKey
+                       contactEmailKey:(NSString*) contactEmailKey
+                  crashDescriptionKeys:(NSArray*) crashDescriptionKeys
 {
     if((self = [super initWithURL:[self urlWithAppIdentifier:appIdentifier]
                         userIDKey:userIDKey

--- a/Sources/KSCrashSinks/KSCrashReportSinkStandard.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkStandard.m
@@ -58,7 +58,7 @@
     return [[self alloc] initWithURL:url];
 }
 
-- (id) initWithURL:(NSURL*) url
+- (instancetype) initWithURL:(NSURL*) url
 {
     if((self = [super init]))
     {

--- a/Sources/KSCrashSinks/KSCrashReportSinkStandard.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkStandard.m
@@ -53,7 +53,7 @@
 @synthesize url = _url;
 @synthesize reachableOperation = _reachableOperation;
 
-+ (KSCrashReportSinkStandard*) sinkWithURL:(NSURL*) url
++ (instancetype) sinkWithURL:(NSURL*) url
 {
     return [[self alloc] initWithURL:url];
 }

--- a/Sources/KSCrashSinks/KSCrashReportSinkVictory.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkVictory.m
@@ -62,9 +62,9 @@
 @synthesize userEmail = _userEmail;
 @synthesize reachableOperation = _reachableOperation;
 
-+ (KSCrashReportSinkVictory*) sinkWithURL:(NSURL*) url
-                                   userName:(NSString*) userName
-                                  userEmail:(NSString*) userEmail
++ (instancetype) sinkWithURL:(NSURL*) url
+                    userName:(NSString*) userName
+                   userEmail:(NSString*) userEmail
 {
     return [[self alloc] initWithURL:url userName:userName userEmail:userEmail];
 }

--- a/Sources/KSCrashSinks/KSCrashReportSinkVictory.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkVictory.m
@@ -69,9 +69,9 @@
     return [[self alloc] initWithURL:url userName:userName userEmail:userEmail];
 }
 
-- (id) initWithURL:(NSURL*) url
-          userName:(NSString*) userName
-         userEmail:(NSString*) userEmail
+- (instancetype) initWithURL:(NSURL*) url
+                    userName:(NSString*) userName
+                   userEmail:(NSString*) userEmail
 {
     if((self = [super init]))
     {

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkConsole.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkConsole.h
@@ -27,16 +27,25 @@
 
 #import "KSCrashReportFilter.h"
 
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * Prints reports directly to the console.
  *
  * Input: Anything
  * Output: Same as input (passthrough)
  */
+NS_SWIFT_NAME(CrashReportSinkConsole)
 @interface KSCrashReportSinkConsole : NSObject <KSCrashReportFilter>
 
+/** Creates a new filter for printing reports to the console. */
 + (KSCrashReportSinkConsole*) filter;
 
+/** Returns the default crash report filter set. */
 - (id <KSCrashReportFilter>) defaultCrashReportFilterSet;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkConsole.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkConsole.h
@@ -41,7 +41,7 @@ NS_SWIFT_NAME(CrashReportSinkConsole)
 @interface KSCrashReportSinkConsole : NSObject <KSCrashReportFilter>
 
 /** Creates a new filter for printing reports to the console. */
-+ (KSCrashReportSinkConsole*) filter;
++ (instancetype) filter;
 
 /** Returns the default crash report filter set. */
 - (id <KSCrashReportFilter>) defaultCrashReportFilterSet;

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkEMail.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkEMail.h
@@ -28,12 +28,14 @@
 #import <Foundation/Foundation.h>
 #import "KSCrashReportFilter.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 /** Sends reports via email.
  *
  * Input: NSData
  * Output: Same as input (passthrough)
  */
+NS_SWIFT_NAME(CrashReportSinkEmail)
 @interface KSCrashReportSinkEMail : NSObject <KSCrashReportFilter>
 
 /**
@@ -43,10 +45,11 @@
  * @param filenameFmt How to name the attachments. You may use "%d" to differentiate
  *                    when multiple reports are sent at once.
  *                    Note: With the default filter set, files are gzipped text.
+ * @return A new instance of KSCrashReportSinkEMail configured with the specified parameters.
  */
-+ (KSCrashReportSinkEMail*) sinkWithRecipients:(NSArray*) recipients
++ (KSCrashReportSinkEMail*) sinkWithRecipients:(NSArray<NSString*>*) recipients
                                        subject:(NSString*) subject
-                                       message:(NSString*) message
+                                       message:(nullable NSString*) message
                                    filenameFmt:(NSString*) filenameFmt;
 
 /**
@@ -57,12 +60,14 @@
  *                    when multiple reports are sent at once.
  *                    Note: With the default filter set, files are gzipped text.
  */
-- (id) initWithRecipients:(NSArray*) recipients
-                  subject:(NSString*) subject
-                  message:(NSString*) message
-              filenameFmt:(NSString*) filenameFmt;
+- (instancetype) initWithRecipients:(NSArray<NSString*>*) recipients
+                            subject:(NSString*) subject
+                            message:(nullable NSString*) message
+                        filenameFmt:(NSString*) filenameFmt;
 
 - (id <KSCrashReportFilter>) defaultCrashReportFilterSet;
 - (id <KSCrashReportFilter>) defaultCrashReportFilterSetAppleFmt;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkEMail.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkEMail.h
@@ -47,10 +47,10 @@ NS_SWIFT_NAME(CrashReportSinkEmail)
  *                    Note: With the default filter set, files are gzipped text.
  * @return A new instance of KSCrashReportSinkEMail configured with the specified parameters.
  */
-+ (KSCrashReportSinkEMail*) sinkWithRecipients:(NSArray<NSString*>*) recipients
-                                       subject:(NSString*) subject
-                                       message:(nullable NSString*) message
-                                   filenameFmt:(NSString*) filenameFmt;
++ (instancetype) sinkWithRecipients:(NSArray<NSString*>*) recipients
+                            subject:(NSString*) subject
+                            message:(nullable NSString*) message
+                        filenameFmt:(NSString*) filenameFmt;
 
 /**
  * @param recipients List of email addresses to send to.

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkQuincyHockey.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkQuincyHockey.h
@@ -27,12 +27,16 @@
 
 #import "KSCrashReportFilter.h"
 
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
 
 /** Sends reports to Quincy.
  *
  * Input: NSDictionary
  * Output: Same as input (passthrough)
  */
+NS_SWIFT_NAME(CrashReportSinkQuincy)
 @interface KSCrashReportSinkQuincy : NSObject <KSCrashReportFilter>
 
 /** If YES, wait until the host becomes reachable before trying to send.
@@ -43,16 +47,16 @@
 @property(nonatomic,readwrite,assign) BOOL waitUntilReachable;
 
 + (KSCrashReportSinkQuincy*) sinkWithURL:(NSURL*) url
-                               userIDKey:(NSString*) userIDKey
-                             userNameKey:(NSString*) userNameKey
-                         contactEmailKey:(NSString*) contactEmailKey
-                    crashDescriptionKeys:(NSArray*) crashDescriptionKeys;
+                               userIDKey:(nullable NSString*) userIDKey
+                             userNameKey:(nullable NSString*) userNameKey
+                         contactEmailKey:(nullable NSString*) contactEmailKey
+                    crashDescriptionKeys:(nullable NSArray*) crashDescriptionKeys;
 
-- (id) initWithURL:(NSURL*) url
-         userIDKey:(NSString*) userIDKey
-       userNameKey:(NSString*) userNameKey
-   contactEmailKey:(NSString*) contactEmailKey
-crashDescriptionKeys:(NSArray*) crashDescriptionKeys;
+- (instancetype) initWithURL:(NSURL*) url
+                   userIDKey:(nullable NSString*) userIDKey
+                 userNameKey:(nullable NSString*) userNameKey
+             contactEmailKey:(nullable NSString*) contactEmailKey
+        crashDescriptionKeys:(nullable NSArray*) crashDescriptionKeys;
 
 - (id <KSCrashReportFilter>) defaultCrashReportFilterSet;
 
@@ -64,18 +68,21 @@ crashDescriptionKeys:(NSArray*) crashDescriptionKeys;
  * Input: NSDictionary
  * Output: Same as input (passthrough)
  */
+NS_SWIFT_NAME(CrashReportSinkHockey)
 @interface KSCrashReportSinkHockey : KSCrashReportSinkQuincy
 
 + (KSCrashReportSinkHockey*) sinkWithAppIdentifier:(NSString*) appIdentifier
-                                         userIDKey:(NSString*) userIDKey
-                                       userNameKey:(NSString*) userNameKey
-                                   contactEmailKey:(NSString*) contactEmailKey
-                              crashDescriptionKeys:(NSArray*) crashDescriptionKeys;
+                                         userIDKey:(nullable NSString*) userIDKey
+                                       userNameKey:(nullable NSString*) userNameKey
+                                   contactEmailKey:(nullable NSString*) contactEmailKey
+                              crashDescriptionKeys:(nullable NSArray*) crashDescriptionKeys;
 
-- (id) initWithAppIdentifier:(NSString*) appIdentifier
-                   userIDKey:(NSString*) userIDKey
-                 userNameKey:(NSString*) userNameKey
-             contactEmailKey:(NSString*) contactEmailKey
-        crashDescriptionKeys:(NSArray*) crashDescriptionKeys;
+- (instancetype) initWithAppIdentifier:(NSString*) appIdentifier
+                             userIDKey:(nullable NSString*) userIDKey
+                           userNameKey:(nullable NSString*) userNameKey
+                       contactEmailKey:(nullable NSString*) contactEmailKey
+                  crashDescriptionKeys:(nullable NSArray*) crashDescriptionKeys;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkQuincyHockey.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkQuincyHockey.h
@@ -46,11 +46,11 @@ NS_SWIFT_NAME(CrashReportSinkQuincy)
  */
 @property(nonatomic,readwrite,assign) BOOL waitUntilReachable;
 
-+ (KSCrashReportSinkQuincy*) sinkWithURL:(NSURL*) url
-                               userIDKey:(nullable NSString*) userIDKey
-                             userNameKey:(nullable NSString*) userNameKey
-                         contactEmailKey:(nullable NSString*) contactEmailKey
-                    crashDescriptionKeys:(nullable NSArray*) crashDescriptionKeys;
++ (instancetype) sinkWithURL:(NSURL*) url
+                   userIDKey:(nullable NSString*) userIDKey
+                 userNameKey:(nullable NSString*) userNameKey
+             contactEmailKey:(nullable NSString*) contactEmailKey
+        crashDescriptionKeys:(nullable NSArray*) crashDescriptionKeys;
 
 - (instancetype) initWithURL:(NSURL*) url
                    userIDKey:(nullable NSString*) userIDKey
@@ -71,11 +71,11 @@ NS_SWIFT_NAME(CrashReportSinkQuincy)
 NS_SWIFT_NAME(CrashReportSinkHockey)
 @interface KSCrashReportSinkHockey : KSCrashReportSinkQuincy
 
-+ (KSCrashReportSinkHockey*) sinkWithAppIdentifier:(NSString*) appIdentifier
-                                         userIDKey:(nullable NSString*) userIDKey
-                                       userNameKey:(nullable NSString*) userNameKey
-                                   contactEmailKey:(nullable NSString*) contactEmailKey
-                              crashDescriptionKeys:(nullable NSArray*) crashDescriptionKeys;
++ (instancetype) sinkWithAppIdentifier:(NSString*) appIdentifier
+                             userIDKey:(nullable NSString*) userIDKey
+                           userNameKey:(nullable NSString*) userNameKey
+                       contactEmailKey:(nullable NSString*) contactEmailKey
+                  crashDescriptionKeys:(nullable NSArray*) crashDescriptionKeys;
 
 - (instancetype) initWithAppIdentifier:(NSString*) appIdentifier
                              userIDKey:(nullable NSString*) userIDKey

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkStandard.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkStandard.h
@@ -27,6 +27,9 @@
 
 #import "KSCrashReportFilter.h"
 
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Sends crash reports to an HTTP server.
@@ -34,6 +37,7 @@
  * Input: NSDictionary
  * Output: Same as input (passthrough)
  */
+NS_SWIFT_NAME(CrashReportSinkStandard)
 @interface KSCrashReportSinkStandard : NSObject <KSCrashReportFilter>
 
 /** Constructor.
@@ -46,8 +50,10 @@
  *
  * @param url The URL to connect to.
  */
-- (id) initWithURL:(NSURL*) url;
+- (instancetype) initWithURL:(NSURL*) url;
 
 - (id <KSCrashReportFilter>) defaultCrashReportFilterSet;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkStandard.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkStandard.h
@@ -44,7 +44,7 @@ NS_SWIFT_NAME(CrashReportSinkStandard)
  *
  * @param url The URL to connect to.
  */
-+ (KSCrashReportSinkStandard*) sinkWithURL:(NSURL*) url;
++ (instancetype) sinkWithURL:(NSURL*) url;
 
 /** Constructor.
  *

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkVictory.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkVictory.h
@@ -27,6 +27,9 @@
 
 #import "KSCrashReportFilter.h"
 
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Sends crash reports to Victory server.
@@ -34,6 +37,7 @@
  * Input: NSDictionary
  * Output: Same as input (passthrough)
  */
+NS_SWIFT_NAME(CrashReportSinkVictory)
 @interface KSCrashReportSinkVictory : NSObject <KSCrashReportFilter>
 
 /** Constructor.
@@ -43,8 +47,8 @@
  * @param userEmail The user email of crash information *optional
  */
 + (KSCrashReportSinkVictory*) sinkWithURL:(NSURL*) url
-                                   userName:(NSString*) userName
-                                  userEmail:(NSString*) userEmail;;
+                                 userName:(nullable NSString*) userName
+                                userEmail:(nullable NSString*) userEmail;
 
 /** Constructor.
  *
@@ -52,10 +56,12 @@
  * @param userName The user name of crash information *required. If value is nil it will be replaced with UIDevice.currentDevice.name
  * @param userEmail The user email of crash information *optional
  */
-- (id) initWithURL:(NSURL*) url
-          userName:(NSString*) userName
-         userEmail:(NSString*) userEmail;
+- (instancetype) initWithURL:(NSURL*) url
+                    userName:(nullable NSString*) userName
+                   userEmail:(nullable NSString*) userEmail;
 
 - (id <KSCrashReportFilter>) defaultCrashReportFilterSet;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkVictory.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkVictory.h
@@ -46,9 +46,9 @@ NS_SWIFT_NAME(CrashReportSinkVictory)
  * @param userName The user name of crash information *required. If value is nil it will be replaced with UIDevice.currentDevice.name
  * @param userEmail The user email of crash information *optional
  */
-+ (KSCrashReportSinkVictory*) sinkWithURL:(NSURL*) url
-                                 userName:(nullable NSString*) userName
-                                userEmail:(nullable NSString*) userEmail;
++ (instancetype) sinkWithURL:(NSURL*) url
+                    userName:(nullable NSString*) userName
+                   userEmail:(nullable NSString*) userEmail;
 
 /** Constructor.
  *

--- a/Tests/KSCrashInstallationsTests/KSCrashInstallationEmail_Tests.m
+++ b/Tests/KSCrashInstallationsTests/KSCrashInstallationEmail_Tests.m
@@ -56,10 +56,13 @@
 - (void) testInstallInvalid
 {
     KSCrashInstallationEmail* installation = [KSCrashInstallationEmail sharedInstance];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     installation.recipients = nil;
     installation.subject = nil;
     installation.message = nil;
     installation.filenameFmt = nil;
+#pragma clang diagnostic pop
     [installation addUnconditionalAlertWithTitle:@"title" message:@"message" dismissButtonText:@"dismiss"];
     [installation installWithConfiguration:nil];
     [installation sendAllReportsWithCompletion:^(__unused NSArray *filteredReports, BOOL completed, NSError *error)

--- a/Tests/KSCrashInstallationsTests/KSCrashInstallationQuincyHockey_Tests.m
+++ b/Tests/KSCrashInstallationsTests/KSCrashInstallationQuincyHockey_Tests.m
@@ -60,7 +60,10 @@
 - (void) testQuincyInstallMissingProperties
 {
     KSCrashInstallationQuincy* installation = [KSCrashInstallationQuincy sharedInstance];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     installation.url = nil;
+#pragma clang diagnostic pop
     [installation installWithConfiguration:nil];
     [installation sendAllReportsWithCompletion:^(__unused NSArray *filteredReports, BOOL completed, NSError *error)
      {

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_Memory_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_Memory_Tests.m
@@ -196,16 +196,16 @@
 
 - (void) testTransitionState
 {
-    XCTAssertFalse(ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionStateStartupPrewarm));
-    XCTAssertFalse(ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionStateBackground));
-    XCTAssertFalse(ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionStateTerminating));
-    XCTAssertFalse(ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionStateExiting));
+    XCTAssertFalse(ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionStateStartupPrewarm));
+    XCTAssertFalse(ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionStateBackground));
+    XCTAssertFalse(ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionStateTerminating));
+    XCTAssertFalse(ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionStateExiting));
     
-    XCTAssertTrue(ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionStateStartup));
-    XCTAssertTrue(ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionStateLaunching));
-    XCTAssertTrue(ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionStateForegrounding));
-    XCTAssertTrue(ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionStateActive));
-    XCTAssertTrue(ksapp_transition_state_is_user_perceptible(KSCrashAppTransitionStateDeactivating));
+    XCTAssertTrue(ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionStateStartup));
+    XCTAssertTrue(ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionStateLaunching));
+    XCTAssertTrue(ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionStateForegrounding));
+    XCTAssertTrue(ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionStateActive));
+    XCTAssertTrue(ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionStateDeactivating));
 }
 
 static KSCrashAppMemory *Memory(uint64_t footprint) {

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_Memory_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_Memory_Tests.m
@@ -168,26 +168,26 @@
     NSUInteger oomReports = 0;
     for (NSDictionary<NSString *, id> *report in reports) {
         
-        if (![report[@KSCrashField_Crash][@KSCrashField_Error][@KSCrashField_Type] isEqualToString:@KSCrashExcType_MemoryTermination]) {
+        if (![report[KSCrashField_Crash][KSCrashField_Error][KSCrashField_Type] isEqualToString:KSCrashExcType_MemoryTermination]) {
             continue;
         }
         
         oomReports++;
         
-        XCTAssertEqualObjects(report[@KSCrashField_System][@KSCrashField_AppMemory][@KSCrashField_MemoryLevel], @"terminal");
-        XCTAssertEqualObjects(report[@KSCrashField_System][@KSCrashField_AppMemory][@KSCrashField_MemoryPressure], @"normal");
-        XCTAssertEqualObjects(report[@KSCrashField_System][@KSCrashField_AppMemory][@KSCrashField_MemoryFootprint], @(100));
-        XCTAssertEqualObjects(report[@KSCrashField_System][@KSCrashField_AppMemory][@KSCrashField_MemoryRemaining], @(0));
-        XCTAssertEqualObjects(report[@KSCrashField_System][@KSCrashField_AppMemory][@KSCrashField_MemoryLimit], @(100));
+        XCTAssertEqualObjects(report[KSCrashField_System][KSCrashField_AppMemory][KSCrashField_MemoryLevel], @"terminal");
+        XCTAssertEqualObjects(report[KSCrashField_System][KSCrashField_AppMemory][KSCrashField_MemoryPressure], @"normal");
+        XCTAssertEqualObjects(report[KSCrashField_System][KSCrashField_AppMemory][KSCrashField_MemoryFootprint], @(100));
+        XCTAssertEqualObjects(report[KSCrashField_System][KSCrashField_AppMemory][KSCrashField_MemoryRemaining], @(0));
+        XCTAssertEqualObjects(report[KSCrashField_System][KSCrashField_AppMemory][KSCrashField_MemoryLimit], @(100));
         
-        XCTAssertEqualObjects(report[@KSCrashField_Crash][@KSCrashField_Error][@KSCrashField_MemoryTermination][@KSCrashField_MemoryLevel], @"terminal");
-        XCTAssertEqualObjects(report[@KSCrashField_Crash][@KSCrashField_Error][@KSCrashField_MemoryTermination][@KSCrashField_MemoryPressure], @"normal");
-        XCTAssertEqualObjects(report[@KSCrashField_Crash][@KSCrashField_Error][@KSCrashField_MemoryTermination][@KSCrashField_MemoryFootprint], @(100));
-        XCTAssertEqualObjects(report[@KSCrashField_Crash][@KSCrashField_Error][@KSCrashField_MemoryTermination][@KSCrashField_MemoryRemaining], @(0));
-        XCTAssertEqualObjects(report[@KSCrashField_Crash][@KSCrashField_Error][@KSCrashField_MemoryTermination][@KSCrashField_MemoryLimit], @(100));
+        XCTAssertEqualObjects(report[KSCrashField_Crash][KSCrashField_Error][KSCrashField_MemoryTermination][KSCrashField_MemoryLevel], @"terminal");
+        XCTAssertEqualObjects(report[KSCrashField_Crash][KSCrashField_Error][KSCrashField_MemoryTermination][KSCrashField_MemoryPressure], @"normal");
+        XCTAssertEqualObjects(report[KSCrashField_Crash][KSCrashField_Error][KSCrashField_MemoryTermination][KSCrashField_MemoryFootprint], @(100));
+        XCTAssertEqualObjects(report[KSCrashField_Crash][KSCrashField_Error][KSCrashField_MemoryTermination][KSCrashField_MemoryRemaining], @(0));
+        XCTAssertEqualObjects(report[KSCrashField_Crash][KSCrashField_Error][KSCrashField_MemoryTermination][KSCrashField_MemoryLimit], @(100));
         
-        XCTAssertEqualObjects(report [@KSCrashField_Crash][@KSCrashField_Error][@KSCrashExcType_Signal][@KSCrashField_Signal], @(SIGKILL));
-        XCTAssertEqualObjects(report [@KSCrashField_Crash][@KSCrashField_Error][@KSCrashExcType_Signal][@KSCrashField_Name], @"SIGKILL");
+        XCTAssertEqualObjects(report [KSCrashField_Crash][KSCrashField_Error][KSCrashExcType_Signal][KSCrashField_Signal], @(SIGKILL));
+        XCTAssertEqualObjects(report [KSCrashField_Crash][KSCrashField_Error][KSCrashExcType_Signal][KSCrashField_Name], @"SIGKILL");
         
     }
     


### PR DESCRIPTION
This PR introduces significant updates to the KSCrash library, focusing on enhancing compatibility with Swift, modernizing the Objective-C code, and improving maintainability. Below are the key changes made:

#### Major Changes:

1. **Swift-Compatible Initializers and Methods**:
   - Replaced all class and instance initializers with `instancetype` to ensure better compatibility and consistency across Swift and Objective-C. This change improves type safety and makes the codebase more modern and reliable.
2. **Introduction of Nullable Annotations**:
   - Applied `nullable` annotations to parameters and return types, where applicable, to clarify which values can be `nil`. This change is crucial for Swift interoperability, reducing potential runtime errors and improving code clarity.
3. **Refactor Enums to `NS_ENUM`**:
   - Updated traditional C-style enums to `NS_ENUM` to enhance type safety and facilitate smoother integration with Swift. This modification allows enums to be used more effectively in Swift, leveraging the language's type system for better safety and usability.
4. **Modernized Key Access Syntax**:
   - Replaced legacy `@KSCrashField_XXX` string literal access with `KSCrashField_XXX` constants to align with contemporary Objective-C practices. This change reduces the risk of errors associated with string literals and ensures a more maintainable codebase.
5. **Swift-Friendly Naming Conventions**:
   - Added `NS_SWIFT_NAME` annotations to key methods and properties to provide more intuitive names when accessed from Swift. This improves the developer experience, making the API more natural and easier to use in Swift projects.
