### PR TITLE
fix import error

### DIFF
--- a/Sources/KSCrashRecording/include/KSCrashAppMemoryTracker.h
+++ b/Sources/KSCrashRecording/include/KSCrashAppMemoryTracker.h
@@ -25,7 +25,7 @@
 //
 #import <Foundation/Foundation.h>
 
-#import <KSCrashAppMemory.h>
+#import <KSCrash/KSCrashAppMemory.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/KSCrashRecording/include/KSCrashAppStateTracker.h
+++ b/Sources/KSCrashRecording/include/KSCrashAppStateTracker.h
@@ -24,7 +24,7 @@
 // THE SOFTWARE.
 //
 #import <Foundation/Foundation.h>
-#import <KSCrashAppTransitionState.h>
+#import <KSCrash/KSCrashAppTransitionState.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
if podfile like this, xcode build error
```ruby
source 'xxx'
install! 'cocoapods',
:generate_multiple_pod_projects => true,
:incremental_installation => true,
:disable_input_output_paths => true

use_frameworks! :linkage => :static
```
![截屏2024-07-17 13 48 22](https://github.com/user-attachments/assets/fa476fdd-88f5-4bab-9232-feaffdbf0d53)

'KSCrashAppTransitionState.h' file not found with <angled> include; use "quotes" instead

