### PR TITLE
refactor: optimizing the logic for retrieving free memory on iOS 13+

### DIFF
--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
@@ -162,8 +162,8 @@ static bool VMStats(vm_statistics_data_t *const vmStats, vm_size_t *const pageSi
 
 static uint64_t freeMemory(void)
 {
-#if ASTROLABECRASH_HOST_IOS
-    if(@available(iOS 13.0, *)) {
+#if KSCRASH_HOST_IOS || KSCRASH_HOST_TV || KSCRASH_HOST_WATCH
+    if(@available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
         return os_proc_available_memory();
     }
 #endif

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
@@ -43,6 +43,7 @@
 #endif
 #include <mach-o/dyld.h>
 #include <mach/mach.h>
+#include <os/proc.h>
 
 typedef struct {
     const char *systemName;
@@ -161,6 +162,11 @@ static bool VMStats(vm_statistics_data_t *const vmStats, vm_size_t *const pageSi
 
 static uint64_t freeMemory(void)
 {
+#if ASTROLABECRASH_HOST_IOS
+    if(@available(iOS 13.0, *)) {
+        return os_proc_available_memory();
+    }
+#endif
     vm_statistics_data_t vmStats;
     vm_size_t pageSize;
     if (VMStats(&vmStats, &pageSize)) {


### PR DESCRIPTION
In iOS 13 and later, Apple has provided an API to obtain available memory.
link: https://developer.apple.com/documentation/os/3191911-os_proc_available_memory