### PR TITLE
Allow custom base override

### DIFF
--- a/Sources/KSCrashRecording/KSCrash.m
+++ b/Sources/KSCrashRecording/KSCrash.m
@@ -61,6 +61,7 @@
 
 @end
 
+static NSString *gCustomBasePath = nil;
 
 static NSString* getBundleName(void)
 {
@@ -74,6 +75,11 @@ static NSString* getBundleName(void)
 
 static NSString* getBasePath(void)
 {
+    if(gCustomBasePath != nil)
+    {
+        return gCustomBasePath;
+    }
+
     NSArray* directories = NSSearchPathForDirectoriesInDomains(NSCachesDirectory,
                                                                NSUserDomainMask,
                                                                YES);
@@ -121,23 +127,23 @@ static NSString* getBasePath(void)
     }
 }
 
++ (void) setBasePath:(NSString*) basePath;
+{
+    gCustomBasePath = [basePath copy];
+}
+
 + (instancetype) sharedInstance
 {
     static KSCrash *sharedInstance = nil;
     static dispatch_once_t onceToken;
     
     dispatch_once(&onceToken, ^{
-        sharedInstance = [[KSCrash alloc] init];
+        sharedInstance = [[KSCrash alloc] initWithBasePath:getBasePath()];
     });
     return sharedInstance;
 }
 
-- (instancetype) init
-{
-    return [self initWithBasePath:getBasePath()];
-}
-
-- (instancetype) initWithBasePath:(NSString *)basePath
+- (instancetype) initWithBasePath:(NSString*) basePath
 {
     if((self = [super init]))
     {

--- a/Sources/KSCrashRecording/KSCrash.m
+++ b/Sources/KSCrashRecording/KSCrash.m
@@ -62,6 +62,7 @@
 @end
 
 static NSString *gCustomBasePath = nil;
+static BOOL gIsSharedInstanceCreated = NO;
 
 static NSString* getBundleName(void)
 {
@@ -129,6 +130,14 @@ static NSString* getBasePath(void)
 
 + (void) setBasePath:(NSString*) basePath;
 {
+    if(basePath == gCustomBasePath || [basePath isEqualToString:gCustomBasePath])
+    {
+        return;
+    }
+    if(gIsSharedInstanceCreated)
+    {
+        KSLOG_WARN(@"A shared instance of KSCrash is already created. Can't change the base path to: %@", basePath);
+    }
     gCustomBasePath = [basePath copy];
 }
 
@@ -139,6 +148,7 @@ static NSString* getBasePath(void)
     
     dispatch_once(&onceToken, ^{
         sharedInstance = [[KSCrash alloc] initWithBasePath:getBasePath()];
+        gIsSharedInstanceCreated = YES;
     });
     return sharedInstance;
 }

--- a/Sources/KSCrashRecording/include/KSCrash.h
+++ b/Sources/KSCrashRecording/include/KSCrash.h
@@ -105,8 +105,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - API -
 
-- (instancetype) init __attribute((unavailable("Use `sharedInstance` instead.")));
-+ (instancetype) new __attribute((unavailable("Use `sharedInstance` instead.")));
+- (instancetype) init NS_UNAVAILABLE;
++ (instancetype) new NS_UNAVAILABLE;
 
 /**
  * Specifies a custom base path for KSCrash installation.

--- a/Sources/KSCrashRecording/include/KSCrash.h
+++ b/Sources/KSCrashRecording/include/KSCrash.h
@@ -105,10 +105,24 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - API -
 
-/** Init KSCrash instance with custom base path. */
-- (instancetype) initWithBasePath:(NSString*) basePath;
+- (instancetype) init __attribute((unavailable("Use `sharedInstance` instead.")));
++ (instancetype) new __attribute((unavailable("Use `sharedInstance` instead.")));
+
+/**
+ * Specifies a custom base path for KSCrash installation.
+ * By default a "KSCrash" directory inside the default cache directory is used.
+ *
+ * @param basePath An absolute path to directory in which KSCrash stores the data.
+ *                 If `nil` the default directory is used.
+ *
+ * @note This method SHOULD be called before any use of `sharedInstance` method.
+ *       Any call of this method after that is ignored.
+ */
++ (void) setBasePath:(nullable NSString*) basePath;
 
 /** Get the singleton instance of the crash reporter.
+ *
+ * @note To specify a custom base direcory for KSCrash use `setBasePath:` method.
  */
 + (instancetype) sharedInstance NS_SWIFT_NAME(shared());
 


### PR DESCRIPTION
This PR removes constroctors of `KSCrash` class, but allows setting a custom base path via a helper static method.

As there are cases when shared instance of `KSCrash` is used from inside of the library code we need to make sure that base path is consistent. 

Also, in general, `KSCrash` is intended to be a singletone as the most of C API under the hood operates with global state. Multiple instances of KSCrash was never supported.