### PR TITLE
Fix Xcode 16 compilation

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,6 +29,8 @@ jobs:
         include:
           - platform: iOS
           - platform: iOS
+            xcode-version: "latest"
+          - platform: iOS
             os-version: ~16.4.0
             macos-version: "13"
             xcode-version: "14.3.1"

--- a/Sources/KSCrashRecording/include/KSCrashCConfiguration.h
+++ b/Sources/KSCrashRecording/include/KSCrashCConfiguration.h
@@ -27,6 +27,7 @@
 #ifndef KSCrashCConfiguration_h
 #define KSCrashCConfiguration_h
 
+#include <stdlib.h>
 #include "KSCrashMonitorType.h"
 #include "KSCrashReportWriter.h"
 


### PR DESCRIPTION
Adds missing include to support `NULL` macros.
Also adds a unit-test variant with latest Xcode.