### PR TITLE
Use protocol for crash report type

### DIFF
--- a/Samples/Common/Sources/LibraryBridge/ReportingSample.swift
+++ b/Samples/Common/Sources/LibraryBridge/ReportingSample.swift
@@ -52,4 +52,82 @@ public class ReportingSample {
             }
         }
     }
+
+    public static func sampleLogToConsole() {
+        KSCrash.shared().sink = CrashReportFilterPipeline(filtersArray: [
+            SampleFilter(),
+            SampleSink(),
+        ])
+        KSCrash.shared().sendAllReports()
+    }
+}
+
+public class SampleCrashReport: NSObject, CrashReport {
+    public struct CrashedThread {
+        var index: Int
+        var callStack: [String]
+    }
+
+    public var untypedValue: Any? { crashedThread }
+
+    public let crashedThread: CrashedThread
+
+    public init?(_ report: CrashReportDictionary) {
+        guard let crashDict = report.value[CrashField.crash.rawValue] as? Dictionary<String, Any>,
+              let threadsArr = crashDict[CrashField.threads.rawValue] as? Array<Any>,
+              let crashedThreadDict = threadsArr
+                .compactMap({ $0 as? Dictionary<String, Any> })
+                .first(where: { ($0[CrashField.crashed.rawValue] as? Bool) ?? false }),
+              let crashedThreadIndex = crashedThreadDict[CrashField.index.rawValue] as? Int,
+              let backtrace = crashedThreadDict[CrashField.backtrace.rawValue] as? Dictionary<String, Any>,
+              let backtraceArr = backtrace[CrashField.contents.rawValue] as? Array<Any>
+        else { return nil }
+
+        crashedThread = .init(
+            index: crashedThreadIndex,
+            callStack: backtraceArr.enumerated().map { (idx: Int, bt: Any) -> String in
+                guard let bt = bt as? Dictionary<String, Any>,
+                      let objectName = bt[CrashField.objectName.rawValue] as? String,
+                      let instructionAddr = bt[CrashField.instructionAddr.rawValue] as? UInt64
+                else { return "\(idx)\t<malformed>" }
+
+                let symbolName = bt[CrashField.symbolName.rawValue] as? String
+                let symbolAddr = bt[CrashField.symbolAddr.rawValue] as? UInt64
+                let offset = symbolAddr.flatMap { instructionAddr - $0 } ?? 0
+                
+                let instructionAddrStr = "0x\(String(instructionAddr, radix: 16))"
+                let symbolAddrStr = "0x\(String(symbolAddr ?? instructionAddr, radix: 16))"
+
+                return "\(idx)\t\(objectName)\t\(instructionAddrStr) \(symbolName ?? symbolAddrStr) + \(offset)"
+            }
+        )
+    }
+}
+
+public class SampleFilter: NSObject, CrashReportFilter {
+    public func filterReports(_ reports: [any CrashReport], onCompletion: (([any CrashReport]?, Bool, (any Error)?) -> Void)? = nil) {
+        let filtered = reports.compactMap { report -> SampleCrashReport? in
+            guard let dictReport = report as? CrashReportDictionary else {
+                return nil
+            }
+            return SampleCrashReport(dictReport)
+        }
+        onCompletion?(filtered, true, nil)
+    }
+}
+
+public class SampleSink: NSObject, CrashReportFilter {
+    public func filterReports(_ reports: [any CrashReport], onCompletion: (([any CrashReport]?, Bool, (any Error)?) -> Void)? = nil) {
+        for (idx, report) in reports.enumerated() {
+            guard let sampleReport = report as? SampleCrashReport else {
+                continue
+            }
+            let lines = [
+                "Crash report #\(idx):",
+                "\tCrashed thread #\(sampleReport.crashedThread.index):",
+            ] + sampleReport.crashedThread.callStack.map { "\t\t\($0)" }
+            print(lines.joined(separator: "\n"))
+        }
+        onCompletion?(reports, true, nil)
+    }
 }

--- a/Samples/Common/Sources/LibraryBridge/ReportingSample.swift
+++ b/Samples/Common/Sources/LibraryBridge/ReportingSample.swift
@@ -35,6 +35,18 @@ public class ReportingSample {
         KSCrash.shared().sendAllReports { reports, isSuccess, error in
             if isSuccess, let reports {
                 print("Logged \(reports.count) reports")
+                for (idx, report) in reports.enumerated() {
+                    switch report {
+                    case let stringReport as CrashReportString:
+                        print("Report #\(idx) is a string (length is \(stringReport.value.count))")
+                    case let dictionaryReport as CrashReportDictionary:
+                        print("Report #\(idx) is a dictionary (number of keys is \(dictionaryReport.value.count))")
+                    case let dataReport as CrashReportData:
+                        print("Report #\(idx) is a binary data (size is \(dataReport.value.count) bytes)")
+                    default:
+                        print("Unknown report #\(idx): \(report.debugDescription ?? "?")")
+                    }
+                }
             } else {
                 print("Failed to log reports: \(error?.localizedDescription ?? "")")
             }

--- a/Samples/Common/Sources/SampleUI/SampleView.swift
+++ b/Samples/Common/Sources/SampleUI/SampleView.swift
@@ -43,6 +43,9 @@ public struct SampleView: View {
                     Button("Log To Console") {
                         ReportingSample.logToConsole()
                     }
+                    Button("Sample Custom Log To Console") {
+                        ReportingSample.sampleLogToConsole()
+                    }
                 }
             }
             .navigationTitle("KSCrash Sample")

--- a/Sources/KSCrashFilters/KSCrashReportFilterAlert.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterAlert.m
@@ -44,7 +44,7 @@
 
 @interface KSCrashAlertViewProcess : NSObject
 
-@property(nonatomic, readwrite, copy) NSArray<KSCrashReport *> *reports;
+@property(nonatomic, readwrite, copy) NSArray<id<KSCrashReport>> *reports;
 @property(nonatomic, readwrite, copy) KSCrashReportFilterCompletion onCompletion;
 @property(nonatomic, readwrite, assign) NSInteger expectedButtonIndex;
 
@@ -54,7 +54,7 @@
                message:(NSString *)message
              yesAnswer:(NSString *)yesAnswer
               noAnswer:(NSString *)noAnswer
-               reports:(NSArray<KSCrashReport *> *)reports
+               reports:(NSArray<id<KSCrashReport>> *)reports
           onCompletion:(KSCrashReportFilterCompletion)onCompletion;
 
 @end
@@ -70,7 +70,7 @@
                message:(NSString *)message
              yesAnswer:(NSString *)yesAnswer
               noAnswer:(NSString *)noAnswer
-               reports:(NSArray<KSCrashReport *> *)reports
+               reports:(NSArray<id<KSCrashReport>> *)reports
           onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
     KSLOG_TRACE(@"Starting alert view process");
@@ -157,7 +157,7 @@
     return self;
 }
 
-- (void)filterReports:(NSArray<KSCrashReport *> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
+- (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         KSLOG_TRACE(@"Launching new alert view process");
@@ -202,7 +202,7 @@
     return self;
 }
 
-- (void)filterReports:(NSArray<KSCrashReport *> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
+- (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
     KSLOG_WARN(@"Alert filter not available on this platform.");
     kscrash_callCompletion(onCompletion, reports, YES, nil);

--- a/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
@@ -198,7 +198,7 @@ static NSDictionary *g_registerOrders;
 {
     NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
     for (KSCrashReportDictionary *report in reports) {
-        if ([report isKindOfClass:[KSCrashReportDictionary class]] == NO || report.value == nil) {
+        if ([report isKindOfClass:[KSCrashReportDictionary class]] == NO) {
             KSLOG_ERROR(@"Unexpected non-dictionary report: %@", report);
             continue;
         }

--- a/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
@@ -194,19 +194,18 @@ static NSDictionary *g_registerOrders;
     return 0;
 }
 
-- (void)filterReports:(NSArray<KSCrashReport *> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
+- (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
-    NSMutableArray<KSCrashReport *> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for (KSCrashReport *report in reports) {
-        NSDictionary *reportDict = report.dictionaryValue;
-        if (reportDict == nil) {
+    NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for (KSCrashReportDictionary *report in reports) {
+        if ([report isKindOfClass:[KSCrashReportDictionary class]] == NO || report.value == nil) {
             KSLOG_ERROR(@"Unexpected non-dictionary report: %@", report);
             continue;
         }
-        if ([self majorVersion:reportDict] == kExpectedMajorVersion) {
-            NSString *appleReportString = [self toAppleFormat:reportDict];
+        if ([self majorVersion:report.value] == kExpectedMajorVersion) {
+            NSString *appleReportString = [self toAppleFormat:report.value];
             if (appleReportString != nil) {
-                [filteredReports addObject:[KSCrashReport reportWithString:appleReportString]];
+                [filteredReports addObject:[KSCrashReportString reportWithValue:appleReportString]];
             }
         }
     }

--- a/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
@@ -344,7 +344,7 @@
 {
     NSMutableArray *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
     for (KSCrashReportDictionary *report in reports) {
-        if ([report isKindOfClass:[KSCrashReportDictionary class]] == NO || report.value == nil) {
+        if ([report isKindOfClass:[KSCrashReportDictionary class]] == NO) {
             KSLOG_ERROR(@"Unexpected non-dictionary report: %@", report);
             continue;
         }
@@ -412,7 +412,7 @@
 {
     NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
     for (KSCrashReportDictionary *report in reports) {
-        if ([report isKindOfClass:[KSCrashReportDictionary class]] == NO || report.value == nil) {
+        if ([report isKindOfClass:[KSCrashReportDictionary class]] == NO) {
             KSLOG_ERROR(@"Unexpected non-dictionary report: %@", report);
             continue;
         }
@@ -448,12 +448,16 @@
 {
     NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
     for (KSCrashReportData *report in reports) {
-        if ([report isKindOfClass:[KSCrashReportData class]] == NO || report.value == nil) {
+        if ([report isKindOfClass:[KSCrashReportData class]] == NO) {
             KSLOG_ERROR(@"Unexpected non-data report: %@", report);
             continue;
         }
 
         NSString *converted = [[NSString alloc] initWithData:report.value encoding:NSUTF8StringEncoding];
+        if (converted == nil) {
+            KSLOG_ERROR(@"Can't decode UTF8 string from binary data: %@", report);
+            continue;
+        }
         [filteredReports addObject:[KSCrashReportString reportWithValue:converted]];
     }
 
@@ -473,7 +477,7 @@
 {
     NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
     for (KSCrashReportString *report in reports) {
-        if ([report isKindOfClass:[KSCrashReportString class]] == NO || report.value == nil) {
+        if ([report isKindOfClass:[KSCrashReportString class]] == NO) {
             KSLOG_ERROR(@"Unexpected non-string report: %@", report);
             continue;
         }

--- a/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
@@ -40,7 +40,7 @@
     return [[self alloc] init];
 }
 
-- (void)filterReports:(NSArray<KSCrashReport *> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
+- (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
     kscrash_callCompletion(onCompletion, reports, YES, nil);
 }
@@ -113,7 +113,7 @@
     return [self initWithFilters:filters keys:keys];
 }
 
-- (void)filterReports:(NSArray<KSCrashReport *> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
+- (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
     NSArray *filters = self.filters;
     NSArray *keys = self.keys;
@@ -144,7 +144,7 @@
             filterCompletion = nil;
         });
     } copy];
-    filterCompletion = [^(NSArray<KSCrashReport *> *filteredReports, BOOL completed, NSError *filterError) {
+    filterCompletion = [^(NSArray<id<KSCrashReport>> *filteredReports, BOOL completed, NSError *filterError) {
         if (!completed || filteredReports == nil) {
             if (!completed) {
                 kscrash_callCompletion(onCompletion, filteredReports, completed, filterError);
@@ -169,18 +169,18 @@
         // All filters complete, or a filter failed.
         // Build final "filteredReports" array.
         NSUInteger reportCount = [(NSArray *)[reportSets objectAtIndex:0] count];
-        NSMutableArray<KSCrashReport *> *combinedReports = [NSMutableArray arrayWithCapacity:reportCount];
+        NSMutableArray<id<KSCrashReport>> *combinedReports = [NSMutableArray arrayWithCapacity:reportCount];
         for (NSUInteger iReport = 0; iReport < reportCount; iReport++) {
             NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithCapacity:filterCount];
             for (NSUInteger iSet = 0; iSet < filterCount; iSet++) {
                 NSString *key = keys[iSet];
                 NSArray *reportSet = reportSets[iSet];
                 if (iReport < reportSet.count) {
-                    KSCrashReport *report = reportSet[iReport];
-                    dict[key] = report.dictionaryValue ?: report.stringValue ?: report.dataValue;
+                    id<KSCrashReport> report = reportSet[iReport];
+                    dict[key] = report.untypedValue;
                 }
             }
-            KSCrashReport *report = [KSCrashReport reportWithDictionary:dict];
+            id<KSCrashReport> report = [KSCrashReportDictionary reportWithValue:dict];
             [combinedReports addObject:report];
         }
 
@@ -242,7 +242,7 @@
     self.filters = [@[ filter ] arrayByAddingObjectsFromArray:self.filters];
 }
 
-- (void)filterReports:(NSArray<KSCrashReport *> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
+- (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
     NSArray *filters = self.filters;
     NSUInteger filterCount = [filters count];
@@ -261,7 +261,7 @@
             filterCompletion = nil;
         });
     } copy];
-    filterCompletion = [^(NSArray<KSCrashReport *> *filteredReports, BOOL completed, NSError *filterError) {
+    filterCompletion = [^(NSArray<id<KSCrashReport>> *filteredReports, BOOL completed, NSError *filterError) {
         if (!completed || filteredReports == nil) {
             if (!completed) {
                 kscrash_callCompletion(onCompletion, filteredReports, completed, filterError);
@@ -340,10 +340,14 @@
     return self;
 }
 
-- (void)filterReports:(NSArray<KSCrashReport *> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
+- (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
     NSMutableArray *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for (KSCrashReport *report in reports) {
+    for (KSCrashReportDictionary *report in reports) {
+        if ([report isKindOfClass:[KSCrashReportDictionary class]] == NO || report.value == nil) {
+            KSLOG_ERROR(@"Unexpected non-dictionary report: %@", report);
+            continue;
+        }
         BOOL firstEntry = YES;
         NSMutableString *concatenated = [NSMutableString string];
         for (NSString *key in self.keys) {
@@ -352,7 +356,7 @@
             } else {
                 [concatenated appendFormat:self.separatorFmt, key];
             }
-            id object = [KSNSDictionaryHelper objectInDictionary:report.dictionaryValue forKeyPath:key];
+            id object = [KSNSDictionaryHelper objectInDictionary:report.value forKeyPath:key];
             [concatenated appendFormat:@"%@", object];
         }
         [filteredReports addObject:concatenated];
@@ -404,19 +408,18 @@
     return self;
 }
 
-- (void)filterReports:(NSArray<KSCrashReport *> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
+- (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
-    NSMutableArray<KSCrashReport *> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for (KSCrashReport *report in reports) {
-        NSDictionary *reportDict = report.dictionaryValue;
-        if (reportDict == nil) {
+    NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for (KSCrashReportDictionary *report in reports) {
+        if ([report isKindOfClass:[KSCrashReportDictionary class]] == NO || report.value == nil) {
             KSLOG_ERROR(@"Unexpected non-dictionary report: %@", report);
             continue;
         }
 
         NSMutableDictionary *subset = [NSMutableDictionary dictionary];
         for (NSString *keyPath in self.keyPaths) {
-            id object = [KSNSDictionaryHelper objectInDictionary:reportDict forKeyPath:keyPath];
+            id object = [KSNSDictionaryHelper objectInDictionary:report.value forKeyPath:keyPath];
             if (object == nil) {
                 kscrash_callCompletion(onCompletion, filteredReports, NO,
                                        [KSNSErrorHelper errorWithDomain:[[self class] description]
@@ -426,7 +429,7 @@
             }
             [subset setObject:object forKey:[keyPath lastPathComponent]];
         }
-        KSCrashReport *subsetReport = [KSCrashReport reportWithDictionary:subset];
+        id<KSCrashReport> subsetReport = [KSCrashReportDictionary reportWithValue:subset];
         [filteredReports addObject:subsetReport];
     }
     kscrash_callCompletion(onCompletion, filteredReports, YES, nil);
@@ -441,18 +444,17 @@
     return [[self alloc] init];
 }
 
-- (void)filterReports:(NSArray<KSCrashReport *> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
+- (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
-    NSMutableArray<KSCrashReport *> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for (KSCrashReport *report in reports) {
-        NSData *data = report.dataValue;
-        if (data == nil) {
+    NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for (KSCrashReportData *report in reports) {
+        if ([report isKindOfClass:[KSCrashReportData class]] == NO || report.value == nil) {
             KSLOG_ERROR(@"Unexpected non-data report: %@", report);
             continue;
         }
 
-        NSString *converted = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-        [filteredReports addObject:[KSCrashReport reportWithString:converted]];
+        NSString *converted = [[NSString alloc] initWithData:report.value encoding:NSUTF8StringEncoding];
+        [filteredReports addObject:[KSCrashReportString reportWithValue:converted]];
     }
 
     kscrash_callCompletion(onCompletion, filteredReports, YES, nil);
@@ -467,17 +469,16 @@
     return [[self alloc] init];
 }
 
-- (void)filterReports:(NSArray<KSCrashReport *> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
+- (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
-    NSMutableArray<KSCrashReport *> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for (KSCrashReport *report in reports) {
-        NSString *string = report.stringValue;
-        if (string == nil) {
+    NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for (KSCrashReportString *report in reports) {
+        if ([report isKindOfClass:[KSCrashReportString class]] == NO || report.value == nil) {
             KSLOG_ERROR(@"Unexpected non-string report: %@", report);
             continue;
         }
 
-        NSData *converted = [string dataUsingEncoding:NSUTF8StringEncoding];
+        NSData *converted = [report.value dataUsingEncoding:NSUTF8StringEncoding];
         if (converted == nil) {
             kscrash_callCompletion(onCompletion, filteredReports, NO,
                                    [KSNSErrorHelper errorWithDomain:[[self class] description]
@@ -485,7 +486,7 @@
                                                         description:@"Could not convert report to UTF-8"]);
             return;
         } else {
-            [filteredReports addObject:[KSCrashReport reportWithData:converted]];
+            [filteredReports addObject:[KSCrashReportData reportWithValue:converted]];
         }
     }
 

--- a/Sources/KSCrashFilters/KSCrashReportFilterGZip.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterGZip.m
@@ -52,25 +52,24 @@
     return self;
 }
 
-- (void)filterReports:(NSArray<KSCrashReport *> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
+- (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
-    NSMutableArray<KSCrashReport *> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for (KSCrashReport *report in reports) {
-        NSData *data = report.dataValue;
-        if (data == nil) {
+    NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for (KSCrashReportData *report in reports) {
+        if ([report isKindOfClass:[KSCrashReportData class]] == NO || report.value == nil) {
             KSLOG_ERROR(@"Unexpected non-data report: %@", report);
             continue;
         }
 
         NSError *error = nil;
-        NSData *compressedData = [KSGZipHelper gzippedData:data
+        NSData *compressedData = [KSGZipHelper gzippedData:report.value
                                           compressionLevel:(int)self.compressionLevel
                                                      error:&error];
         if (compressedData == nil) {
             kscrash_callCompletion(onCompletion, filteredReports, NO, error);
             return;
         } else {
-            [filteredReports addObject:[KSCrashReport reportWithData:compressedData]];
+            [filteredReports addObject:[KSCrashReportData reportWithValue:compressedData]];
         }
     }
 
@@ -86,23 +85,22 @@
     return [[self alloc] init];
 }
 
-- (void)filterReports:(NSArray<KSCrashReport *> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
+- (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
-    NSMutableArray<KSCrashReport *> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for (KSCrashReport *report in reports) {
-        NSData *data = report.dataValue;
-        if (data == nil) {
+    NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for (KSCrashReportData *report in reports) {
+        if ([report isKindOfClass:[KSCrashReportData class]] == NO || report.value == nil) {
             KSLOG_ERROR(@"Unexpected non-data report: %@", report);
             continue;
         }
 
         NSError *error = nil;
-        NSData *decompressedData = [KSGZipHelper gunzippedData:data error:&error];
+        NSData *decompressedData = [KSGZipHelper gunzippedData:report.value error:&error];
         if (decompressedData == nil) {
             kscrash_callCompletion(onCompletion, filteredReports, NO, error);
             return;
         } else {
-            [filteredReports addObject:[KSCrashReport reportWithData:decompressedData]];
+            [filteredReports addObject:[KSCrashReportData reportWithValue:decompressedData]];
         }
     }
 

--- a/Sources/KSCrashFilters/KSCrashReportFilterGZip.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterGZip.m
@@ -56,7 +56,7 @@
 {
     NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
     for (KSCrashReportData *report in reports) {
-        if ([report isKindOfClass:[KSCrashReportData class]] == NO || report.value == nil) {
+        if ([report isKindOfClass:[KSCrashReportData class]] == NO) {
             KSLOG_ERROR(@"Unexpected non-data report: %@", report);
             continue;
         }
@@ -89,7 +89,7 @@
 {
     NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
     for (KSCrashReportData *report in reports) {
-        if ([report isKindOfClass:[KSCrashReportData class]] == NO || report.value == nil) {
+        if ([report isKindOfClass:[KSCrashReportData class]] == NO) {
             KSLOG_ERROR(@"Unexpected non-data report: %@", report);
             continue;
         }

--- a/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
@@ -51,23 +51,22 @@
     return self;
 }
 
-- (void)filterReports:(NSArray<KSCrashReport *> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
+- (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
-    NSMutableArray<KSCrashReport *> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for (KSCrashReport *report in reports) {
-        NSDictionary *reportDict = report.dictionaryValue;
-        if (reportDict == nil) {
+    NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for (KSCrashReportDictionary *report in reports) {
+        if ([report isKindOfClass:[KSCrashReportDictionary class]] == NO || report.value == nil) {
             KSLOG_ERROR(@"Unexpected non-dictionary report: %@", report);
             continue;
         }
 
         NSError *error = nil;
-        NSData *jsonData = [KSJSONCodec encode:reportDict options:self.encodeOptions error:&error];
+        NSData *jsonData = [KSJSONCodec encode:report.value options:self.encodeOptions error:&error];
         if (jsonData == nil) {
             kscrash_callCompletion(onCompletion, filteredReports, NO, error);
             return;
         } else {
-            [filteredReports addObject:[KSCrashReport reportWithData:jsonData]];
+            [filteredReports addObject:[KSCrashReportData reportWithValue:jsonData]];
         }
     }
 
@@ -97,23 +96,22 @@
     return self;
 }
 
-- (void)filterReports:(NSArray<KSCrashReport *> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
+- (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
-    NSMutableArray<KSCrashReport *> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for (KSCrashReport *report in reports) {
-        NSData *data = report.dataValue;
-        if (data == nil) {
+    NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for (KSCrashReportData *report in reports) {
+        if ([report isKindOfClass:[KSCrashReportData class]] == NO || report.value == nil) {
             KSLOG_ERROR(@"Unexpected non-data report: %@", report);
             continue;
         }
 
         NSError *error = nil;
-        NSDictionary *decodedReport = [KSJSONCodec decode:data options:self.decodeOptions error:&error];
-        if (decodedReport == nil) {
+        NSDictionary *decodedReport = [KSJSONCodec decode:report.value options:self.decodeOptions error:&error];
+        if (decodedReport == nil || [decodedReport isKindOfClass:[NSDictionary class]] == NO) {
             kscrash_callCompletion(onCompletion, filteredReports, NO, error);
             return;
         } else {
-            [filteredReports addObject:[KSCrashReport reportWithDictionary:decodedReport]];
+            [filteredReports addObject:[KSCrashReportDictionary reportWithValue:decodedReport]];
         }
     }
 

--- a/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
@@ -55,7 +55,7 @@
 {
     NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
     for (KSCrashReportDictionary *report in reports) {
-        if ([report isKindOfClass:[KSCrashReportDictionary class]] == NO || report.value == nil) {
+        if ([report isKindOfClass:[KSCrashReportDictionary class]] == NO) {
             KSLOG_ERROR(@"Unexpected non-dictionary report: %@", report);
             continue;
         }
@@ -100,7 +100,7 @@
 {
     NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
     for (KSCrashReportData *report in reports) {
-        if ([report isKindOfClass:[KSCrashReportData class]] == NO || report.value == nil) {
+        if ([report isKindOfClass:[KSCrashReportData class]] == NO) {
             KSLOG_ERROR(@"Unexpected non-data report: %@", report);
             continue;
         }

--- a/Sources/KSCrashFilters/KSCrashReportFilterStringify.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterStringify.m
@@ -36,30 +36,32 @@
     return [[self alloc] init];
 }
 
-- (NSString *)stringifyReport:(KSCrashReport *)report
+- (NSString *)stringifyReport:(id<KSCrashReport>)report
 {
-    if (report.stringValue != nil) {
-        return report.stringValue;
+    if ([report isKindOfClass:[KSCrashReportString class]]) {
+        return ((KSCrashReportString *)report).value;
     }
-    if (report.dataValue != nil) {
-        return [[NSString alloc] initWithData:report.dataValue encoding:NSUTF8StringEncoding];
+    if ([report isKindOfClass:[KSCrashReportData class]]) {
+        NSData *value = ((KSCrashReportData *)report).value;
+        return [[NSString alloc] initWithData:value encoding:NSUTF8StringEncoding];
     }
-    if (report.dictionaryValue != nil) {
-        if ([NSJSONSerialization isValidJSONObject:report.dictionaryValue]) {
-            NSData *data = [NSJSONSerialization dataWithJSONObject:report.dictionaryValue options:0 error:nil];
+    if ([report isKindOfClass:[KSCrashReportDictionary class]]) {
+        NSDictionary *value = ((KSCrashReportDictionary *)report).value;
+        if ([NSJSONSerialization isValidJSONObject:value]) {
+            NSData *data = [NSJSONSerialization dataWithJSONObject:value options:0 error:nil];
             return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
         }
-        return [NSString stringWithFormat:@"%@", report.dictionaryValue];
+        return [NSString stringWithFormat:@"%@", value];
     }
-    return [NSString stringWithFormat:@"%@", report];
+    return [report description];
 }
 
-- (void)filterReports:(NSArray<KSCrashReport *> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
+- (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
-    NSMutableArray<KSCrashReport *> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for (KSCrashReport *report in reports) {
+    NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for (id<KSCrashReport> report in reports) {
         NSString *reportString = [self stringifyReport:report];
-        [filteredReports addObject:[KSCrashReport reportWithString:reportString]];
+        [filteredReports addObject:[KSCrashReportString reportWithValue:reportString]];
     }
 
     kscrash_callCompletion(onCompletion, filteredReports, YES, nil);

--- a/Sources/KSCrashFilters/KSCrashReportFilterStringify.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterStringify.m
@@ -53,7 +53,7 @@
         }
         return [NSString stringWithFormat:@"%@", value];
     }
-    return [report description];
+    return [report description] ?: @"Unknown";
 }
 
 - (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion

--- a/Sources/KSCrashRecording/KSCrash.m
+++ b/Sources/KSCrashRecording/KSCrash.m
@@ -381,7 +381,7 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     return [reportIDs copy];
 }
 
-- (id<KSCrashReport>)reportForID:(int64_t)reportID
+- (KSCrashReportDictionary *)reportForID:(int64_t)reportID
 {
     NSData *jsonData = [self loadCrashReportJSONWithID:reportID];
     if (jsonData == nil) {
@@ -406,14 +406,14 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     return [KSCrashReportDictionary reportWithValue:crashReport];
 }
 
-- (NSArray<id<KSCrashReport>> *)allReports
+- (NSArray<KSCrashReportDictionary *> *)allReports
 {
     int reportCount = kscrash_getReportCount();
     int64_t reportIDs[reportCount];
     reportCount = kscrash_getReportIDs(reportIDs, reportCount);
-    NSMutableArray<id<KSCrashReport>> *reports = [NSMutableArray arrayWithCapacity:(NSUInteger)reportCount];
+    NSMutableArray<KSCrashReportDictionary *> *reports = [NSMutableArray arrayWithCapacity:(NSUInteger)reportCount];
     for (int i = 0; i < reportCount; i++) {
-        id<KSCrashReport> report = [self reportForID:reportIDs[i]];
+        KSCrashReportDictionary *report = [self reportForID:reportIDs[i]];
         if (report != nil) {
             [reports addObject:report];
         }

--- a/Sources/KSCrashRecording/KSCrash.m
+++ b/Sources/KSCrashRecording/KSCrash.m
@@ -327,7 +327,7 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     return kscrash_getReportCount();
 }
 
-- (void)sendReports:(NSArray<KSCrashReport *> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
+- (void)sendReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
     if ([reports count] == 0) {
         kscrash_callCompletion(onCompletion, reports, YES, nil);
@@ -381,7 +381,7 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     return [reportIDs copy];
 }
 
-- (KSCrashReport *)reportForID:(int64_t)reportID
+- (id<KSCrashReport>)reportForID:(int64_t)reportID
 {
     NSData *jsonData = [self loadCrashReportJSONWithID:reportID];
     if (jsonData == nil) {
@@ -403,17 +403,17 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     }
     [self doctorReport:crashReport];
 
-    return [KSCrashReport reportWithDictionary:crashReport];
+    return [KSCrashReportDictionary reportWithValue:crashReport];
 }
 
-- (NSArray<KSCrashReport *> *)allReports
+- (NSArray<id<KSCrashReport>> *)allReports
 {
     int reportCount = kscrash_getReportCount();
     int64_t reportIDs[reportCount];
     reportCount = kscrash_getReportIDs(reportIDs, reportCount);
-    NSMutableArray<KSCrashReport *> *reports = [NSMutableArray arrayWithCapacity:(NSUInteger)reportCount];
+    NSMutableArray<id<KSCrashReport>> *reports = [NSMutableArray arrayWithCapacity:(NSUInteger)reportCount];
     for (int i = 0; i < reportCount; i++) {
-        KSCrashReport *report = [self reportForID:reportIDs[i]];
+        id<KSCrashReport> report = [self reportForID:reportIDs[i]];
         if (report != nil) {
             [reports addObject:report];
         }

--- a/Sources/KSCrashRecording/KSCrashReport.m
+++ b/Sources/KSCrashRecording/KSCrashReport.m
@@ -26,69 +26,44 @@
 
 #import "KSCrashReport.h"
 
-@implementation KSCrashReport
+#define REPORT_IMPL(NAME, TYPE)                                               \
+    @implementation NAME                                                      \
+                                                                              \
+    +(instancetype)reportWithValue : (TYPE)value                              \
+    {                                                                         \
+        return [[NAME alloc] initWithValue:value];                            \
+    }                                                                         \
+                                                                              \
+    -(instancetype)initWithValue : (TYPE)value                                \
+    {                                                                         \
+        self = [super init];                                                  \
+        if (self != nil) {                                                    \
+            _value = [value copy];                                            \
+        }                                                                     \
+        return self;                                                          \
+    }                                                                         \
+                                                                              \
+    -(id)untypedValue                                                         \
+    {                                                                         \
+        return _value;                                                        \
+    }                                                                         \
+                                                                              \
+    -(BOOL)isEqual : (id)object                                               \
+    {                                                                         \
+        if ([object isKindOfClass:[NAME class]] == NO) {                      \
+            return NO;                                                        \
+        }                                                                     \
+        NAME *other = object;                                                 \
+        return self.value == other.value || [self.value isEqual:other.value]; \
+    }                                                                         \
+                                                                              \
+    -(NSString *)description                                                  \
+    {                                                                         \
+        return [self.value description];                                      \
+    }                                                                         \
+                                                                              \
+    @end
 
-- (instancetype)initWithValueType:(KSCrashReportValueType)valueType
-                  dictionaryValue:(nullable NSDictionary<NSString *, id> *)dictionaryValue
-                      stringValue:(nullable NSString *)stringValue
-                        dataValue:(nullable NSData *)dataValue
-{
-    self = [super init];
-    if (self != nil) {
-        _valueType = valueType;
-        _dictionaryValue = [dictionaryValue copy];
-        _stringValue = [stringValue copy];
-        _dataValue = [dataValue copy];
-    }
-    return self;
-}
-
-+ (instancetype)reportWithDictionary:(NSDictionary<NSString *, id> *)dictionaryValue
-{
-    return [[KSCrashReport alloc] initWithValueType:KSCrashReportValueTypeDictionary
-                                    dictionaryValue:dictionaryValue
-                                        stringValue:nil
-                                          dataValue:nil];
-}
-
-+ (instancetype)reportWithString:(NSString *)stringValue
-{
-    return [[KSCrashReport alloc] initWithValueType:KSCrashReportValueTypeString
-                                    dictionaryValue:nil
-                                        stringValue:stringValue
-                                          dataValue:nil];
-}
-
-+ (instancetype)reportWithData:(NSData *)dataValue
-{
-    return [[KSCrashReport alloc] initWithValueType:KSCrashReportValueTypeData
-                                    dictionaryValue:nil
-                                        stringValue:nil
-                                          dataValue:dataValue];
-}
-
-- (BOOL)isEqual:(id)object
-{
-    if ([object isKindOfClass:[KSCrashReport class]] == NO) {
-        return NO;
-    }
-    KSCrashReport *other = object;
-#define SAME_OR_EQUAL(GETTER) ((self.GETTER) == (other.GETTER) || [(self.GETTER) isEqual:(other.GETTER)])
-    return self.valueType == other.valueType && SAME_OR_EQUAL(stringValue) && SAME_OR_EQUAL(dictionaryValue) &&
-           SAME_OR_EQUAL(dataValue);
-#undef SAME_OR_EQUAL
-}
-
-- (NSString *)description
-{
-    switch (self.valueType) {
-        case KSCrashReportValueTypeDictionary:
-            return [self.dictionaryValue description];
-        case KSCrashReportValueTypeString:
-            return [self.stringValue description];
-        case KSCrashReportValueTypeData:
-            return [self.dataValue description];
-    }
-}
-
-@end
+REPORT_IMPL(KSCrashReportDictionary, NSDictionary *)
+REPORT_IMPL(KSCrashReportString, NSString *)
+REPORT_IMPL(KSCrashReportData, NSData *)

--- a/Sources/KSCrashRecording/include/KSCrash.h
+++ b/Sources/KSCrashRecording/include/KSCrash.h
@@ -33,6 +33,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class KSCrashConfiguration;
+@class KSCrashReportDictionary;
 
 /**
  * Reports any crashes that occur in the application.
@@ -155,7 +156,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A crash report with a dictionary value. The dectionary fields are described in KSCrashReportFields.h.
  */
-- (nullable id<KSCrashReport>)reportForID:(int64_t)reportID NS_SWIFT_NAME(report(for:));
+- (nullable KSCrashReportDictionary *)reportForID:(int64_t)reportID NS_SWIFT_NAME(report(for:));
 
 /** Delete all unsent reports.
  */

--- a/Sources/KSCrashRecording/include/KSCrash.h
+++ b/Sources/KSCrashRecording/include/KSCrash.h
@@ -155,7 +155,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A crash report with a dictionary value. The dectionary fields are described in KSCrashReportFields.h.
  */
-- (nullable KSCrashReport *)reportForID:(int64_t)reportID NS_SWIFT_NAME(report(for:));
+- (nullable id<KSCrashReport>)reportForID:(int64_t)reportID NS_SWIFT_NAME(report(for:));
 
 /** Delete all unsent reports.
  */

--- a/Sources/KSCrashRecording/include/KSCrashReport.h
+++ b/Sources/KSCrashRecording/include/KSCrashReport.h
@@ -54,7 +54,7 @@ NS_SWIFT_NAME(CrashReportDictionary)
  * A structured dictionary version of crash report.
  * This is usually a raw report that can be serialized to JSON.
  */
-@property(nonatomic, readonly, nullable, copy) NSDictionary<NSString *, id> *value;
+@property(nonatomic, readonly, copy) NSDictionary<NSString *, id> *value;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
@@ -69,7 +69,7 @@ NS_SWIFT_NAME(CrashReportString)
 /**
  * A serialized or formatted string version of crash report.
  */
-@property(nonatomic, readonly, nullable, copy) NSString *value;
+@property(nonatomic, readonly, copy) NSString *value;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
@@ -85,7 +85,7 @@ NS_SWIFT_NAME(CrashReportData)
  * A serialized data version of crash report.
  * This usually contain a serialized JSON.
  */
-@property(nonatomic, readonly, nullable, copy) NSData *value;
+@property(nonatomic, readonly, copy) NSData *value;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/Sources/KSCrashRecording/include/KSCrashReport.h
+++ b/Sources/KSCrashRecording/include/KSCrashReport.h
@@ -28,52 +28,63 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSUInteger, KSCrashReportValueType) {
-    KSCrashReportValueTypeDictionary,
-    KSCrashReportValueTypeString,
-    KSCrashReportValueTypeData,
-} NS_SWIFT_NAME(CrashReportValueType);
-
 /**
- * A class that represent a recorded crash report.
- * Under the hood it can be a dictionary or a serialized data (e.g. JSON data or formatted string).
+ * A protocol that represent a recorded crash report.
  */
 NS_SWIFT_NAME(CrashReport)
-@interface KSCrashReport : NSObject
+@protocol KSCrashReport <NSObject>
 
 /**
- * The type of the value of this crash report (dictionary, string, data)
+ * An underlying report value of any type (string, dictionary, data etc)
  */
-@property(nonatomic, readonly, assign) KSCrashReportValueType valueType;
+@property(nonatomic, readonly, nullable, strong) id untypedValue;
+
+@end
+
+NS_SWIFT_NAME(CrashReportDictionary)
+@interface KSCrashReportDictionary : NSObject <KSCrashReport>
 
 /**
  * A structured dictionary version of crash report.
  * This is usually a raw report that can be serialized to JSON.
  */
-@property(nonatomic, readonly, nullable, copy) NSDictionary<NSString *, id> *dictionaryValue;
+@property(nonatomic, readonly, nullable, copy) NSDictionary<NSString *, id> *value;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
++ (instancetype)reportWithValue:(NSDictionary<NSString *, id> *)value;
+
+@end
+
+NS_SWIFT_NAME(CrashReportString)
+@interface KSCrashReportString : NSObject <KSCrashReport>
 
 /**
  * A serialized or formatted string version of crash report.
  */
-@property(nonatomic, readonly, nullable, copy) NSString *stringValue;
+@property(nonatomic, readonly, nullable, copy) NSString *value;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
++ (instancetype)reportWithValue:(NSString *)value;
+
+@end
+
+NS_SWIFT_NAME(CrashReportData)
+@interface KSCrashReportData : NSObject <KSCrashReport>
 
 /**
  * A serialized data version of crash report.
  * This usually contain a serialized JSON.
  */
-@property(nonatomic, readonly, nullable, copy) NSData *dataValue;
+@property(nonatomic, readonly, nullable, copy) NSData *value;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 
-- (instancetype)initWithValueType:(KSCrashReportValueType)valueType
-                  dictionaryValue:(nullable NSDictionary<NSString *, id> *)dictionaryValue
-                      stringValue:(nullable NSString *)stringValue
-                        dataValue:(nullable NSData *)dataValue NS_DESIGNATED_INITIALIZER;
-
-+ (instancetype)reportWithDictionary:(NSDictionary<NSString *, id> *)dictionaryValue;
-+ (instancetype)reportWithString:(NSString *)stringValue;
-+ (instancetype)reportWithData:(NSData *)dataValue;
++ (instancetype)reportWithValue:(NSData *)value;
 
 @end
 

--- a/Sources/KSCrashRecording/include/KSCrashReport.h
+++ b/Sources/KSCrashRecording/include/KSCrashReport.h
@@ -29,13 +29,19 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * A protocol that represent a recorded crash report.
+ * A protocol that represent a recorded or a filtered crash report.
+ *
+ * @see `KSCrashReportDictionary`, `KSCrashReportString` and `KSCrashReportData` are
+ *      the types of reports that provided and used by KSCrash.
  */
 NS_SWIFT_NAME(CrashReport)
 @protocol KSCrashReport <NSObject>
 
 /**
  * An underlying report value of any type (string, dictionary, data etc)
+ *
+ * @note It's preferable to safely cast to one of the implementations of `KSCrashReport`
+ *       and use a strongly typed value from there.
  */
 @property(nonatomic, readonly, nullable, strong) id untypedValue;
 

--- a/Sources/KSCrashRecording/include/KSCrashReportFilter.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportFilter.h
@@ -28,7 +28,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class KSCrashReport;
+@protocol KSCrashReport;
 
 /** Callback for filter operations.
  *
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  *                  user cancelling the operation).
  * @param error Non-nil if an error occurred.
  */
-typedef void (^KSCrashReportFilterCompletion)(NSArray<KSCrashReport *> *_Nullable filteredReports, BOOL completed,
+typedef void (^KSCrashReportFilterCompletion)(NSArray<id<KSCrashReport>> *_Nullable filteredReports, BOOL completed,
                                               NSError *_Nullable error)
     NS_SWIFT_UNAVAILABLE("Use Swift closures instead!");
 
@@ -55,7 +55,7 @@ NS_SWIFT_NAME(CrashReportFilter)
  * @param reports The reports to process.
  * @param onCompletion Block to call when processing is complete.
  */
-- (void)filterReports:(NSArray<KSCrashReport *> *)reports
+- (void)filterReports:(NSArray<id<KSCrashReport>> *)reports
          onCompletion:(nullable KSCrashReportFilterCompletion)onCompletion;
 
 @end
@@ -68,7 +68,7 @@ NS_SWIFT_NAME(CrashReportFilter)
  * @param error The parameter to send as "error".
  */
 static inline void kscrash_callCompletion(KSCrashReportFilterCompletion _Nullable onCompletion,
-                                          NSArray<KSCrashReport *> *_Nullable filteredReports, BOOL completed,
+                                          NSArray<id<KSCrashReport>> *_Nullable filteredReports, BOOL completed,
                                           NSError *_Nullable error)
 {
     if (onCompletion) {

--- a/Sources/KSCrashSinks/KSCrashReportSinkConsole.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkConsole.m
@@ -50,7 +50,7 @@
 {
     int i = 0;
     for (KSCrashReportString *report in reports) {
-        if ([report isKindOfClass:[KSCrashReportString class]] == NO || report.value == nil) {
+        if ([report isKindOfClass:[KSCrashReportString class]] == NO) {
             KSLOG_ERROR(@"Unexpected non-string report: %@", report);
             continue;
         }

--- a/Sources/KSCrashSinks/KSCrashReportSinkConsole.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkConsole.m
@@ -46,15 +46,15 @@
                           nil];
 }
 
-- (void)filterReports:(NSArray<KSCrashReport *> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
+- (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
     int i = 0;
-    for (KSCrashReport *report in reports) {
-        if (report.stringValue == nil) {
+    for (KSCrashReportString *report in reports) {
+        if ([report isKindOfClass:[KSCrashReportString class]] == NO || report.value == nil) {
             KSLOG_ERROR(@"Unexpected non-string report: %@", report);
             continue;
         }
-        printf("Report %d:\n%s\n", ++i, report.stringValue.UTF8String);
+        printf("Report %d:\n%s\n", ++i, report.value.UTF8String);
     }
 
     kscrash_callCompletion(onCompletion, reports, YES, nil);

--- a/Sources/KSCrashSinks/KSCrashReportSinkStandard.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkStandard.m
@@ -64,7 +64,7 @@
     return self;
 }
 
-- (void)filterReports:(NSArray<KSCrashReport *> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
+- (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
     NSError *error = nil;
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:self.url
@@ -72,11 +72,17 @@
                                                        timeoutInterval:15];
     KSHTTPMultipartPostBody *body = [KSHTTPMultipartPostBody body];
     NSMutableArray *jsonArray = [NSMutableArray array];
-    for (KSCrashReport *report in reports) {
-        if (report.dictionaryValue != nil) {
-            [jsonArray addObject:report.dictionaryValue];
-        } else if (report.stringValue != nil) {
-            [jsonArray addObject:report.stringValue];
+    for (id<KSCrashReport> report in reports) {
+        if ([report isKindOfClass:[KSCrashReportDictionary class]]) {
+            KSCrashReportDictionary *dReport = report;
+            if (dReport.value != nil) {
+                [jsonArray addObject:dReport.value];
+            }
+        } else if ([report isKindOfClass:[KSCrashReportString class]]) {
+            KSCrashReportString *sReport = report;
+            if (sReport.value != nil) {
+                [jsonArray addObject:sReport.value];
+            }
         } else {
             KSLOG_ERROR(@"Unexpected non-dictionary/non-string report: %@", report);
         }

--- a/Tests/KSCrashFiltersTests/KSCrashReportFilterGZip_Tests.m
+++ b/Tests/KSCrashFiltersTests/KSCrashReportFilterGZip_Tests.m
@@ -42,16 +42,16 @@
 - (void)setUp
 {
     self.decompressedReports = @[
-        [KSCrashReport reportWithData:[@"this is a test" dataUsingEncoding:NSUTF8StringEncoding]],
-        [KSCrashReport reportWithData:[@"here is another test" dataUsingEncoding:NSUTF8StringEncoding]],
-        [KSCrashReport reportWithData:[@"testing is fun!" dataUsingEncoding:NSUTF8StringEncoding]],
+        [KSCrashReportData reportWithValue:[@"this is a test" dataUsingEncoding:NSUTF8StringEncoding]],
+        [KSCrashReportData reportWithValue:[@"here is another test" dataUsingEncoding:NSUTF8StringEncoding]],
+        [KSCrashReportData reportWithValue:[@"testing is fun!" dataUsingEncoding:NSUTF8StringEncoding]],
     ];
 
     NSError *error = nil;
     NSMutableArray *compressed = [NSMutableArray array];
-    for (KSCrashReport *report in self.decompressedReports) {
-        NSData *newData = [KSGZipHelper gzippedData:report.dataValue compressionLevel:-1 error:&error];
-        [compressed addObject:[KSCrashReport reportWithData:newData]];
+    for (KSCrashReportData *report in self.decompressedReports) {
+        NSData *newData = [KSGZipHelper gzippedData:report.value compressionLevel:-1 error:&error];
+        [compressed addObject:[KSCrashReportData reportWithValue:newData]];
     }
     self.compressedReports = [compressed copy];
 }

--- a/Tests/KSCrashFiltersTests/KSCrashReportFilterJSON_Tests.m
+++ b/Tests/KSCrashFiltersTests/KSCrashReportFilterJSON_Tests.m
@@ -41,14 +41,14 @@
 - (void)setUp
 {
     self.decodedReports = @[
-        [KSCrashReport reportWithDictionary:@{ @"a" : @"b" }],
-        [KSCrashReport reportWithDictionary:@{ @"1" : @ { @"2" : @"3" } }],
-        [KSCrashReport reportWithDictionary:@{ @"?" : @[ @1, @2, @3 ] }],
+        [KSCrashReportDictionary reportWithValue:@{ @"a" : @"b" }],
+        [KSCrashReportDictionary reportWithValue:@{ @"1" : @ { @"2" : @"3" } }],
+        [KSCrashReportDictionary reportWithValue:@{ @"?" : @[ @1, @2, @3 ] }],
     ];
     self.encodedReports = @[
-        [KSCrashReport reportWithData:[@"{\"a\":\"b\"}" dataUsingEncoding:NSUTF8StringEncoding]],
-        [KSCrashReport reportWithData:[@"{\"1\":{\"2\":\"3\"}}" dataUsingEncoding:NSUTF8StringEncoding]],
-        [KSCrashReport reportWithData:[@"{\"?\":[1,2,3]}" dataUsingEncoding:NSUTF8StringEncoding]],
+        [KSCrashReportData reportWithValue:[@"{\"a\":\"b\"}" dataUsingEncoding:NSUTF8StringEncoding]],
+        [KSCrashReportData reportWithValue:[@"{\"1\":{\"2\":\"3\"}}" dataUsingEncoding:NSUTF8StringEncoding]],
+        [KSCrashReportData reportWithValue:[@"{\"?\":[1,2,3]}" dataUsingEncoding:NSUTF8StringEncoding]],
     ];
 }
 
@@ -66,7 +66,7 @@
 - (void)testFilterJSONEncodeInvalid
 {
     NSArray *decoded = @[
-        [KSCrashReport reportWithDictionary:@{ @1 : @2 }],  // Not a JSON
+        [KSCrashReportDictionary reportWithValue:@{ @1 : @2 }],  // Not a JSON
     ];
 
     id<KSCrashReportFilter> filter = [KSCrashReportFilterJSONEncode filterWithOptions:0];
@@ -91,7 +91,7 @@
 - (void)testFilterJSONDencodeInvalid
 {
     NSArray *encoded = @[
-        [KSCrashReport reportWithData:[@"[\"1\"\",\"2\",\"3\"]" dataUsingEncoding:NSUTF8StringEncoding]],
+        [KSCrashReportData reportWithValue:[@"[\"1\"\",\"2\",\"3\"]" dataUsingEncoding:NSUTF8StringEncoding]],
     ];
 
     id<KSCrashReportFilter> filter = [KSCrashReportFilterJSONDecode filterWithOptions:0];

--- a/Tests/KSCrashFiltersTests/KSCrashReportFilter_Tests.m
+++ b/Tests/KSCrashFiltersTests/KSCrashReportFilter_Tests.m
@@ -56,7 +56,7 @@
 @property(nonatomic, readwrite, assign) BOOL completed;
 @property(nonatomic, readwrite, strong) NSError *error;
 @property(nonatomic, readwrite, strong) NSTimer *timer;
-@property(nonatomic, readwrite, copy) NSArray<KSCrashReport *> *reports;
+@property(nonatomic, readwrite, copy) NSArray<id<KSCrashReport>> *reports;
 @property(nonatomic, readwrite, copy) KSCrashReportFilterCompletion onCompletion;
 
 @end
@@ -78,7 +78,7 @@
     return self;
 }
 
-- (void)filterReports:(NSArray<KSCrashReport *> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
+- (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
     self.reports = reports;
     self.onCompletion = onCompletion;
@@ -102,9 +102,9 @@
 
 @interface KSCrashReportFilter_Tests : XCTestCase
 
-@property(nonatomic, copy) NSArray *reports;
-@property(nonatomic, copy) NSArray *reportsWithData;
-@property(nonatomic, copy) NSArray *reportsWithDict;
+@property(nonatomic, copy) NSArray<KSCrashReportString *> *reports;
+@property(nonatomic, copy) NSArray<KSCrashReportData *> *reportsWithData;
+@property(nonatomic, copy) NSArray<KSCrashReportDictionary *> *reportsWithDict;
 
 @end
 
@@ -115,17 +115,17 @@
 - (void)setUp
 {
     self.reports = @[
-        [KSCrashReport reportWithString:@"1"],
-        [KSCrashReport reportWithString:@"2"],
-        [KSCrashReport reportWithString:@"3"],
+        [KSCrashReportString reportWithValue:@"1"],
+        [KSCrashReportString reportWithValue:@"2"],
+        [KSCrashReportString reportWithValue:@"3"],
     ];
     self.reportsWithData = @[
-        [KSCrashReport reportWithData:[@"1" dataUsingEncoding:NSUTF8StringEncoding]],
-        [KSCrashReport reportWithData:[@"2" dataUsingEncoding:NSUTF8StringEncoding]],
-        [KSCrashReport reportWithData:[@"3" dataUsingEncoding:NSUTF8StringEncoding]],
+        [KSCrashReportData reportWithValue:[@"1" dataUsingEncoding:NSUTF8StringEncoding]],
+        [KSCrashReportData reportWithValue:[@"2" dataUsingEncoding:NSUTF8StringEncoding]],
+        [KSCrashReportData reportWithValue:[@"3" dataUsingEncoding:NSUTF8StringEncoding]],
     ];
     self.reportsWithDict = @[
-        [KSCrashReport reportWithDictionary:@{
+        [KSCrashReportDictionary reportWithValue:@{
             @"first" : @"1",
             @"second" : @"a",
             @"third" : @"b",
@@ -135,7 +135,7 @@
 
 - (void)testPassthroughLeak
 {
-    __block NSArray *reports = @[ [KSCrashReport reportWithString:@""] ];
+    __block NSArray *reports = @[ [KSCrashReportString reportWithValue:@""] ];
     __weak id weakRef = reports;
 
     __block KSCrashReportFilterPassthrough *filter = [KSCrashReportFilterPassthrough filter];
@@ -320,11 +320,11 @@
                  XCTAssertTrue(completed, @"");
                  XCTAssertNil(error, @"");
                  for (NSUInteger i = 0; i < self.reports.count; i++) {
-                     id exp1 = [[self.reports objectAtIndex:i] stringValue];
-                     id exp2 = [[self.reportsWithData objectAtIndex:i] dataValue];
-                     KSCrashReport *entry = [filteredReports objectAtIndex:i];
-                     id result1 = entry.dictionaryValue[@"normal"];
-                     id result2 = entry.dictionaryValue[@"data"];
+                     id exp1 = [[self.reports objectAtIndex:i] value];
+                     id exp2 = [[self.reportsWithData objectAtIndex:i] value];
+                     KSCrashReportDictionary *entry = [filteredReports objectAtIndex:i];
+                     id result1 = entry.value[@"normal"];
+                     id result2 = entry.value[@"data"];
                      XCTAssertNotNil(result1);
                      XCTAssertNotNil(result2);
                      XCTAssertEqualObjects(result1, exp1, @"");
@@ -345,11 +345,11 @@
                  XCTAssertTrue(completed, @"");
                  XCTAssertNil(error, @"");
                  for (NSUInteger i = 0; i < [self.reports count]; i++) {
-                     id exp1 = [[self.reports objectAtIndex:i] stringValue];
-                     id exp2 = [[self.reportsWithData objectAtIndex:i] dataValue];
-                     KSCrashReport *entry = [filteredReports objectAtIndex:i];
-                     id result1 = entry.dictionaryValue[@"normal"];
-                     id result2 = entry.dictionaryValue[@"data"];
+                     id exp1 = [[self.reports objectAtIndex:i] value];
+                     id exp2 = [[self.reportsWithData objectAtIndex:i] value];
+                     KSCrashReportDictionary *entry = [filteredReports objectAtIndex:i];
+                     id result1 = entry.value[@"normal"];
+                     id result2 = entry.value[@"data"];
                      XCTAssertNotNil(result1);
                      XCTAssertNotNil(result2);
                      XCTAssertEqualObjects(result1, exp1, @"");
@@ -411,11 +411,11 @@
                  XCTAssertTrue(completed, @"");
                  XCTAssertNil(error, @"");
                  for (NSUInteger i = 0; i < [self.reports count]; i++) {
-                     id exp1 = [[self.reports objectAtIndex:i] stringValue];
-                     id exp2 = [[self.reportsWithData objectAtIndex:i] dataValue];
-                     KSCrashReport *entry = [filteredReports objectAtIndex:i];
-                     id result1 = entry.dictionaryValue[@"normal"];
-                     id result2 = entry.dictionaryValue[@"data"];
+                     id exp1 = [[self.reports objectAtIndex:i] value];
+                     id exp2 = [[self.reportsWithData objectAtIndex:i] value];
+                     KSCrashReportDictionary *entry = [filteredReports objectAtIndex:i];
+                     id result1 = entry.value[@"normal"];
+                     id result2 = entry.value[@"data"];
                      XCTAssertNotNil(result1);
                      XCTAssertNotNil(result2);
                      XCTAssertEqualObjects(result1, exp1, @"");
@@ -470,7 +470,7 @@
 
 - (void)testSubset
 {
-    KSCrashReport *expected = [KSCrashReport reportWithDictionary:@{
+    id<KSCrashReport> expected = [KSCrashReportDictionary reportWithValue:@{
         @"first" : @"1",
         @"third" : @"b",
     }];
@@ -497,7 +497,7 @@
 
 - (void)testSubsetInit
 {
-    KSCrashReport *expected = [KSCrashReport reportWithDictionary:@{
+    id<KSCrashReport> expected = [KSCrashReportDictionary reportWithValue:@{
         @"first" : @"1",
         @"third" : @"b",
     }];


### PR DESCRIPTION
The 3-values crash report type wasn't a good idea form an API side of view as some users were confused that `stringValue` would automatically convert crash report to string.

This PR replaces `KSCrashReport` class with an abstract protocol. This also allows writing custom filters with user-defined representations of crash report (e.g. protobuf or something else).