### PR TITLE
Disable iOS integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -25,7 +25,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: iOS
+          # iOS integration tests are too flaky and are temporary excluded
+          # - platform: iOS
           - platform: macOS
           - platform: tvOS
           - platform: watchOS


### PR DESCRIPTION
As having flaky tests is worse than no tests at all.