### PR TITLE
Fix initial report type

### DIFF
--- a/Samples/Common/Sources/LibraryBridge/ReportingSample.swift
+++ b/Samples/Common/Sources/LibraryBridge/ReportingSample.swift
@@ -32,6 +32,12 @@ import KSCrashSinks
 public class ReportingSample {
     public static func logToConsole() {
         KSCrash.shared().sink = CrashReportSinkConsole.filter().defaultCrashReportFilterSet()
-        KSCrash.shared().sendAllReports()
+        KSCrash.shared().sendAllReports { reports, isSuccess, error in
+            if isSuccess, let reports {
+                print("Logged \(reports.count) reoprts")
+            } else {
+                print("Failed to log reports: \(error?.localizedDescription ?? "")")
+            }
+        }
     }
 }

--- a/Samples/Common/Sources/LibraryBridge/ReportingSample.swift
+++ b/Samples/Common/Sources/LibraryBridge/ReportingSample.swift
@@ -34,7 +34,7 @@ public class ReportingSample {
         KSCrash.shared().sink = CrashReportSinkConsole.filter().defaultCrashReportFilterSet()
         KSCrash.shared().sendAllReports { reports, isSuccess, error in
             if isSuccess, let reports {
-                print("Logged \(reports.count) reoprts")
+                print("Logged \(reports.count) reports")
             } else {
                 print("Failed to log reports: \(error?.localizedDescription ?? "")")
             }

--- a/Sources/KSCrashRecording/KSCrash.m
+++ b/Sources/KSCrashRecording/KSCrash.m
@@ -39,6 +39,7 @@
 #import "KSCrashMonitor_System.h"
 #import "KSSystemCapabilities.h"
 #import "KSCrashMonitor_Memory.h"
+#import "KSCrashReport.h"
 
 //#define KSLogger_LocalLevel TRACE
 #import "KSLogger.h"
@@ -427,7 +428,7 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     return [reportIDs copy];
 }
 
-- (NSDictionary*) reportForID:(int64_t) reportID
+- (KSCrashReport*) reportForID:(int64_t) reportID
 {
     NSData* jsonData = [self loadCrashReportJSONWithID:reportID];
     if(jsonData == nil)
@@ -452,18 +453,18 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     }
     [self doctorReport:crashReport];
 
-    return [crashReport copy];
+    return [KSCrashReport reportWithDictionary:crashReport];
 }
 
-- (NSArray*) allReports
+- (NSArray<KSCrashReport*>*) allReports
 {
     int reportCount = kscrash_getReportCount();
     int64_t reportIDs[reportCount];
     reportCount = kscrash_getReportIDs(reportIDs, reportCount);
-    NSMutableArray* reports = [NSMutableArray arrayWithCapacity:(NSUInteger)reportCount];
+    NSMutableArray<KSCrashReport*>* reports = [NSMutableArray arrayWithCapacity:(NSUInteger)reportCount];
     for(int i = 0; i < reportCount; i++)
     {
-        NSDictionary* report = [self reportForID:reportIDs[i]];
+        KSCrashReport* report = [self reportForID:reportIDs[i]];
         if(report != nil)
         {
             [reports addObject:report];

--- a/Sources/KSCrashRecording/include/KSCrash.h
+++ b/Sources/KSCrashRecording/include/KSCrash.h
@@ -153,9 +153,9 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param reportID An ID of report.
  *
- * @return A dictionary with report fields. See KSCrashReportFields.h for available fields.
+ * @return A crash report with a dictionary value. The dectionary fields are described in KSCrashReportFields.h.
  */
-- (nullable NSDictionary<NSString*, id>*) reportForID:(int64_t) reportID NS_SWIFT_NAME(report(for:));
+- (nullable KSCrashReport*) reportForID:(int64_t) reportID NS_SWIFT_NAME(report(for:));
 
 /** Delete all unsent reports.
  */


### PR DESCRIPTION
Many unit-tests, no integration tests. 
Previously #516  has broken the core API for reports sending. This is a fix.