### PR TITLE
Add Support for Unsigned Integer Elements, Enhance JSON Encoding/Decoding Robustness, and Replace `sprintf` with Safer `snprintf`

### DIFF
--- a/Sources/KSCrashRecordingCore/KSJSONCodec.c
+++ b/Sources/KSCrashRecordingCore/KSJSONCodec.c
@@ -320,8 +320,13 @@ int ksjson_addFloatingPointElement(KSJSONEncodeContext *const context, const cha
         }
     }
 
-    if (written < 0 || written >= (int)sizeof(buff)) {
-        return KSJSON_ERROR_INVALID_DATA;
+    if (written < 0) {
+        // An encoding error occurred
+        return KSJSON_ERROR_INVALID_CHARACTER;
+    } else if (written >= (int)sizeof(buff)) {
+        // The number was too long to fit in the buffer
+        // Note: In this case, buff is still null-terminated, but truncated
+        return KSJSON_ERROR_DATA_TOO_LONG;
     }
 
     return addJSONData(context, buff, written);

--- a/Sources/KSCrashRecordingCore/include/KSJSONCodec.h
+++ b/Sources/KSCrashRecordingCore/include/KSJSONCodec.h
@@ -409,6 +409,18 @@ typedef struct KSJSONDecodeCallbacks {
      */
     int (*onIntegerElement)(const char *name, int64_t value, void *userData);
 
+    /** Called when an unsigned integer element is decoded.
+     *
+     * @param name The element's name.
+     *
+     * @param value The element's value.
+     *
+     * @param userData Data that was specified when calling ksjson_decode().
+     *
+     * @return KSJSON_OK if decoding should continue.
+     */
+    int (*onUnsignedIntegerElement)(const char *name, uint64_t value, void *userData);
+
     /** Called when a null element is decoded.
      *
      * @param name The element's name.

--- a/Tests/KSCrashRecordingCoreTests/KSJSONCodec_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSJSONCodec_Tests.m
@@ -1424,24 +1424,24 @@ static int addJSONData(const char *data, int length, void *userData)
 - (void)testSerializeDeserializeDoubleEdgeCases
 {
     [self testDoubleSerialization:DBL_MIN];
-//    [self testDoubleSerialization:DBL_MAX]; // Attributed as +inf
+    //    [self testDoubleSerialization:DBL_MAX]; // Attributed as +inf
     [self testDoubleSerialization:-0.0];
     [self testDoubleSerialization:0.0];
     [self testDoubleSerialization:INFINITY];
     [self testDoubleSerialization:-INFINITY];
     [self testDoubleSerialization:NAN];
-//    [self testDoubleSerialization:0.123456789012345]; // Attributed as float
+    //    [self testDoubleSerialization:0.123456789012345]; // Attributed as float
     [self testDoubleSerialization:1.000000000000001];
     [self testDoubleSerialization:0.999999999999999];
-//    [self testDoubleSerialization:1234567.8]; // Attributed as float and deoceded as 12345670
-//    [self testDoubleSerialization:1.000000001]; // Counted as 1
+    //    [self testDoubleSerialization:1234567.8]; // Attributed as float and deoceded as 12345670
+    //    [self testDoubleSerialization:1.000000001]; // Counted as 1
 }
 
 - (void)testIntegerSerialization:(long long)value
 {
     NSError *error = nil;
     NSNumber *number = @(value);
-    NSArray *array = @[number];
+    NSArray *array = @[ number ];
     NSString *jsonString = toString([KSJSONCodec encode:array options:KSJSONEncodeOptionSorted error:&error]);
     XCTAssertNotNil(jsonString);
     XCTAssertNil(error);
@@ -1460,7 +1460,7 @@ static int addJSONData(const char *data, int length, void *userData)
 {
     NSError *error = nil;
     NSNumber *number = @(value);
-    NSArray *array = @[number];
+    NSArray *array = @[ number ];
     NSString *jsonString = toString([KSJSONCodec encode:array options:KSJSONEncodeOptionSorted error:&error]);
     XCTAssertNotNil(jsonString);
     XCTAssertNil(error);
@@ -1479,7 +1479,7 @@ static int addJSONData(const char *data, int length, void *userData)
 {
     NSError *error = nil;
     NSNumber *number = @(value);
-    NSArray *array = @[number];
+    NSArray *array = @[ number ];
     NSString *jsonString = toString([KSJSONCodec encode:array options:KSJSONEncodeOptionSorted error:&error]);
     XCTAssertNotNil(jsonString);
     XCTAssertNil(error);
@@ -1492,9 +1492,11 @@ static int addJSONData(const char *data, int length, void *userData)
         XCTAssertTrue([decodedArray[0] isKindOfClass:[NSNull class]], @"NaN should be decoded as NSNull");
     } else if (isinf(value)) {
         if (value > 0) {
-            XCTAssertEqualObjects(jsonString, @"[1e999]", @"Positive infinity should be encoded as a very large number");
+            XCTAssertEqualObjects(jsonString, @"[1e999]",
+                                  @"Positive infinity should be encoded as a very large number");
         } else {
-            XCTAssertEqualObjects(jsonString, @"[-1e999]", @"Negative infinity should be encoded as a very large negative number");
+            XCTAssertEqualObjects(jsonString, @"[-1e999]",
+                                  @"Negative infinity should be encoded as a very large negative number");
         }
         XCTAssertEqual([decodedArray[0] floatValue], value);
     } else {
@@ -1506,7 +1508,7 @@ static int addJSONData(const char *data, int length, void *userData)
 {
     NSError *error = nil;
     NSNumber *number = @(value);
-    NSArray *array = @[number];
+    NSArray *array = @[ number ];
     NSString *jsonString = toString([KSJSONCodec encode:array options:KSJSONEncodeOptionSorted error:&error]);
     XCTAssertNotNil(jsonString);
     XCTAssertNil(error);
@@ -1519,9 +1521,11 @@ static int addJSONData(const char *data, int length, void *userData)
         XCTAssertTrue([decodedArray[0] isKindOfClass:[NSNull class]], @"NaN should be decoded as NSNull");
     } else if (isinf(value)) {
         if (value > 0) {
-            XCTAssertEqualObjects(jsonString, @"[1e999]", @"Positive infinity should be encoded as a very large number");
+            XCTAssertEqualObjects(jsonString, @"[1e999]",
+                                  @"Positive infinity should be encoded as a very large number");
         } else {
-            XCTAssertEqualObjects(jsonString, @"[-1e999]", @"Negative infinity should be encoded as a very large negative number");
+            XCTAssertEqualObjects(jsonString, @"[-1e999]",
+                                  @"Negative infinity should be encoded as a very large negative number");
         }
         XCTAssertEqual([decodedArray[0] doubleValue], value);
     } else {


### PR DESCRIPTION
This update adds support for handling and accurately encoding/decoding unsigned integer elements in JSON, ensures compatibility with large values, replaces `sprintf` with the safer `snprintf` function, and extends the test suite to cover edge cases for integers, unsigned integers, and floating point numbers. 
_However_, it does not address the suboptimal implementation where a single function handles both float and double types, which ideally need separate functions for better precision and clarity.