### PR TITLE
Add reports-only set up API

### DIFF
--- a/Samples/Common/Sources/LibraryBridge/InstallBridge.swift
+++ b/Samples/Common/Sources/LibraryBridge/InstallBridge.swift
@@ -67,7 +67,7 @@ public class InstallBridge: ObservableObject {
 
     @Published public var basePath: BasePath = .default
     @Published public var installed: Bool = false
-    @Published public var installSkipped: Bool = false
+    @Published public var reportsOnlySetup: Bool = false
     @Published public var error: InstallationError?
 
     public init() {
@@ -99,10 +99,10 @@ public class InstallBridge: ObservableObject {
         }
     }
 
-    public func installReportsOnly() {
+    public func setupReportsOnly() {
         do {
-            try KSCrash.shared.installReportsOnly(withInstallPath: config.installPath)
-            installSkipped = true
+            try KSCrash.shared.setupReportStore(withPath: config.installPath)
+            reportsOnlySetup = true
         } catch let error as KSCrashInstallError {
             let message = error.localizedDescription
             Self.logger.error("Failed to install KSCrash: \(message)")

--- a/Samples/Common/Sources/LibraryBridge/InstallBridge.swift
+++ b/Samples/Common/Sources/LibraryBridge/InstallBridge.swift
@@ -67,6 +67,7 @@ public class InstallBridge: ObservableObject {
 
     @Published public var basePath: BasePath = .default
     @Published public var installed: Bool = false
+    @Published public var installSkipped: Bool = false
     @Published public var error: InstallationError?
 
     public init() {
@@ -87,6 +88,21 @@ public class InstallBridge: ObservableObject {
         do {
             try KSCrash.shared.install(with: config)
             installed = true
+        } catch let error as KSCrashInstallError {
+            let message = error.localizedDescription
+            Self.logger.error("Failed to install KSCrash: \(message)")
+            self.error = .kscrashError(message)
+        } catch {
+            let message = error.localizedDescription
+            Self.logger.error("Unexpected error during KSCrash installation: \(message)")
+            self.error = .unexpectedError(message)
+        }
+    }
+
+    public func installReportsOnly() {
+        do {
+            try KSCrash.shared.installReportsOnly(withInstallPath: config.installPath)
+            installSkipped = true
         } catch let error as KSCrashInstallError {
             let message = error.localizedDescription
             Self.logger.error("Failed to install KSCrash: \(message)")

--- a/Samples/Common/Sources/SampleUI/SampleView.swift
+++ b/Samples/Common/Sources/SampleUI/SampleView.swift
@@ -34,19 +34,16 @@ public struct SampleView: View {
 
     @ObservedObject var installBridge = InstallBridge()
 
-    @State private var installSkipped = false
-
     public var body: some View {
         NavigationView {
-            if installBridge.installed || installSkipped {
+            if installBridge.installed || installBridge.installSkipped {
                 MainView(
-                    installSkipped: $installSkipped
+                    installSkipped: $installBridge.installSkipped
                 )
                 .navigationTitle("KSCrash Sample")
             } else {
                 InstallView(
-                    bridge: installBridge,
-                    installSkipped: $installSkipped
+                    bridge: installBridge
                 )
                 .navigationTitle("Install KSCrash")
             }

--- a/Samples/Common/Sources/SampleUI/SampleView.swift
+++ b/Samples/Common/Sources/SampleUI/SampleView.swift
@@ -36,9 +36,9 @@ public struct SampleView: View {
 
     public var body: some View {
         NavigationView {
-            if installBridge.installed || installBridge.installSkipped {
+            if installBridge.installed || installBridge.reportsOnlySetup {
                 MainView(
-                    installSkipped: $installBridge.installSkipped
+                    reportsOnlySetup: $installBridge.reportsOnlySetup
                 )
                 .navigationTitle("KSCrash Sample")
             } else {

--- a/Samples/Common/Sources/SampleUI/Screens/InstallView.swift
+++ b/Samples/Common/Sources/SampleUI/Screens/InstallView.swift
@@ -79,8 +79,8 @@ struct InstallView: View {
                 // TODO: Add deleteBehaviorAfterSendAll
             }
 
-            Button("Skip install") {
-                bridge.installReportsOnly()
+            Button("Only set up reports") {
+                bridge.setupReportsOnly()
             }
             .foregroundStyle(Color.red)
         }

--- a/Samples/Common/Sources/SampleUI/Screens/InstallView.swift
+++ b/Samples/Common/Sources/SampleUI/Screens/InstallView.swift
@@ -31,8 +31,6 @@ import LibraryBridge
 struct InstallView: View {
     @ObservedObject var bridge: InstallBridge
 
-    @Binding var installSkipped: Bool
-
     @State private var showingInstallAlert = false
 
     var body: some View {
@@ -82,7 +80,7 @@ struct InstallView: View {
             }
 
             Button("Skip install") {
-                installSkipped = true
+                bridge.installReportsOnly()
             }
             .foregroundStyle(Color.red)
         }

--- a/Samples/Common/Sources/SampleUI/Screens/MainView.swift
+++ b/Samples/Common/Sources/SampleUI/Screens/MainView.swift
@@ -29,14 +29,16 @@ import SwiftUI
 
 struct MainView: View {
 
-    @Binding var installSkipped: Bool
+    @Binding var reportsOnlySetup: Bool
 
     var body: some View {
         List {
             Section {
-                if installSkipped {
+                if reportsOnlySetup {
+                    Text("It's only reporting that was set up. Crashes won't be caught. You can go back to the install screen.")
+                        .foregroundStyle(Color.secondary)
                     Button("Back to Install") {
-                        installSkipped = false
+                        reportsOnlySetup = false
                     }
                 } else {
                     Text("KSCrash is installed successfully")

--- a/Sources/KSCrashRecording/KSCrash.m
+++ b/Sources/KSCrashRecording/KSCrash.m
@@ -235,10 +235,10 @@ static NSString *getDefaultInstallPath(void)
     return YES;
 }
 
-- (BOOL)installReportsOnlyWithInstallPath:(NSString *)installPath error:(NSError **)error
+- (BOOL)setupReportStoreWithPath:(NSString *)installPath error:(NSError **)error
 {
     KSCrashInstallErrorCode result =
-        kscrash_installReports(self.bundleName.UTF8String, (installPath ?: getDefaultInstallPath()).UTF8String);
+        kscrash_setupReportsStore(self.bundleName.UTF8String, (installPath ?: getDefaultInstallPath()).UTF8String);
 
     if (result != KSCrashInstallErrorNone) {
         if (error != NULL) {

--- a/Sources/KSCrashRecording/KSCrash.m
+++ b/Sources/KSCrashRecording/KSCrash.m
@@ -235,6 +235,21 @@ static NSString *getDefaultInstallPath(void)
     return YES;
 }
 
+- (BOOL)installReportsOnlyWithInstallPath:(NSString *)installPath error:(NSError **)error
+{
+    KSCrashInstallErrorCode result =
+        kscrash_installReports(self.bundleName.UTF8String, (installPath ?: getDefaultInstallPath()).UTF8String);
+
+    if (result != KSCrashInstallErrorNone) {
+        if (error != NULL) {
+            *error = [self errorForInstallErrorCode:result];
+        }
+        return NO;
+    }
+
+    return YES;
+}
+
 - (void)sendAllReportsWithCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
     NSArray *reports = [self allReports];

--- a/Sources/KSCrashRecording/KSCrashC.c
+++ b/Sources/KSCrashRecording/KSCrashC.c
@@ -86,8 +86,6 @@ static const size_t g_monitorMappingCount = sizeof(g_monitorMappings) / sizeof(g
 
 /** True if KSCrash has been installed. */
 static volatile bool g_installed = 0;
-/** True if the reports store has been installed. */
-static volatile bool g_reportsInstalled = 0;
 
 static bool g_shouldAddConsoleLogToReport = false;
 static bool g_shouldPrintPreviousLog = false;
@@ -211,7 +209,7 @@ void handleConfiguration(KSCrashCConfiguration *configuration)
 #pragma mark - API -
 // ============================================================================
 
-static KSCrashInstallErrorCode installReportsStore(const char *appName, const char *const installPath)
+static KSCrashInstallErrorCode setupReportsStore(const char *appName, const char *const installPath)
 {
     char path[KSFU_MAX_PATH_LENGTH];
     if (snprintf(path, sizeof(path), "%s/Reports", installPath) >= (int)sizeof(path)) {
@@ -243,11 +241,9 @@ KSCrashInstallErrorCode kscrash_install(const char *appName, const char *const i
 
     handleConfiguration(&configuration);
 
-    if (g_reportsInstalled == false) {
-        KSCrashInstallErrorCode result = installReportsStore(appName, installPath);
-        if (result != KSCrashInstallErrorNone) {
-            return result;
-        }
+    KSCrashInstallErrorCode result = setupReportsStore(appName, installPath);
+    if (result != KSCrashInstallErrorNone) {
+        return result;
     }
 
     char path[KSFU_MAX_PATH_LENGTH];
@@ -293,26 +289,20 @@ KSCrashInstallErrorCode kscrash_install(const char *appName, const char *const i
     return KSCrashInstallErrorNone;
 }
 
-KSCrashInstallErrorCode kscrash_installReports(const char *appName, const char *const installPath)
+KSCrashInstallErrorCode kscrash_setupReportsStore(const char *appName, const char *const installPath)
 {
     KSLOG_DEBUG("Installing reports store.");
-
-    if (g_reportsInstalled) {
-        KSLOG_DEBUG("Crash reporter already installed.");
-        return KSCrashInstallErrorAlreadyInstalled;
-    }
 
     if (appName == NULL || installPath == NULL) {
         KSLOG_ERROR("Invalid parameters: appName or installPath is NULL.");
         return KSCrashInstallErrorInvalidParameter;
     }
 
-    KSCrashInstallErrorCode result = installReportsStore(appName, installPath);
+    KSCrashInstallErrorCode result = setupReportsStore(appName, installPath);
     if (result != KSCrashInstallErrorNone) {
         return result;
     }
 
-    g_reportsInstalled = true;
     return KSCrashInstallErrorNone;
 }
 

--- a/Sources/KSCrashRecording/KSCrashC.c
+++ b/Sources/KSCrashRecording/KSCrashC.c
@@ -293,6 +293,11 @@ KSCrashInstallErrorCode kscrash_setupReportsStore(const char *appName, const cha
 {
     KSLOG_DEBUG("Installing reports store.");
 
+    if (g_installed) {
+        KSLOG_DEBUG("Crash reporter is already installed and it's not allowed to set up reports store.");
+        return KSCrashInstallErrorAlreadyInstalled;
+    }
+
     if (appName == NULL || installPath == NULL) {
         KSLOG_ERROR("Invalid parameters: appName or installPath is NULL.");
         return KSCrashInstallErrorInvalidParameter;

--- a/Sources/KSCrashRecording/KSCrashReportStore.c
+++ b/Sources/KSCrashRecording/KSCrashReportStore.c
@@ -26,6 +26,7 @@
 
 #include "KSCrashReportStore.h"
 
+#include <assert.h>
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -35,7 +36,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <assert.h>
 
 #include "KSFileUtils.h"
 #include "KSLogger.h"

--- a/Sources/KSCrashRecording/KSCrashReportStore.c
+++ b/Sources/KSCrashRecording/KSCrashReportStore.c
@@ -170,12 +170,12 @@ static void initializeIDs(void)
 
 void kscrs_initialize(const char *appName, const char *reportsPath)
 {
-    char *oldAppName = NULL;
-    char *oldReportsPath = NULL;
+    const char *previousAppName = NULL;
+    const char *previousReportsPath = NULL;
 
     pthread_mutex_lock(&g_mutex);
-    oldAppName = g_appName;
-    oldReportsPath = g_reportsPath;
+    previousAppName = g_appName;
+    previousReportsPath = g_reportsPath;
     g_appName = strdup(appName);
     g_reportsPath = strdup(reportsPath);
     ksfu_makePath(reportsPath);
@@ -183,13 +183,13 @@ void kscrs_initialize(const char *appName, const char *reportsPath)
     initializeIDs();
     pthread_mutex_unlock(&g_mutex);
 
-    if (oldAppName) {
-        KSLOG_WARN("Reports app name is changed from '%s' to '%s'", oldAppName, appName);
-        free(oldAppName);
+    if (previousAppName) {
+        KSLOG_WARN("Reports app name is changed from '%s' to '%s'", previousAppName, appName);
+        free((void *)previousAppName);
     }
-    if (oldReportsPath) {
-        KSLOG_WARN("Reports path is changed from '%s' to '%s'", oldReportsPath, reportsPath);
-        free(oldReportsPath);
+    if (previousReportsPath) {
+        KSLOG_WARN("Reports path is changed from '%s' to '%s'", previousReportsPath, reportsPath);
+        free((void *)previousReportsPath);
     }
 }
 

--- a/Sources/KSCrashRecording/KSCrashReportStore.c
+++ b/Sources/KSCrashRecording/KSCrashReportStore.c
@@ -45,7 +45,6 @@ static _Atomic(uint32_t) g_nextUniqueIDLow;
 static int64_t g_nextUniqueIDHigh;
 static const char *g_appName;
 static const char *g_reportsPath;
-static const char *g_installPath;
 static pthread_mutex_t g_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static int compareInt64(const void *a, const void *b)
@@ -157,12 +156,10 @@ static void initializeIDs(void)
 
 // Public API
 
-void kscrs_initialize(const char *appName, const char *installPath, const char *reportsPath)
+void kscrs_initialize(const char *appName, const char *reportsPath)
 {
     pthread_mutex_lock(&g_mutex);
     g_appName = strdup(appName);
-    g_installPath = strdup(installPath);
-    ksfu_makePath(installPath);
     g_reportsPath = strdup(reportsPath);
     ksfu_makePath(reportsPath);
     pruneReports();

--- a/Sources/KSCrashRecording/KSCrashReportStore.h
+++ b/Sources/KSCrashRecording/KSCrashReportStore.h
@@ -38,10 +38,9 @@ extern "C" {
 /** Initialize the report store.
  *
  * @param appName The application's name.
- * @param installPath Full path to directory where the crash system writes files.
  * @param reportsPath Full path to directory where the reports are to be stored (path will be created if needed).
  */
-void kscrs_initialize(const char *appName, const char *installPath, const char *reportsPath);
+void kscrs_initialize(const char *appName, const char *reportsPath);
 
 /** Get the next crash report to be generated.
  * Max length for paths is KSCRS_MAX_PATH_LENGTH

--- a/Sources/KSCrashRecording/include/KSCrash.h
+++ b/Sources/KSCrashRecording/include/KSCrash.h
@@ -129,8 +129,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Sets up the crash repors store.
  * A call of this method is required before working with crash reports.
- * The `installWithConfiguration:error:` method sets up the crash report store. 
- * You only need to call this method if you are not using the `installWithConfiguration:error:` method 
+ * The `installWithConfiguration:error:` method sets up the crash report store.
+ * You only need to call this method if you are not using the `installWithConfiguration:error:` method
  * or want to read crash reports from a custom location.
  *
  * @note This method can be called multiple times, but only before `installWithConfiguration:error:` is called.
@@ -175,7 +175,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)deleteAllReports;
 
 /** Delete report.
- * 
+ *
  * @note A call of `setupReportStoreWithPath:error:` or `installWithConfiguration:error:` is required
  *       before working with crash reports.
  *

--- a/Sources/KSCrashRecording/include/KSCrash.h
+++ b/Sources/KSCrashRecording/include/KSCrash.h
@@ -127,7 +127,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)installWithConfiguration:(KSCrashConfiguration *)configuration error:(NSError **)error;
 
-/** TODO: Add docs
+/** Sets up the crash repors store.
+ * A call of this method is required before working with crash reports.
+ * The `installWithConfiguration:error:` method sets up the crash report store. 
+ * You only need to call this method if you are not using the `installWithConfiguration:error:` method 
+ * or want to read crash reports from a custom location.
+ *
+ * @note This method can be called multiple times, but only before `installWithConfiguration:error:` is called.
+ *
+ * @param installPath The path to the directory where the crash reports are stored. If `nil`, the default path is used.
+ * @param error A pointer to an NSError object. If an error occurs, this pointer is set to an actual error object.
+ * @return YES if the crash report store was successfully set up, NO otherwise.
  */
 - (BOOL)setupReportStoreWithPath:(nullable NSString *)installPath error:(NSError **)error;
 
@@ -136,8 +146,9 @@ NS_ASSUME_NONNULL_BEGIN
  * deleted. Once the reports are successfully sent to the server, they may be
  * deleted locally, depending on the property "deleteAfterSendAll".
  *
- * Note: property "sink" MUST be set or else this method will call onCompletion
- *       with an error.
+ * @note A call of `setupReportStoreWithPath:error:` or `installWithConfiguration:error:` is required
+ *       before working with crash reports.
+ * @note Property "sink" MUST be set or else this method will call `onCompletion` with an error.
  *
  * @param onCompletion Called when sending is complete (nil = ignore).
  */
@@ -148,6 +159,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Get report.
  *
+ * @note A call of `setupReportStoreWithPath:error:` or `installWithConfiguration:error:` is required
+ *       before working with crash reports.
+ *
  * @param reportID An ID of report.
  *
  * @return A crash report with a dictionary value. The dectionary fields are described in KSCrashReportFields.h.
@@ -155,10 +169,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable KSCrashReportDictionary *)reportForID:(int64_t)reportID NS_SWIFT_NAME(report(for:));
 
 /** Delete all unsent reports.
+ * @note A call of `setupReportStoreWithPath:error:` or `installWithConfiguration:error:` is required
+ *       before working with crash reports.
  */
 - (void)deleteAllReports;
 
 /** Delete report.
+ * 
+ * @note A call of `setupReportStoreWithPath:error:` or `installWithConfiguration:error:` is required
+ *       before working with crash reports.
  *
  * @param reportID An ID of report to delete.
  */

--- a/Sources/KSCrashRecording/include/KSCrash.h
+++ b/Sources/KSCrashRecording/include/KSCrash.h
@@ -127,6 +127,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)installWithConfiguration:(KSCrashConfiguration *)configuration error:(NSError **)error;
 
+/** TODO: Add docs
+ */
+- (BOOL)installReportsOnlyWithInstallPath:(nullable NSString *)installPath error:(NSError **)error;
+
 /** Send all outstanding crash reports to the current sink.
  * It will only attempt to send the most recent 5 reports. All others will be
  * deleted. Once the reports are successfully sent to the server, they may be

--- a/Sources/KSCrashRecording/include/KSCrash.h
+++ b/Sources/KSCrashRecording/include/KSCrash.h
@@ -129,7 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** TODO: Add docs
  */
-- (BOOL)installReportsOnlyWithInstallPath:(nullable NSString *)installPath error:(NSError **)error;
+- (BOOL)setupReportStoreWithPath:(nullable NSString *)installPath error:(NSError **)error;
 
 /** Send all outstanding crash reports to the current sink.
  * It will only attempt to send the most recent 5 reports. All others will be

--- a/Sources/KSCrashRecording/include/KSCrashC.h
+++ b/Sources/KSCrashRecording/include/KSCrashC.h
@@ -87,7 +87,7 @@ KSCrashInstallErrorCode kscrash_install(const char *appName, const char *const i
 
 /** TODO: Add docs
  */
-KSCrashInstallErrorCode kscrash_installReports(const char *appName, const char *const installPath);
+KSCrashInstallErrorCode kscrash_setupReportsStore(const char *appName, const char *const installPath);
 
 /** Set the user-supplied data in JSON format.
  *

--- a/Sources/KSCrashRecording/include/KSCrashC.h
+++ b/Sources/KSCrashRecording/include/KSCrashC.h
@@ -85,7 +85,17 @@ extern "C" {
 KSCrashInstallErrorCode kscrash_install(const char *appName, const char *const installPath,
                                         KSCrashCConfiguration configuration);
 
-/** TODO: Add docs
+/** Sets up the crash repors store.
+ * This function is used to initialize the storage for crash reports.
+ * The `kscrash_install` function sets up the reports store internally.
+ * You only need to call this function if you are not using the `kscrash_install` function 
+ * or want to read crash reports from a custom location.
+ * 
+ * @note this function can be called multiple times, but only before `kscrash_install` is called.
+ * 
+ * @param appName The name of the application. Usually it's bundle name.
+ * @param installPath The directory where the crash reports and related data will be stored.
+ * @return KSCrashInstallErrorCode indicating the result of the setup.
  */
 KSCrashInstallErrorCode kscrash_setupReportsStore(const char *appName, const char *const installPath);
 

--- a/Sources/KSCrashRecording/include/KSCrashC.h
+++ b/Sources/KSCrashRecording/include/KSCrashC.h
@@ -85,6 +85,10 @@ extern "C" {
 KSCrashInstallErrorCode kscrash_install(const char *appName, const char *const installPath,
                                         KSCrashCConfiguration configuration);
 
+/** TODO: Add docs
+ */
+KSCrashInstallErrorCode kscrash_installReports(const char *appName, const char *const installPath);
+
 /** Set the user-supplied data in JSON format.
  *
  * @param userInfoJSON Pre-baked JSON containing user-supplied information.

--- a/Sources/KSCrashRecording/include/KSCrashC.h
+++ b/Sources/KSCrashRecording/include/KSCrashC.h
@@ -88,11 +88,11 @@ KSCrashInstallErrorCode kscrash_install(const char *appName, const char *const i
 /** Sets up the crash repors store.
  * This function is used to initialize the storage for crash reports.
  * The `kscrash_install` function sets up the reports store internally.
- * You only need to call this function if you are not using the `kscrash_install` function 
+ * You only need to call this function if you are not using the `kscrash_install` function
  * or want to read crash reports from a custom location.
- * 
+ *
  * @note this function can be called multiple times, but only before `kscrash_install` is called.
- * 
+ *
  * @param appName The name of the application. Usually it's bundle name.
  * @param installPath The directory where the crash reports and related data will be stored.
  * @return KSCrashInstallErrorCode indicating the result of the setup.

--- a/Tests/KSCrashRecordingTests/KSCrashReportStore_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashReportStore_Tests.m
@@ -62,7 +62,7 @@
 - (void)prepareReportStoreWithPathEnd:(NSString *)pathEnd
 {
     self.reportStorePath = [self.tempPath stringByAppendingPathComponent:pathEnd];
-    kscrs_initialize(self.appName.UTF8String, self.tempPath.UTF8String, self.reportStorePath.UTF8String);
+    kscrs_initialize(self.appName.UTF8String, self.reportStorePath.UTF8String);
 }
 
 - (NSArray *)getReportIDs


### PR DESCRIPTION
It was impossible to read reports without "installing" KSCrash. Yet there might be cases when reading reports and staring crash monitoring should be configured separately:
1. Migrations of reports store path.
2. Delayed installation after a user consent.

This PR adds a new API method (both ObjC/Swift and C) to just setup reports store. And also fixes the crashes if reports API is used before this new method is called or full installation is done.