### PR TITLE
Use typed crash reports

### DIFF
--- a/Sources/KSCrashFilters/KSCrashReportFilterAlert.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterAlert.m
@@ -27,6 +27,7 @@
 #import "KSCrashReportFilterAlert.h"
 
 #import "KSSystemCapabilities.h"
+#import "KSCrashReport.h"
 
 //#define KSLogger_LocalLevel TRACE
 #import "KSLogger.h"
@@ -39,7 +40,7 @@
 
 #if KSCRASH_HAS_NSALERT
 #import <AppKit/AppKit.h>
-#endif 
+#endif
 
 @interface KSCrashAlertViewProcess : NSObject
 

--- a/Sources/KSCrashFilters/KSCrashReportFilterAlert.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterAlert.m
@@ -43,7 +43,7 @@
 
 @interface KSCrashAlertViewProcess : NSObject
 
-@property(nonatomic,readwrite,retain) NSArray* reports;
+@property(nonatomic,readwrite,copy) NSArray<KSCrashReport*>* reports;
 @property(nonatomic,readwrite,copy) KSCrashReportFilterCompletion onCompletion;
 @property(nonatomic,readwrite,assign) NSInteger expectedButtonIndex;
 
@@ -53,7 +53,7 @@
                 message:(NSString*) message
               yesAnswer:(NSString*) yesAnswer
                noAnswer:(NSString*) noAnswer
-                reports:(NSArray*) reports
+                reports:(NSArray<KSCrashReport*>*) reports
            onCompletion:(KSCrashReportFilterCompletion) onCompletion;
 
 @end
@@ -73,11 +73,11 @@
                 message:(NSString*) message
               yesAnswer:(NSString*) yesAnswer
                noAnswer:(NSString*) noAnswer
-                reports:(NSArray*) reports
+                reports:(NSArray<KSCrashReport*>*) reports
            onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
     KSLOG_TRACE(@"Starting alert view process");
-    self.reports = reports;
+    self.reports = [reports copy];
     self.onCompletion = onCompletion;
     self.expectedButtonIndex = noAnswer == nil ? 0 : 1;
 
@@ -170,7 +170,7 @@
     return self;
 }
 
-- (void) filterReports:(NSArray*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
     dispatch_async(dispatch_get_main_queue(), ^
@@ -225,7 +225,7 @@
     return self;
 }
 
-- (void) filterReports:(NSArray*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
     KSLOG_WARN(@"Alert filter not available on this platform.");

--- a/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
@@ -227,7 +227,12 @@ static NSDictionary* g_registerOrders;
     for(KSCrashReport* report in reports)
     {
         NSDictionary *reportDict = report.dictionaryValue;
-        if(reportDict != nil && [self majorVersion:reportDict] == kExpectedMajorVersion)
+        if(reportDict == nil)
+        {
+            KSLOG_ERROR(@"Unexpected non-dictionary report: %@", report);
+            continue;
+        }
+        if([self majorVersion:reportDict] == kExpectedMajorVersion)
         {
             NSString* appleReportString = [self toAppleFormat:reportDict];
             if(appleReportString != nil)

--- a/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
@@ -27,6 +27,7 @@
 
 #import "KSCrashReportFilterAppleFmt.h"
 #import "KSSystemCapabilities.h"
+#import "KSCrashReport.h"
 
 #import <inttypes.h>
 #import <mach/machine.h>

--- a/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
@@ -37,6 +37,9 @@
 #import "KSJSONCodecObjC.h"
 #import "KSCPU.h"
 
+//#define KSLogger_LocalLevel TRACE
+#import "KSLogger.h"
+
 #if defined(__LP64__)
     #define FMT_LONG_DIGITS "16"
     #define FMT_RJ_SPACES "18"

--- a/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
@@ -219,18 +219,19 @@ static NSDictionary* g_registerOrders;
     return 0;
 }
 
-- (void) filterReports:(NSArray*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
-    NSMutableArray* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for(NSDictionary* report in reports)
+    NSMutableArray<KSCrashReport*>* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for(KSCrashReport* report in reports)
     {
-        if([self majorVersion:report] == kExpectedMajorVersion)
+        NSDictionary *reportDict = report.dictionaryValue;
+        if(reportDict != nil && [self majorVersion:reportDict] == kExpectedMajorVersion)
         {
-            id appleReport = [self toAppleFormat:report];
-            if(appleReport != nil)
+            NSString* appleReportString = [self toAppleFormat:reportDict];
+            if(appleReportString != nil)
             {
-                [filteredReports addObject:appleReport];
+                [filteredReports addObject:[KSCrashReport reportWithString:appleReportString]];
             }
         }
     }

--- a/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
@@ -29,6 +29,7 @@
 #import "NSError+SimpleConstructor.h"
 #import "Container+DeepSearch.h"
 #import "KSVarArgs.h"
+#import "KSCrashReport.h"
 
 //#define KSLogger_LocalLevel TRACE
 #import "KSLogger.h"

--- a/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
@@ -41,7 +41,7 @@
     return [[self alloc] init];
 }
 
-- (void) filterReports:(NSArray*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
     kscrash_callCompletion(onCompletion, reports, YES, nil);
@@ -132,7 +132,7 @@
     return [self initWithFilters:filters keys:keys];
 }
 
-- (void) filterReports:(NSArray*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
     NSArray* filters = self.filters;
@@ -168,7 +168,7 @@
                                                                    filterCompletion = nil;
                                                                });
                                             } copy];
-    filterCompletion = [^(NSArray* filteredReports,
+    filterCompletion = [^(NSArray<KSCrashReport*>* filteredReports,
                           BOOL completed,
                           NSError* filterError)
                         {
@@ -204,20 +204,21 @@
                             // All filters complete, or a filter failed.
                             // Build final "filteredReports" array.
                             NSUInteger reportCount = [(NSArray*)[reportSets objectAtIndex:0] count];
-                            NSMutableArray* combinedReports = [NSMutableArray arrayWithCapacity:reportCount];
+                            NSMutableArray<KSCrashReport*>* combinedReports = [NSMutableArray arrayWithCapacity:reportCount];
                             for(NSUInteger iReport = 0; iReport < reportCount; iReport++)
                             {
                                 NSMutableDictionary* dict = [NSMutableDictionary dictionaryWithCapacity:filterCount];
                                 for(NSUInteger iSet = 0; iSet < filterCount; iSet++)
                                 {
-                                    NSArray* reportSet = [reportSets objectAtIndex:iSet];
-                                    if(reportSet.count>iReport){
-                                        NSDictionary* report = [reportSet objectAtIndex:iReport];
-                                        [dict setObject:report
-                                                 forKey:[keys objectAtIndex:iSet]];
+                                    NSString* key = keys[iSet];
+                                    NSArray* reportSet = reportSets[iSet];
+                                    if(iReport < reportSet.count){
+                                        KSCrashReport* report = reportSet[iReport];
+                                        dict[key] = report.dictionaryValue;
                                     }
                                 }
-                                [combinedReports addObject:dict];
+                                KSCrashReport* report = [KSCrashReport reportWithDictionary:dict];
+                                [combinedReports addObject:report];
                             }
                             
                             kscrash_callCompletion(onCompletion, combinedReports, completed, filterError);
@@ -288,7 +289,7 @@
     self.filters = [@[filter] arrayByAddingObjectsFromArray:self.filters];
 }
 
-- (void) filterReports:(NSArray*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
     NSArray* filters = self.filters;
@@ -311,7 +312,7 @@
                                                                    filterCompletion = nil;
                                                                });
                                             } copy];
-    filterCompletion = [^(NSArray* filteredReports,
+    filterCompletion = [^(NSArray<KSCrashReport*>* filteredReports,
                           BOOL completed,
                           NSError* filterError)
                         {
@@ -353,71 +354,6 @@
     // Initial call with first filter to start everything going.
     id<KSCrashReportFilter> filter = [filters objectAtIndex:iFilter];
     [filter filterReports:reports onCompletion:filterCompletion];
-}
-
-@end
-
-
-@interface KSCrashReportFilterObjectForKey ()
-
-@property(nonatomic, readwrite, retain) id key;
-@property(nonatomic, readwrite, assign) BOOL allowNotFound;
-
-@end
-
-@implementation KSCrashReportFilterObjectForKey
-
-@synthesize key = _key;
-@synthesize allowNotFound = _allowNotFound;
-
-+ (instancetype) filterWithKey:(id)key allowNotFound:(BOOL) allowNotFound
-{
-    return [[self alloc] initWithKey:key allowNotFound:allowNotFound];
-}
-
-- (instancetype) initWithKey:(id)key allowNotFound:(BOOL) allowNotFound
-{
-    if((self = [super init]))
-    {
-        self.key = key;
-        self.allowNotFound = allowNotFound;
-    }
-    return self;
-}
-
-- (void) filterReports:(NSArray*) reports
-          onCompletion:(KSCrashReportFilterCompletion) onCompletion
-{
-    NSMutableArray* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for(NSDictionary* report in reports)
-    {
-        id object = nil;
-        if([self.key isKindOfClass:[NSString class]])
-        {
-            object = [report objectForKeyPath:self.key];
-        }
-        else
-        {
-            object = [report objectForKey:self.key];
-        }
-        if(object == nil)
-        {
-            if(!self.allowNotFound)
-            {
-                kscrash_callCompletion(onCompletion, filteredReports, NO,
-                                         [NSError errorWithDomain:[[self class] description]
-                                                             code:0
-                                                      description:@"Key not found: %@", self.key]);
-                return;
-            }
-            [filteredReports addObject:[NSDictionary dictionary]];
-        }
-        else
-        {
-            [filteredReports addObject:object];
-        }
-    }
-    kscrash_callCompletion(onCompletion, filteredReports, YES, nil);
 }
 
 @end
@@ -475,11 +411,11 @@
     return self;
 }
 
-- (void) filterReports:(NSArray*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
     NSMutableArray* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for(NSDictionary* report in reports)
+    for(KSCrashReport* report in reports)
     {
         BOOL firstEntry = YES;
         NSMutableString* concatenated = [NSMutableString string];
@@ -493,7 +429,7 @@
             {
                 [concatenated appendFormat:self.separatorFmt, key];
             }
-            id object = [report objectForKeyPath:key];
+            id object = [report.dictionaryValue objectForKeyPath:key];
             [concatenated appendFormat:@"%@", object];
         }
         [filteredReports addObject:concatenated];
@@ -553,16 +489,22 @@
     return self;
 }
 
-- (void) filterReports:(NSArray*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
-    NSMutableArray* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for(NSDictionary* report in reports)
+    NSMutableArray<KSCrashReport*>* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for(KSCrashReport* report in reports)
     {
+        NSDictionary *reportDict = report.dictionaryValue;
+        if(reportDict == nil)
+        {
+            continue;
+        }
+
         NSMutableDictionary* subset = [NSMutableDictionary dictionary];
         for(NSString* keyPath in self.keyPaths)
         {
-            id object = [report objectForKeyPath:keyPath];
+            id object = [reportDict objectForKeyPath:keyPath];
             if(object == nil)
             {
                 kscrash_callCompletion(onCompletion, filteredReports, NO,
@@ -573,7 +515,8 @@
             }
             [subset setObject:object forKey:[keyPath lastPathComponent]];
         }
-        [filteredReports addObject:subset];
+        KSCrashReport *subsetReport = [KSCrashReport reportWithDictionary:subset];
+        [filteredReports addObject:subsetReport];
     }
     kscrash_callCompletion(onCompletion, filteredReports, YES, nil);
 }
@@ -588,14 +531,20 @@
     return [[self alloc] init];
 }
 
-- (void) filterReports:(NSArray*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
-    NSMutableArray* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for(NSData* report in reports)
+    NSMutableArray<KSCrashReport*>* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for(KSCrashReport* report in reports)
     {
-        NSString* converted = [[NSString alloc] initWithData:report encoding:NSUTF8StringEncoding];
-        [filteredReports addObject:converted];
+        NSData* data = report.dataValue;
+        if(data == nil)
+        {
+            continue;
+        }
+
+        NSString* converted = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        [filteredReports addObject:[KSCrashReport reportWithString:converted]];
     }
 
     kscrash_callCompletion(onCompletion, filteredReports, YES, nil);
@@ -611,13 +560,19 @@
     return [[self alloc] init];
 }
 
-- (void) filterReports:(NSArray*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
-    NSMutableArray* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for(NSString* report in reports)
+    NSMutableArray<KSCrashReport*>* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for(KSCrashReport* report in reports)
     {
-        NSData* converted = [report dataUsingEncoding:NSUTF8StringEncoding];
+        NSString* string = report.stringValue;
+        if(string == nil)
+        {
+            continue;
+        }
+
+        NSData* converted = [string dataUsingEncoding:NSUTF8StringEncoding];
         if(converted == nil)
         {
             kscrash_callCompletion(onCompletion, filteredReports, NO,
@@ -628,7 +583,7 @@
         }
         else
         {
-            [filteredReports addObject:converted];
+            [filteredReports addObject:[KSCrashReport reportWithData:converted]];
         }
     }
 

--- a/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
@@ -499,6 +499,7 @@
         NSDictionary *reportDict = report.dictionaryValue;
         if(reportDict == nil)
         {
+            KSLOG_ERROR(@"Unexpected non-dictionary report: %@", report);
             continue;
         }
 
@@ -541,6 +542,7 @@
         NSData* data = report.dataValue;
         if(data == nil)
         {
+            KSLOG_ERROR(@"Unexpected non-data report: %@", report);
             continue;
         }
 
@@ -570,6 +572,7 @@
         NSString* string = report.stringValue;
         if(string == nil)
         {
+            KSLOG_ERROR(@"Unexpected non-string report: %@", report);
             continue;
         }
 

--- a/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
@@ -215,7 +215,7 @@
                                     NSArray* reportSet = reportSets[iSet];
                                     if(iReport < reportSet.count){
                                         KSCrashReport* report = reportSet[iReport];
-                                        dict[key] = report.dictionaryValue;
+                                        dict[key] = report.dictionaryValue ?: report.stringValue ?: report.dataValue;
                                     }
                                 }
                                 KSCrashReport* report = [KSCrashReport reportWithDictionary:dict];

--- a/Sources/KSCrashFilters/KSCrashReportFilterGZip.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterGZip.m
@@ -29,6 +29,8 @@
 #import "NSData+KSGZip.h"
 #import "KSCrashReport.h"
 
+//#define KSLogger_LocalLevel TRACE
+#import "KSLogger.h"
 
 @interface KSCrashReportFilterGZipCompress ()
 
@@ -63,8 +65,7 @@
         NSData* data = report.dataValue;
         if(data == nil)
         {
-            // TODO: Log or return error
-            [filteredReports addObject:report];
+            KSLOG_ERROR(@"Unexpected non-data report: %@", report);
             continue;
         }
 
@@ -104,6 +105,7 @@
         NSData* data = report.dataValue;
         if(data == nil)
         {
+            KSLOG_ERROR(@"Unexpected non-data report: %@", report);
             continue;
         }
 

--- a/Sources/KSCrashFilters/KSCrashReportFilterGZip.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterGZip.m
@@ -53,15 +53,23 @@
     return self;
 }
 
-- (void) filterReports:(NSArray*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
-    NSMutableArray* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for(NSData* report in reports)
+    NSMutableArray<KSCrashReport*>* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for(KSCrashReport* report in reports)
     {
+        NSData* data = report.dataValue;
+        if(data == nil)
+        {
+            // TODO: Log or return error
+            [filteredReports addObject:report];
+            continue;
+        }
+
         NSError* error = nil;
-        NSData* compressedData = [report gzippedWithCompressionLevel:(int)self.compressionLevel
-                                                               error:&error];
+        NSData* compressedData = [data gzippedWithCompressionLevel:(int)self.compressionLevel
+                                                             error:&error];
         if(compressedData == nil)
         {
             kscrash_callCompletion(onCompletion, filteredReports, NO, error);
@@ -69,7 +77,7 @@
         }
         else
         {
-            [filteredReports addObject:compressedData];
+            [filteredReports addObject:[KSCrashReport reportWithData:compressedData]];
         }
     }
 
@@ -86,14 +94,20 @@
     return [[self alloc] init];
 }
 
-- (void) filterReports:(NSArray*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
-    NSMutableArray* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for(NSData* report in reports)
+    NSMutableArray<KSCrashReport*>* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for(KSCrashReport* report in reports)
     {
+        NSData* data = report.dataValue;
+        if(data == nil)
+        {
+            continue;
+        }
+
         NSError* error = nil;
-        NSData* decompressedData = [report gunzippedWithError:&error];
+        NSData* decompressedData = [data gunzippedWithError:&error];
         if(decompressedData == nil)
         {
             kscrash_callCompletion(onCompletion, filteredReports, NO, error);
@@ -101,7 +115,7 @@
         }
         else
         {
-            [filteredReports addObject:decompressedData];
+            [filteredReports addObject:[KSCrashReport reportWithData:decompressedData]];
         }
     }
 

--- a/Sources/KSCrashFilters/KSCrashReportFilterGZip.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterGZip.m
@@ -27,6 +27,7 @@
 
 #import "KSCrashReportFilterGZip.h"
 #import "NSData+KSGZip.h"
+#import "KSCrashReport.h"
 
 
 @interface KSCrashReportFilterGZipCompress ()

--- a/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
@@ -133,7 +133,7 @@
         NSDictionary* decodedReport = [KSJSONCodec decode:data
                                                   options:self.decodeOptions
                                                     error:&error];
-        if(report == nil)
+        if(decodedReport == nil)
         {
             kscrash_callCompletion(onCompletion, filteredReports, NO, error);
             return;

--- a/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
@@ -66,7 +66,7 @@
         NSDictionary *reportDict = report.dictionaryValue;
         if(reportDict == nil)
         {
-            [filteredReports addObject:report];
+            KSLOG_ERROR(@"Unexpected non-dictionary report: %@", report);
             continue;
         }
 
@@ -125,6 +125,7 @@
         NSData *data = report.dataValue;
         if(data == nil)
         {
+            KSLOG_ERROR(@"Unexpected non-data report: %@", report);
             continue;
         }
 

--- a/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
@@ -56,14 +56,21 @@
     return self;
 }
 
-- (void) filterReports:(NSArray*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
-    NSMutableArray* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for(NSDictionary* report in reports)
+    NSMutableArray<KSCrashReport*>* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for(KSCrashReport* report in reports)
     {
+        NSDictionary *reportDict = report.dictionaryValue;
+        if(reportDict == nil)
+        {
+            [filteredReports addObject:report];
+            continue;
+        }
+
         NSError* error = nil;
-        NSData* jsonData = [KSJSONCodec encode:report
+        NSData* jsonData = [KSJSONCodec encode:reportDict
                                        options:self.encodeOptions
                                          error:&error];
         if(jsonData == nil)
@@ -73,7 +80,7 @@
         }
         else
         {
-            [filteredReports addObject:jsonData];
+            [filteredReports addObject:[KSCrashReport reportWithData:jsonData]];
         }
     }
 
@@ -108,16 +115,22 @@
     return self;
 }
 
-- (void) filterReports:(NSArray*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
-    NSMutableArray* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for(NSData* data in reports)
+    NSMutableArray<KSCrashReport*>* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for(KSCrashReport* report in reports)
     {
+        NSData *data = report.dataValue;
+        if(data == nil)
+        {
+            continue;
+        }
+
         NSError* error = nil;
-        NSDictionary* report = [KSJSONCodec decode:data
-                                           options:self.decodeOptions
-                                             error:&error];
+        NSDictionary* decodedReport = [KSJSONCodec decode:data
+                                                  options:self.decodeOptions
+                                                    error:&error];
         if(report == nil)
         {
             kscrash_callCompletion(onCompletion, filteredReports, NO, error);
@@ -125,7 +138,7 @@
         }
         else
         {
-            [filteredReports addObject:report];
+            [filteredReports addObject:[KSCrashReport reportWithDictionary:decodedReport]];
         }
     }
 

--- a/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
@@ -26,6 +26,7 @@
 
 
 #import "KSCrashReportFilterJSON.h"
+#import "KSCrashReport.h"
 
 //#define KSLogger_LocalLevel TRACE
 #import "KSLogger.h"

--- a/Sources/KSCrashFilters/KSCrashReportFilterStringify.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterStringify.m
@@ -33,17 +33,26 @@
     return [[self alloc] init];
 }
 
-- (NSString*) stringifyObject:(id) object
+- (NSString*) stringifyReport:(KSCrashReport*) report
 {
-    if([object isKindOfClass:[NSString class]])
+    if(report.stringValue != nil)
     {
-        return object;
+        return report.stringValue;
     }
-    if([object isKindOfClass:[NSData class]])
+    if(report.dataValue != nil)
     {
-        return [[NSString alloc] initWithData:object encoding:NSUTF8StringEncoding];
+        return [[NSString alloc] initWithData:report.dataValue encoding:NSUTF8StringEncoding];
     }
-    return [NSString stringWithFormat:@"%@", object];
+    if(report.dictionaryValue != nil)
+    {
+        if([NSJSONSerialization isValidJSONObject:report.dictionaryValue])
+        {
+            NSData* data = [NSJSONSerialization dataWithJSONObject:report.dictionaryValue options:0 error:nil];
+            return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        }
+        return [NSString stringWithFormat:@"%@", report.dictionaryValue];
+    }
+    return [NSString stringWithFormat:@"%@", report];
 }
 
 - (void) filterReports:(NSArray<KSCrashReport*>*) reports
@@ -52,7 +61,7 @@
     NSMutableArray<KSCrashReport*>* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
     for(KSCrashReport* report in reports)
     {
-        NSString *reportString = [self stringifyObject:report];
+        NSString *reportString = [self stringifyReport:report];
         [filteredReports addObject:[KSCrashReport reportWithString:reportString]];
     }
     

--- a/Sources/KSCrashFilters/KSCrashReportFilterStringify.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterStringify.m
@@ -26,6 +26,9 @@
 #import "KSCrashReportFilterStringify.h"
 #import "KSCrashReport.h"
 
+//#define KSLogger_LocalLevel TRACE
+#import "KSLogger.h"
+
 @implementation KSCrashReportFilterStringify
 
 + (instancetype) filter

--- a/Sources/KSCrashFilters/KSCrashReportFilterStringify.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterStringify.m
@@ -24,6 +24,7 @@
 //
 
 #import "KSCrashReportFilterStringify.h"
+#import "KSCrashReport.h"
 
 @implementation KSCrashReportFilterStringify
 

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
@@ -152,33 +152,6 @@ NS_SWIFT_NAME(CrashReportFilterPipeline)
 
 
 /**
- * Extracts data associated with a key from each report.
- */
-NS_SWIFT_NAME(CrashReportFilterObjectForKey)
-@interface KSCrashReportFilterObjectForKey : NSObject <KSCrashReportFilter>
-
-/** Constructor.
- *
- * @param key The key to search for in each report. If the key is a string,
- *            it will be interpreted as a key path.
- * @param allowNotFound If NO, filtering will stop with an error if the key
- *                      was not found in a report.
- */
-+ (instancetype) filterWithKey:(id) key allowNotFound:(BOOL) allowNotFound;
-
-/** Initializer.
- *
- * @param key The key to search for in each report. If the key is a string,
- *            it will be interpreted as a key path.
- * @param allowNotFound If NO, filtering will stop with an error if the key
- *                      was not found in a report.
- */
-- (instancetype) initWithKey:(id) key allowNotFound:(BOOL) allowNotFound;
-
-@end
-
-
-/**
  * Takes values by key from the report and concatenates their string representations.
  *
  * Input: NSDictionary

--- a/Sources/KSCrashRecording/KSCrash.m
+++ b/Sources/KSCrashRecording/KSCrash.m
@@ -350,7 +350,7 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     return kscrash_getReportCount();
 }
 
-- (void) sendReports:(NSArray*) reports onCompletion:(KSCrashReportFilterCompletion) onCompletion
+- (void) sendReports:(NSArray<KSCrashReport*>*) reports onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
     if([reports count] == 0)
     {

--- a/Sources/KSCrashRecording/KSCrashC.c
+++ b/Sources/KSCrashRecording/KSCrashC.c
@@ -28,7 +28,7 @@
 #include "KSCrashC.h"
 
 #include "KSCrashCachedData.h"
-#include "KSCrashReport.h"
+#include "KSCrashReportC.h"
 #include "KSCrashReportFixer.h"
 #include "KSCrashReportStore.h"
 #include "KSCrashMonitorType.h"

--- a/Sources/KSCrashRecording/KSCrashReport.m
+++ b/Sources/KSCrashRecording/KSCrashReport.m
@@ -1,6 +1,7 @@
 //
-//  KSCrashReportFilterStringify.m
-//  KSCrash
+//  KSCrashReport.m
+//
+//  Created by Nikolay Volosatov on 2024-06-23.
 //
 //  Copyright (c) 2012 Karl Stenerud. All rights reserved.
 //
@@ -23,39 +24,37 @@
 // THE SOFTWARE.
 //
 
-#import "KSCrashReportFilterStringify.h"
+#import "KSCrashReport.h"
 
-@implementation KSCrashReportFilterStringify
+@implementation KSCrashReport
 
-+ (instancetype) filter
+- (instancetype)initWithDictionaryValue:(NSDictionary<NSString *,id> *)dictionaryValue
+                            stringValue:(NSString *)stringValue
+                              dataValue:(NSData *)dataValue
 {
-    return [[self alloc] init];
+    self = [super init];
+    if(self != nil)
+    {
+        _dictionaryValue = [dictionaryValue copy];
+        _stringValue = [stringValue copy];
+        _dataValue = [dataValue copy];
+    }
+    return self;
 }
 
-- (NSString*) stringifyObject:(id) object
++ (instancetype) reportWithDictionary:(NSDictionary<NSString*, id>*) dictionaryValue
 {
-    if([object isKindOfClass:[NSString class]])
-    {
-        return object;
-    }
-    if([object isKindOfClass:[NSData class]])
-    {
-        return [[NSString alloc] initWithData:object encoding:NSUTF8StringEncoding];
-    }
-    return [NSString stringWithFormat:@"%@", object];
+    return [[KSCrashReport alloc] initWithDictionaryValue:dictionaryValue stringValue:nil dataValue:nil];
 }
 
-- (void) filterReports:(NSArray<KSCrashReport*>*) reports
-          onCompletion:(KSCrashReportFilterCompletion) onCompletion
++ (instancetype) reportWithString:(NSString*) stringValue
 {
-    NSMutableArray<KSCrashReport*>* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for(KSCrashReport* report in reports)
-    {
-        NSString *reportString = [self stringifyObject:report];
-        [filteredReports addObject:[KSCrashReport reportWithString:reportString]];
-    }
-    
-    kscrash_callCompletion(onCompletion, filteredReports, YES, nil);
+    return [[KSCrashReport alloc] initWithDictionaryValue:nil stringValue:stringValue dataValue:nil];
+}
+
++ (instancetype) reportWithData:(NSData*) dataValue
+{
+    return [[KSCrashReport alloc] initWithDictionaryValue:nil stringValue:nil dataValue:dataValue];
 }
 
 @end

--- a/Sources/KSCrashRecording/KSCrashReport.m
+++ b/Sources/KSCrashRecording/KSCrashReport.m
@@ -71,4 +71,9 @@
 #undef SAME_OR_EQUAL
 }
 
+- (NSString*) description
+{
+    return [(self.stringValue ?: self.dictionaryValue ?: self.dataValue) description];
+}
+
 @end

--- a/Sources/KSCrashRecording/KSCrashReport.m
+++ b/Sources/KSCrashRecording/KSCrashReport.m
@@ -28,15 +28,15 @@
 
 @implementation KSCrashReport
 
-- (instancetype) initWithReportType:(KSCrashReportType) reportType
-                    dictionaryValue:(nullable NSDictionary<NSString*, id>*) dictionaryValue
-                        stringValue:(nullable NSString*) stringValue
-                          dataValue:(nullable NSData*) dataValue
+- (instancetype) initWithValueType:(KSCrashReportValueType) valueType
+                   dictionaryValue:(nullable NSDictionary<NSString*, id>*) dictionaryValue
+                       stringValue:(nullable NSString*) stringValue
+                         dataValue:(nullable NSData*) dataValue
 {
     self = [super init];
     if(self != nil)
     {
-        _reportType = reportType;
+        _valueType = valueType;
         _dictionaryValue = [dictionaryValue copy];
         _stringValue = [stringValue copy];
         _dataValue = [dataValue copy];
@@ -46,26 +46,26 @@
 
 + (instancetype) reportWithDictionary:(NSDictionary<NSString*, id>*) dictionaryValue
 {
-    return [[KSCrashReport alloc] initWithReportType:KSCrashReportTypeDictionary
-                                     dictionaryValue:dictionaryValue
-                                         stringValue:nil
-                                           dataValue:nil];
+    return [[KSCrashReport alloc] initWithValueType:KSCrashReportValueTypeDictionary
+                                    dictionaryValue:dictionaryValue
+                                        stringValue:nil
+                                          dataValue:nil];
 }
 
 + (instancetype) reportWithString:(NSString*) stringValue
 {
-    return [[KSCrashReport alloc] initWithReportType:KSCrashReportTypeString
-                                     dictionaryValue:nil
-                                         stringValue:stringValue
-                                           dataValue:nil];
+    return [[KSCrashReport alloc] initWithValueType:KSCrashReportValueTypeString
+                                    dictionaryValue:nil
+                                        stringValue:stringValue
+                                          dataValue:nil];
 }
 
 + (instancetype) reportWithData:(NSData*) dataValue
 {
-    return [[KSCrashReport alloc] initWithReportType:KSCrashReportTypeData
-                                     dictionaryValue:nil
-                                         stringValue:nil
-                                           dataValue:dataValue];
+    return [[KSCrashReport alloc] initWithValueType:KSCrashReportValueTypeData
+                                    dictionaryValue:nil
+                                        stringValue:nil
+                                          dataValue:dataValue];
 }
 
 - (BOOL) isEqual:(id) object
@@ -76,7 +76,7 @@
     }
     KSCrashReport *other = object;
 #define SAME_OR_EQUAL(GETTER) ((self.GETTER) == (other.GETTER) || [(self.GETTER) isEqual:(other.GETTER)])
-    return self.reportType == other.reportType
+    return self.valueType == other.valueType
         && SAME_OR_EQUAL(stringValue)
         && SAME_OR_EQUAL(dictionaryValue)
         && SAME_OR_EQUAL(dataValue);
@@ -85,13 +85,13 @@
 
 - (NSString*) description
 {
-    switch(self.reportType)
+    switch(self.valueType)
     {
-        case KSCrashReportTypeDictionary:
+        case KSCrashReportValueTypeDictionary:
             return [self.dictionaryValue description];
-        case KSCrashReportTypeString:
+        case KSCrashReportValueTypeString:
             return [self.stringValue description];
-        case KSCrashReportTypeData:
+        case KSCrashReportValueTypeData:
             return [self.dataValue description];
     }
 }

--- a/Sources/KSCrashRecording/KSCrashReport.m
+++ b/Sources/KSCrashRecording/KSCrashReport.m
@@ -57,4 +57,18 @@
     return [[KSCrashReport alloc] initWithDictionaryValue:nil stringValue:nil dataValue:dataValue];
 }
 
+- (BOOL) isEqual:(id) object
+{
+    if([object isKindOfClass:[KSCrashReport class]] == NO)
+    {
+        return NO;
+    }
+    KSCrashReport *other = object;
+#define SAME_OR_EQUAL(GETTER) ((self.GETTER) == (other.GETTER) || [(self.GETTER) isEqual:(other.GETTER)])
+    return SAME_OR_EQUAL(stringValue)
+        && SAME_OR_EQUAL(dictionaryValue)
+        && SAME_OR_EQUAL(dataValue);
+#undef SAME_OR_EQUAL
+}
+
 @end

--- a/Sources/KSCrashRecording/KSCrashReport.m
+++ b/Sources/KSCrashRecording/KSCrashReport.m
@@ -28,13 +28,15 @@
 
 @implementation KSCrashReport
 
-- (instancetype)initWithDictionaryValue:(NSDictionary<NSString *,id> *)dictionaryValue
-                            stringValue:(NSString *)stringValue
-                              dataValue:(NSData *)dataValue
+- (instancetype) initWithReportType:(KSCrashReportType) reportType
+                    dictionaryValue:(nullable NSDictionary<NSString*, id>*) dictionaryValue
+                        stringValue:(nullable NSString*) stringValue
+                          dataValue:(nullable NSData*) dataValue
 {
     self = [super init];
     if(self != nil)
     {
+        _reportType = reportType;
         _dictionaryValue = [dictionaryValue copy];
         _stringValue = [stringValue copy];
         _dataValue = [dataValue copy];
@@ -44,17 +46,26 @@
 
 + (instancetype) reportWithDictionary:(NSDictionary<NSString*, id>*) dictionaryValue
 {
-    return [[KSCrashReport alloc] initWithDictionaryValue:dictionaryValue stringValue:nil dataValue:nil];
+    return [[KSCrashReport alloc] initWithReportType:KSCrashReportTypeDictionary
+                                     dictionaryValue:dictionaryValue
+                                         stringValue:nil
+                                           dataValue:nil];
 }
 
 + (instancetype) reportWithString:(NSString*) stringValue
 {
-    return [[KSCrashReport alloc] initWithDictionaryValue:nil stringValue:stringValue dataValue:nil];
+    return [[KSCrashReport alloc] initWithReportType:KSCrashReportTypeString
+                                     dictionaryValue:nil
+                                         stringValue:stringValue
+                                           dataValue:nil];
 }
 
 + (instancetype) reportWithData:(NSData*) dataValue
 {
-    return [[KSCrashReport alloc] initWithDictionaryValue:nil stringValue:nil dataValue:dataValue];
+    return [[KSCrashReport alloc] initWithReportType:KSCrashReportTypeData
+                                     dictionaryValue:nil
+                                         stringValue:nil
+                                           dataValue:dataValue];
 }
 
 - (BOOL) isEqual:(id) object
@@ -65,7 +76,8 @@
     }
     KSCrashReport *other = object;
 #define SAME_OR_EQUAL(GETTER) ((self.GETTER) == (other.GETTER) || [(self.GETTER) isEqual:(other.GETTER)])
-    return SAME_OR_EQUAL(stringValue)
+    return self.reportType == other.reportType
+        && SAME_OR_EQUAL(stringValue)
         && SAME_OR_EQUAL(dictionaryValue)
         && SAME_OR_EQUAL(dataValue);
 #undef SAME_OR_EQUAL
@@ -73,7 +85,15 @@
 
 - (NSString*) description
 {
-    return [(self.stringValue ?: self.dictionaryValue ?: self.dataValue) description];
+    switch(self.reportType)
+    {
+        case KSCrashReportTypeDictionary:
+            return [self.dictionaryValue description];
+        case KSCrashReportTypeString:
+            return [self.stringValue description];
+        case KSCrashReportTypeData:
+            return [self.dataValue description];
+    }
 }
 
 @end

--- a/Sources/KSCrashRecording/KSCrashReportC.c
+++ b/Sources/KSCrashRecording/KSCrashReportC.c
@@ -25,7 +25,7 @@
 //
 
 
-#include "KSCrashReport.h"
+#include "KSCrashReportC.h"
 
 #include "KSString.h"
 #include "KSCrashReportFields.h"

--- a/Sources/KSCrashRecording/KSCrashReportC.h
+++ b/Sources/KSCrashRecording/KSCrashReportC.h
@@ -1,5 +1,5 @@
 //
-//  KSCrashReport.h
+//  KSCrashReportC.h
 //
 //  Created by Karl Stenerud on 2012-01-28.
 //

--- a/Sources/KSCrashRecording/include/KSCrashReport.h
+++ b/Sources/KSCrashRecording/include/KSCrashReport.h
@@ -28,11 +28,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSUInteger, KSCrashReportType) {
-    KSCrashReportTypeDictionary,
-    KSCrashReportTypeString,
-    KSCrashReportTypeData,
-};
+typedef NS_ENUM(NSUInteger, KSCrashReportValueType) {
+    KSCrashReportValueTypeDictionary,
+    KSCrashReportValueTypeString,
+    KSCrashReportValueTypeData,
+} NS_SWIFT_NAME(CrashReportValueType);
 
 /**
  * A class that represent a recorded crash report.
@@ -42,9 +42,9 @@ NS_SWIFT_NAME(CrashReport)
 @interface KSCrashReport : NSObject
 
 /**
- * This report type defines which one of the value properties below is populated.
+ * The type of the value of this crash report (dictionary, string, data)
  */
-@property (nonatomic, readonly, assign) KSCrashReportType reportType;
+@property (nonatomic, readonly, assign) KSCrashReportValueType valueType;
 
 /**
  * A structured dictionary version of crash report.
@@ -66,10 +66,10 @@ NS_SWIFT_NAME(CrashReport)
 - (instancetype) init NS_UNAVAILABLE;
 + (instancetype) new NS_UNAVAILABLE;
 
-- (instancetype) initWithReportType:(KSCrashReportType) reportType
-                    dictionaryValue:(nullable NSDictionary<NSString*, id>*) dictionaryValue
-                        stringValue:(nullable NSString*) stringValue
-                          dataValue:(nullable NSData*) dataValue NS_DESIGNATED_INITIALIZER;
+- (instancetype) initWithValueType:(KSCrashReportValueType) valueType
+                   dictionaryValue:(nullable NSDictionary<NSString*, id>*) dictionaryValue
+                       stringValue:(nullable NSString*) stringValue
+                         dataValue:(nullable NSData*) dataValue NS_DESIGNATED_INITIALIZER;
 
 + (instancetype) reportWithDictionary:(NSDictionary<NSString*, id>*) dictionaryValue;
 + (instancetype) reportWithString:(NSString*) stringValue;

--- a/Sources/KSCrashRecording/include/KSCrashReport.h
+++ b/Sources/KSCrashRecording/include/KSCrashReport.h
@@ -1,0 +1,60 @@
+//
+//  KSCrashReport.h
+//
+//  Created by Nikolay Volosatov on 2024-06-23.
+//
+//  Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * A class that represent a recorded crash report.
+ * Under the hood it can be a dictionary or a serialized data (e.g. JSON string).
+ */
+NS_SWIFT_NAME(CrashReport)
+@interface KSCrashReport : NSObject
+
+/**
+ * A structured dictionary version of crash report.
+ */
+@property (nonatomic, readonly, nullable, copy) NSDictionary<NSString*, id>* dictionaryValue;
+
+@property (nonatomic, readonly, nullable, copy) NSString* stringValue;
+
+@property (nonatomic, readonly, nullable, copy) NSData* dataValue;
+
+- (instancetype) init __attribute((unavailable));
++ (instancetype) new __attribute((unavailable));
+
+- (instancetype) initWithDictionaryValue:(nullable NSDictionary<NSString*, id>*) dictionaryValue
+                             stringValue:(nullable NSString*) stringValue
+                               dataValue:(nullable NSData*) dataValue NS_DESIGNATED_INITIALIZER;
+
++ (instancetype) reportWithDictionary:(NSDictionary<NSString*, id>*) dictionaryValue;
++ (instancetype) reportWithString:(NSString*) stringValue;
++ (instancetype) reportWithData:(NSData*) dataValue;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashRecording/include/KSCrashReport.h
+++ b/Sources/KSCrashRecording/include/KSCrashReport.h
@@ -28,28 +28,48 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSUInteger, KSCrashReportType) {
+    KSCrashReportTypeDictionary,
+    KSCrashReportTypeString,
+    KSCrashReportTypeData,
+};
+
 /**
  * A class that represent a recorded crash report.
- * Under the hood it can be a dictionary or a serialized data (e.g. JSON string).
+ * Under the hood it can be a dictionary or a serialized data (e.g. JSON data or formatted string).
  */
 NS_SWIFT_NAME(CrashReport)
 @interface KSCrashReport : NSObject
 
 /**
+ * This report type defines which one of the value properties below is populated.
+ */
+@property (nonatomic, readonly, assign) KSCrashReportType reportType;
+
+/**
  * A structured dictionary version of crash report.
+ * This is usually a raw report that can be serialized to JSON.
  */
 @property (nonatomic, readonly, nullable, copy) NSDictionary<NSString*, id>* dictionaryValue;
 
+/**
+ * A serialized or formatted string version of crash report.
+ */
 @property (nonatomic, readonly, nullable, copy) NSString* stringValue;
 
+/**
+ * A serialized data version of crash report.
+ * This usually contain a serialized JSON.
+ */
 @property (nonatomic, readonly, nullable, copy) NSData* dataValue;
 
-- (instancetype) init __attribute((unavailable));
-+ (instancetype) new __attribute((unavailable));
+- (instancetype) init NS_UNAVAILABLE;
++ (instancetype) new NS_UNAVAILABLE;
 
-- (instancetype) initWithDictionaryValue:(nullable NSDictionary<NSString*, id>*) dictionaryValue
-                             stringValue:(nullable NSString*) stringValue
-                               dataValue:(nullable NSData*) dataValue NS_DESIGNATED_INITIALIZER;
+- (instancetype) initWithReportType:(KSCrashReportType) reportType
+                    dictionaryValue:(nullable NSDictionary<NSString*, id>*) dictionaryValue
+                        stringValue:(nullable NSString*) stringValue
+                          dataValue:(nullable NSData*) dataValue NS_DESIGNATED_INITIALIZER;
 
 + (instancetype) reportWithDictionary:(NSDictionary<NSString*, id>*) dictionaryValue;
 + (instancetype) reportWithString:(NSString*) stringValue;

--- a/Sources/KSCrashRecording/include/KSCrashReportFilter.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportFilter.h
@@ -28,6 +28,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class KSCrashReport;
+
 /** Callback for filter operations.
  *
  * @param filteredReports The filtered reports (may be incomplete if "completed"
@@ -37,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  *                  user cancelling the operation).
  * @param error Non-nil if an error occurred.
  */
-typedef void(^KSCrashReportFilterCompletion)(NSArray<NSDictionary<NSString *,id> *>* _Nullable filteredReports,
+typedef void(^KSCrashReportFilterCompletion)(NSArray<KSCrashReport*>* _Nullable filteredReports,
                                              BOOL completed,
                                              NSError* _Nullable  error)
 NS_SWIFT_UNAVAILABLE("Use Swift closures instead!");
@@ -55,7 +57,7 @@ NS_SWIFT_NAME(CrashReportFilter)
  * @param reports The reports to process.
  * @param onCompletion Block to call when processing is complete.
  */
-- (void) filterReports:(NSArray<NSDictionary<NSString *,id> *>*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(nullable KSCrashReportFilterCompletion) onCompletion;
 
 @end
@@ -69,7 +71,7 @@ NS_SWIFT_NAME(CrashReportFilter)
  * @param error The parameter to send as "error".
  */
 static inline void kscrash_callCompletion(KSCrashReportFilterCompletion _Nullable onCompletion,
-                                          NSArray<NSDictionary<NSString *,id> *>* _Nullable filteredReports,
+                                          NSArray<KSCrashReport*>* _Nullable filteredReports,
                                           BOOL completed,
                                           NSError* _Nullable error)
 {

--- a/Sources/KSCrashRecordingCore/KSJSONCodecObjC.m
+++ b/Sources/KSCrashRecordingCore/KSJSONCodecObjC.m
@@ -371,6 +371,13 @@ static int encodeObject(KSJSONCodec* codec, id object, NSString* name, KSJSONEnc
         }
         for(id key in keys)
         {
+            if([key isKindOfClass:[NSString class]] == NO)
+            {
+                codec.error = [NSError errorWithDomain:@"KSJSONCodecObjC"
+                                                  code:0
+                                           description:@"Invalid key: %@", key];
+                return KSJSON_ERROR_INVALID_DATA;
+            }
             if((result = encodeObject(codec, [object valueForKey:key], key, context)) != KSJSON_OK)
             {
                 return result;

--- a/Sources/KSCrashSinks/KSCrashReportSinkConsole.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkConsole.m
@@ -52,6 +52,11 @@
     int i = 0;
     for(KSCrashReport* report in reports)
     {
+        if(report.stringValue == nil)
+        {
+            KSLOG_ERROR(@"Unexpected non-string report: %@", report);
+            continue;
+        }
         printf("Report %d:\n%s\n", ++i, report.stringValue.UTF8String);
     }
 

--- a/Sources/KSCrashSinks/KSCrashReportSinkConsole.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkConsole.m
@@ -45,13 +45,13 @@
             nil];
 }
 
-- (void) filterReports:(NSArray*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
     int i = 0;
-    for(NSString* report in reports)
+    for(KSCrashReport* report in reports)
     {
-        printf("Report %d:\n%s\n", ++i, report.UTF8String);
+        printf("Report %d:\n%s\n", ++i, report.stringValue.UTF8String);
     }
 
     kscrash_callCompletion(onCompletion, reports, YES, nil);

--- a/Sources/KSCrashSinks/KSCrashReportSinkConsole.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkConsole.m
@@ -30,6 +30,9 @@
 #import "KSCrashReportFilterBasic.h"
 #import "KSCrashReport.h"
 
+//#define KSLogger_LocalLevel TRACE
+#import "KSLogger.h"
+
 
 @implementation KSCrashReportSinkConsole
 

--- a/Sources/KSCrashSinks/KSCrashReportSinkConsole.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkConsole.m
@@ -28,6 +28,7 @@
 #import "KSCrashReportSinkConsole.h"
 #import "KSCrashReportFilterAppleFmt.h"
 #import "KSCrashReportFilterBasic.h"
+#import "KSCrashReport.h"
 
 
 @implementation KSCrashReportSinkConsole

--- a/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
@@ -88,7 +88,8 @@
         NSData* data = report.dataValue;
         if(data == nil)
         {
-            KSLOG_ERROR(@"Report has no data: %@", report);
+            KSLOG_ERROR(@"Unexpected non-data report: %@", report);
+            continue;
         }
         [controller addAttachmentData:data
                              mimeType:@"binary"

--- a/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
@@ -43,7 +43,7 @@
 
 @interface KSCrashMailProcess : NSObject <MFMailComposeViewControllerDelegate>
 
-@property(nonatomic,readwrite,retain) NSArray* reports;
+@property(nonatomic,readwrite,copy) NSArray<KSCrashReport*>* reports;
 @property(nonatomic,readwrite,copy) KSCrashReportFilterCompletion onCompletion;
 
 @property(nonatomic,readwrite,retain) UIViewController* dummyVC;
@@ -51,7 +51,7 @@
 + (KSCrashMailProcess*) process;
 
 - (void) startWithController:(MFMailComposeViewController*) controller
-                     reports:(NSArray*) reports
+                     reports:(NSArray<KSCrashReport*>*) reports
                  filenameFmt:(NSString*) filenameFmt
                 onCompletion:(KSCrashReportFilterCompletion) onCompletion;
 
@@ -72,28 +72,26 @@
 }
 
 - (void) startWithController:(MFMailComposeViewController*) controller
-                     reports:(NSArray*) reports
+                     reports:(NSArray<KSCrashReport*>*) reports
                  filenameFmt:(NSString*) filenameFmt
                 onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
-    self.reports = reports;
+    self.reports = [reports copy];
     self.onCompletion = onCompletion;
 
     controller.mailComposeDelegate = self;
 
     int i = 1;
-    for(NSData* report in reports)
+    for(KSCrashReport* report in reports)
     {
-        if(![report isKindOfClass:[NSData class]])
+        NSData* data = report.dataValue;
+        if(data == nil)
         {
-            KSLOG_ERROR(@"Report was of type %@", [report class]);
+            KSLOG_ERROR(@"Report has no data: %@", report);
         }
-        else
-        {
-            [controller addAttachmentData:report
-                                 mimeType:@"binary"
-                                 fileName:[NSString stringWithFormat:filenameFmt, i++]];
-        }
+        [controller addAttachmentData:data
+                             mimeType:@"binary"
+                             fileName:[NSString stringWithFormat:filenameFmt, i++]];
     }
 
     [self presentModalVC:controller];
@@ -242,7 +240,7 @@
             nil];
 }
 
-- (void) filterReports:(NSArray*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
     if(![MFMailComposeViewController canSendMail])
@@ -319,12 +317,11 @@
     return [super init];
 }
 
-- (void) filterReports:(NSArray*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
-    for(NSData* reportData in reports)
+    for(KSCrashReport* report in reports)
     {
-        NSString* report = [[NSString alloc] initWithData:[reportData gunzippedWithError:nil] encoding:NSUTF8StringEncoding];
         NSLog(@"Report\n%@", report);
     }
     kscrash_callCompletion(onCompletion, reports, NO,

--- a/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
@@ -33,6 +33,7 @@
 #import "KSCrashReportFilterJSON.h"
 #import "NSError+SimpleConstructor.h"
 #import "KSSystemCapabilities.h"
+#import "KSCrashReport.h"
 
 //#define KSLogger_LocalLevel TRACE
 #import "KSLogger.h"

--- a/Sources/KSCrashSinks/KSCrashReportSinkStandard.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkStandard.m
@@ -92,6 +92,10 @@
         {
             [jsonArray addObject:report.stringValue];
         }
+        else
+        {
+            KSLOG_ERROR(@"Unexpected non-dictionary/non-string report: %@", report);
+        }
     }
     NSData* jsonData = [KSJSONCodec encode:jsonArray
                                    options:KSJSONEncodeOptionSorted

--- a/Sources/KSCrashSinks/KSCrashReportSinkStandard.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkStandard.m
@@ -33,6 +33,7 @@
 #import "KSJSONCodecObjC.h"
 #import "KSReachabilityKSCrash.h"
 #import "NSError+SimpleConstructor.h"
+#import "KSCrashReport.h"
 
 //#define KSLogger_LocalLevel TRACE
 #import "KSLogger.h"

--- a/Sources/KSCrashSinks/KSCrashReportSinkStandard.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkStandard.m
@@ -72,7 +72,7 @@
     return self;
 }
 
-- (void) filterReports:(NSArray*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
     NSError* error = nil;
@@ -80,7 +80,19 @@
                                                            cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
                                                        timeoutInterval:15];
     KSHTTPMultipartPostBody* body = [KSHTTPMultipartPostBody body];
-    NSData* jsonData = [KSJSONCodec encode:reports
+    NSMutableArray* jsonArray = [NSMutableArray array];
+    for (KSCrashReport* report in reports)
+    {
+        if(report.dictionaryValue != nil)
+        {
+            [jsonArray addObject:report.dictionaryValue];
+        }
+        else if (report.stringValue != nil)
+        {
+            [jsonArray addObject:report.stringValue];
+        }
+    }
+    NSData* jsonData = [KSJSONCodec encode:jsonArray
                                    options:KSJSONEncodeOptionSorted
                                      error:&error];
     if(jsonData == nil)

--- a/Tests/KSCrashFiltersTests/KSCrashReportFilterGZip_Tests.m
+++ b/Tests/KSCrashFiltersTests/KSCrashReportFilterGZip_Tests.m
@@ -29,68 +29,60 @@
 
 #import "KSCrashReportFilterGZip.h"
 #import "NSData+KSGZip.h"
+#import "KSCrashReport.h"
 
 
-@interface KSCrashReportFilterGZip_Tests : XCTestCase @end
+@interface KSCrashReportFilterGZip_Tests : XCTestCase
+
+@property (nonatomic, copy) NSArray* decompressedReports;
+@property (nonatomic, copy) NSArray* compressedReports;
+
+@end
 
 
 @implementation KSCrashReportFilterGZip_Tests
 
-- (void) testFilterGZipCompress
+- (void) setUp
 {
-    NSArray* decompressed = [NSArray arrayWithObjects:
-                             (id _Nonnull)[@"this is a test" dataUsingEncoding:NSUTF8StringEncoding],
-                             (id _Nonnull)[@"here is another test" dataUsingEncoding:NSUTF8StringEncoding],
-                             (id _Nonnull)[@"testing is fun!" dataUsingEncoding:NSUTF8StringEncoding],
-                             nil];
-    
+    self.decompressedReports = @[
+        [KSCrashReport reportWithData:[@"this is a test" dataUsingEncoding:NSUTF8StringEncoding]],
+        [KSCrashReport reportWithData:[@"here is another test" dataUsingEncoding:NSUTF8StringEncoding]],
+        [KSCrashReport reportWithData:[@"testing is fun!" dataUsingEncoding:NSUTF8StringEncoding]],
+    ];
+
     NSError* error = nil;
     NSMutableArray* compressed = [NSMutableArray array];
-    for(NSData* data in decompressed)
+    for(KSCrashReport* report in self.decompressedReports)
     {
-        NSData* newData = [data gzippedWithCompressionLevel:-1 error:&error];
-        XCTAssertNotNil(newData, @"");
-        XCTAssertNil(error, @"");
-        [compressed addObject:newData];
+        NSData* newData = [report.dataValue gzippedWithCompressionLevel:-1 error:&error];
+        [compressed addObject:[KSCrashReport reportWithData:newData]];
     }
-    
+    self.compressedReports = [compressed copy];
+}
+
+- (void) testFilterGZipCompress
+{
     id<KSCrashReportFilter> filter = [KSCrashReportFilterGZipCompress filterWithCompressionLevel:-1];
-    [filter filterReports:decompressed onCompletion:^(NSArray* filteredReports,
-                                                      BOOL completed,
-                                                      NSError* error2)
+    [filter filterReports:self.decompressedReports onCompletion:^(NSArray* filteredReports,
+                                                                  BOOL completed,
+                                                                  NSError* error2)
      {
          XCTAssertTrue(completed, @"");
          XCTAssertNil(error2, @"");
-         XCTAssertEqualObjects(compressed, filteredReports, @"");
+         XCTAssertEqualObjects(filteredReports, self.compressedReports, @"");
      }];
 }
 
 - (void) testFilterGZipDecompress
 {
-    NSArray* decompressed = [NSArray arrayWithObjects:
-                             (id _Nonnull)[@"this is a test" dataUsingEncoding:NSUTF8StringEncoding],
-                             (id _Nonnull)[@"here is another test" dataUsingEncoding:NSUTF8StringEncoding],
-                             (id _Nonnull)[@"testing is fun!" dataUsingEncoding:NSUTF8StringEncoding],
-                             nil];
-    
-    NSError* error = nil;
-    NSMutableArray* compressed = [NSMutableArray array];
-    for(NSData* data in decompressed)
-    {
-        NSData* newData = [data gzippedWithCompressionLevel:-1 error:&error];
-        XCTAssertNotNil(newData, @"");
-        XCTAssertNil(error, @"");
-        [compressed addObject:newData];
-    }
-    
     id<KSCrashReportFilter> filter = [KSCrashReportFilterGZipDecompress filter];
-    [filter filterReports:compressed onCompletion:^(NSArray* filteredReports,
+    [filter filterReports:self.compressedReports onCompletion:^(NSArray* filteredReports,
                                                     BOOL completed,
                                                     NSError* error2)
      {
          XCTAssertTrue(completed, @"");
          XCTAssertNil(error2, @"");
-         XCTAssertEqualObjects(decompressed, filteredReports, @"");
+         XCTAssertEqualObjects(filteredReports, self.decompressedReports, @"");
      }];
 }
 

--- a/Tests/KSCrashFiltersTests/KSCrashReportFilter_Tests.m
+++ b/Tests/KSCrashFiltersTests/KSCrashReportFilter_Tests.m
@@ -60,7 +60,7 @@
 @property(nonatomic,readwrite,assign) BOOL completed;
 @property(nonatomic,readwrite,retain) NSError* error;
 @property(nonatomic,readwrite,retain) NSTimer* timer;
-@property(nonatomic,readwrite,retain) NSArray* reports;
+@property(nonatomic,readwrite,retain) NSArray<KSCrashReport*>* reports;
 @property(nonatomic,readwrite,copy) KSCrashReportFilterCompletion onCompletion;
 
 @end
@@ -94,7 +94,7 @@
     return self;
 }
 
-- (void) filterReports:(NSArray*) reports
+- (void) filterReports:(NSArray<KSCrashReport*>*) reports
           onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
     self.reports = reports;
@@ -530,86 +530,6 @@
     [filter filterReports:expected1 onCompletion:^(__unused NSArray* filteredReports,
                                                    BOOL completed,
                                                    NSError* error)
-     {
-         XCTAssertFalse(completed, @"");
-         XCTAssertNotNil(error, @"");
-     }];
-}
-
-- (void) testObjectForKey
-{
-    NSString* key = @"someKey";
-    NSString* expected = @"value";
-    NSArray* reports = [NSArray arrayWithObjects:
-                        [NSDictionary dictionaryWithObject:expected forKey:key],
-                        nil];
-    
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterObjectForKey filterWithKey:key allowNotFound:NO];
-
-    [filter filterReports:reports onCompletion:^(__unused NSArray* filteredReports,
-                                                 BOOL completed,
-                                                 NSError* error)
-     {
-         XCTAssertTrue(completed, @"");
-         XCTAssertNil(error, @"");
-         XCTAssertEqualObjects([filteredReports objectAtIndex:0], expected, @"");
-     }];
-}
-
-- (void) testObjectForKey2
-{
-    id key = [NSNumber numberWithInt:100];
-    NSString* expected = @"value";
-    NSArray* reports = [NSArray arrayWithObjects:
-                        [NSDictionary dictionaryWithObject:expected forKey:key],
-                        nil];
-    
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterObjectForKey filterWithKey:key allowNotFound:NO];
-    
-    [filter filterReports:reports onCompletion:^(__unused NSArray* filteredReports,
-                                                 BOOL completed,
-                                                 NSError* error)
-     {
-         XCTAssertTrue(completed, @"");
-         XCTAssertNil(error, @"");
-         XCTAssertEqualObjects([filteredReports objectAtIndex:0], expected, @"");
-     }];
-}
-
-- (void) testObjectForKeyNotFoundAllowed
-{
-    NSString* key = @"someKey";
-    NSString* expected = @"value";
-    NSArray* reports = [NSArray arrayWithObjects:
-                        [NSDictionary dictionaryWithObject:expected forKey:key],
-                        nil];
-    
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterObjectForKey filterWithKey:@"someOtherKey" allowNotFound:YES];
-    
-    [filter filterReports:reports onCompletion:^(__unused NSArray* filteredReports,
-                                                 BOOL completed,
-                                                 NSError* error)
-     {
-         XCTAssertTrue(completed, @"");
-         XCTAssertNil(error, @"");
-         NSDictionary* firstReport = filteredReports[0];
-         XCTAssertTrue(firstReport.count == 0, @"");
-     }];
-}
-
-- (void) testObjectForKeyNotFoundNotAllowed
-{
-    NSString* key = @"someKey";
-    NSString* expected = @"value";
-    NSArray* reports = [NSArray arrayWithObjects:
-                        [NSDictionary dictionaryWithObject:expected forKey:key],
-                        nil];
-    
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterObjectForKey filterWithKey:@"someOtherKey" allowNotFound:NO];
-    
-    [filter filterReports:reports onCompletion:^(__unused NSArray* filteredReports,
-                                                 BOOL completed,
-                                                 NSError* error)
      {
          XCTAssertFalse(completed, @"");
          XCTAssertNotNil(error, @"");


### PR DESCRIPTION
The filters API was using dictionary in definitions but actually the report there can become a string or a data.
There's no nice way to implement union type or enum with associated values in ObjC. So this is a kind of workaround.