### PR TITLE
API review

### DIFF
--- a/Samples/Common/Sources/IntegrationTestsHelper/ReportConfig.swift
+++ b/Samples/Common/Sources/IntegrationTestsHelper/ReportConfig.swift
@@ -44,7 +44,7 @@ extension ReportConfig {
         guard let store = KSCrash.shared.reportStore else {
             return
         }
-        store.sink = CrashReportFilterPipeline(filtersArray: [
+        store.sink = CrashReportFilterPipeline(filters: [
             CrashReportFilterAppleFmt(),
             DirectorySink(url),
         ])

--- a/Samples/Common/Sources/IntegrationTestsHelper/ReportConfig.swift
+++ b/Samples/Common/Sources/IntegrationTestsHelper/ReportConfig.swift
@@ -45,7 +45,7 @@ extension ReportConfig {
             return
         }
         store.sink = CrashReportFilterPipeline(filters: [
-            CrashReportFilterAppleFmt(),
+            CrashReportFilterAppleFmt(reportStyle: .symbolicated),
             DirectorySink(url),
         ])
         store.sendAllReports()

--- a/Samples/Common/Sources/IntegrationTestsHelper/ReportConfig.swift
+++ b/Samples/Common/Sources/IntegrationTestsHelper/ReportConfig.swift
@@ -45,7 +45,7 @@ extension ReportConfig {
             return
         }
         store.sink = CrashReportFilterPipeline(filters: [
-            CrashReportFilterAppleFmt(reportStyle: .symbolicated),
+            CrashReportFilterAppleFmt(),
             DirectorySink(url),
         ])
         store.sendAllReports()

--- a/Samples/Common/Sources/LibraryBridge/CrashReportStore+Bridge.swift
+++ b/Samples/Common/Sources/LibraryBridge/CrashReportStore+Bridge.swift
@@ -70,7 +70,7 @@ public extension CrashReportStore {
     func logWithAlert() {
         sink = CrashReportFilterPipeline(filters: [
             CrashReportFilterAlert(title: "Sample Alert", message: "Do you want to log?", yesAnswer: "Yes", noAnswer: "No"),
-            CrashReportFilterAppleFmt(reportStyle: .symbolicated),
+            CrashReportFilterAppleFmt(),
             CrashReportSinkConsole(),
         ])
         sendAllReports()

--- a/Samples/Common/Sources/LibraryBridge/CrashReportStore+Bridge.swift
+++ b/Samples/Common/Sources/LibraryBridge/CrashReportStore+Bridge.swift
@@ -45,7 +45,7 @@ public extension CrashReportStore {
     }
 
     func logToConsole() {
-        sink = CrashReportSinkConsole.filter().defaultCrashReportFilterSet()
+        sink = CrashReportSinkConsole.filter.defaultCrashReportFilterSet
         sendAllReports { reports, error in
             if let reports {
                 Self.logger.info("Logged \(reports.count) reports")

--- a/Samples/Common/Sources/LibraryBridge/CrashReportStore+Bridge.swift
+++ b/Samples/Common/Sources/LibraryBridge/CrashReportStore+Bridge.swift
@@ -70,7 +70,7 @@ public extension CrashReportStore {
     func logWithAlert() {
         sink = CrashReportFilterPipeline(filters: [
             CrashReportFilterAlert(title: "Sample Alert", message: "Do you want to log?", yesAnswer: "Yes", noAnswer: "No"),
-            CrashReportFilterAppleFmt(),
+            CrashReportFilterAppleFmt(reportStyle: .symbolicated),
             CrashReportSinkConsole(),
         ])
         sendAllReports()

--- a/Samples/Common/Sources/LibraryBridge/CrashReportStore+Bridge.swift
+++ b/Samples/Common/Sources/LibraryBridge/CrashReportStore+Bridge.swift
@@ -68,7 +68,7 @@ public extension CrashReportStore {
     }
 
     func logWithAlert() {
-        sink = CrashReportFilterPipeline(filtersArray: [
+        sink = CrashReportFilterPipeline(filters: [
             CrashReportFilterAlert(title: "Sample Alert", message: "Do you want to log?", yesAnswer: "Yes", noAnswer: "No"),
             CrashReportFilterAppleFmt(),
             CrashReportSinkConsole(),
@@ -77,7 +77,7 @@ public extension CrashReportStore {
     }
 
     func sampleLogToConsole() {
-        sink = CrashReportFilterPipeline(filtersArray: [
+        sink = CrashReportFilterPipeline(filters: [
             CrashReportFilterDemangle(),
             SampleFilter(),
             SampleSink(),

--- a/Samples/Common/Sources/LibraryBridge/CrashReportStore+Bridge.swift
+++ b/Samples/Common/Sources/LibraryBridge/CrashReportStore+Bridge.swift
@@ -45,7 +45,7 @@ public extension CrashReportStore {
     }
 
     func logToConsole() {
-        sink = CrashReportSinkConsole.filter.defaultCrashReportFilterSet
+        sink = CrashReportSinkConsole().defaultCrashReportFilterSet
         sendAllReports { reports, error in
             if let reports {
                 Self.logger.info("Logged \(reports.count) reports")

--- a/Sources/KSCrashFilters/KSCrashReportFilterAlert.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterAlert.m
@@ -141,14 +141,6 @@
 
 @implementation KSCrashReportFilterAlert
 
-+ (instancetype)filterWithTitle:(NSString *)title
-                        message:(nullable NSString *)message
-                      yesAnswer:(NSString *)yesAnswer
-                       noAnswer:(nullable NSString *)noAnswer;
-{
-    return [[self alloc] initWithTitle:title message:message yesAnswer:yesAnswer noAnswer:noAnswer];
-}
-
 - (instancetype)initWithTitle:(NSString *)title
                       message:(nullable NSString *)message
                     yesAnswer:(NSString *)yesAnswer

--- a/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
@@ -166,11 +166,6 @@ static NSDictionary *g_registerOrders;
                                x86Order, @"i686", x86_64Order, @"x86_64", nil];
 }
 
-+ (instancetype)filterWithReportStyle:(KSAppleReportStyle)reportStyle
-{
-    return [[self alloc] initWithReportStyle:reportStyle];
-}
-
 - (instancetype)initWithReportStyle:(KSAppleReportStyle)reportStyle
 {
     if ((self = [super init])) {

--- a/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterAppleFmt.m
@@ -174,6 +174,11 @@ static NSDictionary *g_registerOrders;
     return self;
 }
 
+- (instancetype)init
+{
+    return [self initWithReportStyle:KSAppleReportStyleSymbolicated];
+}
+
 - (int)majorVersion:(NSDictionary *)report
 {
     NSDictionary *info = [self infoReport:report];

--- a/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
@@ -178,18 +178,10 @@
 
 @implementation KSCrashReportFilterPipeline
 
-- (instancetype)initWithFilters:(NSArray *)filters
+- (instancetype)initWithFilters:(NSArray<id<KSCrashReportFilter>> *)filters
 {
     if ((self = [super init])) {
-        NSMutableArray *expandedFilters = [NSMutableArray array];
-        for (id<KSCrashReportFilter> filter in filters) {
-            if ([filter isKindOfClass:[NSArray class]]) {
-                [expandedFilters addObjectsFromArray:(NSArray *)filter];
-            } else {
-                [expandedFilters addObject:filter];
-            }
-        }
-        _filters = [expandedFilters copy];
+        _filters = [filters copy];
     }
     return self;
 }

--- a/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
@@ -87,27 +87,6 @@
     return [block copy];
 }
 
-+ (instancetype)filterWithFiltersAndKeys:(id)firstFilter, ...
-{
-    NSMutableArray *filters = [NSMutableArray array];
-    NSMutableArray *keys = [NSMutableArray array];
-    ksva_iterate_list(firstFilter, [self argBlockWithFilters:filters andKeys:keys]);
-    return [[self class] filterWithFilters:filters keys:keys];
-}
-
-+ (instancetype)filterWithFilters:(NSArray *)filters keys:(NSArray<NSString *> *)keys
-{
-    return [[self alloc] initWithFilters:filters keys:keys];
-}
-
-- (instancetype)initWithFiltersAndKeys:(id)firstFilter, ...
-{
-    NSMutableArray *filters = [NSMutableArray array];
-    NSMutableArray *keys = [NSMutableArray array];
-    ksva_iterate_list(firstFilter, [[self class] argBlockWithFilters:filters andKeys:keys]);
-    return [self initWithFilters:filters keys:keys];
-}
-
 - (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
     NSArray *filters = self.filters;
@@ -199,24 +178,7 @@
 
 @implementation KSCrashReportFilterPipeline
 
-+ (instancetype)filterWithFilters:(id)firstFilter, ...
-{
-    ksva_list_to_nsarray(firstFilter, filters);
-    return [[self class] filterWithFiltersArray:filters];
-}
-
-+ (instancetype)filterWithFiltersArray:(NSArray *)filters
-{
-    return [[self alloc] initWithFiltersArray:filters];
-}
-
-- (instancetype)initWithFilters:(id)firstFilter, ...
-{
-    ksva_list_to_nsarray(firstFilter, filters);
-    return [self initWithFiltersArray:filters];
-}
-
-- (instancetype)initWithFiltersArray:(NSArray *)filters
+- (instancetype)initWithFilters:(NSArray *)filters
 {
     if ((self = [super init])) {
         NSMutableArray *expandedFilters = [NSMutableArray array];
@@ -300,24 +262,7 @@
 
 @implementation KSCrashReportFilterConcatenate
 
-+ (instancetype)filterWithSeparatorFmt:(NSString *)separatorFmt keys:(id)firstKey, ...
-{
-    ksva_list_to_nsarray(firstKey, keys);
-    return [[self class] filterWithSeparatorFmt:separatorFmt keysArray:keys];
-}
-
-+ (instancetype)filterWithSeparatorFmt:(NSString *)separatorFmt keysArray:(NSArray<NSString *> *)keys
-{
-    return [[self alloc] initWithSeparatorFmt:separatorFmt keysArray:keys];
-}
-
-- (instancetype)initWithSeparatorFmt:(NSString *)separatorFmt keys:(id)firstKey, ...
-{
-    ksva_list_to_nsarray(firstKey, keys);
-    return [self initWithSeparatorFmt:separatorFmt keysArray:keys];
-}
-
-- (instancetype)initWithSeparatorFmt:(NSString *)separatorFmt keysArray:(NSArray<NSString *> *)keys
+- (instancetype)initWithSeparatorFmt:(NSString *)separatorFmt keys:(NSArray<NSString *> *)keys
 {
     if ((self = [super init])) {
         NSMutableArray *realKeys = [NSMutableArray array];
@@ -368,23 +313,6 @@
 @end
 
 @implementation KSCrashReportFilterSubset
-
-+ (instancetype)filterWithKeys:(id)firstKeyPath, ...
-{
-    ksva_list_to_nsarray(firstKeyPath, keyPaths);
-    return [[self class] filterWithKeysArray:keyPaths];
-}
-
-+ (instancetype)filterWithKeysArray:(NSArray<NSString *> *)keyPaths
-{
-    return [[self alloc] initWithKeysArray:keyPaths];
-}
-
-- (instancetype)initWithKeys:(id)firstKeyPath, ...
-{
-    ksva_list_to_nsarray(firstKeyPath, keyPaths);
-    return [self initWithKeysArray:keyPaths];
-}
 
 - (instancetype)initWithKeysArray:(NSArray<NSString *> *)keyPaths
 {

--- a/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
@@ -35,11 +35,6 @@
 
 @implementation KSCrashReportFilterPassthrough
 
-+ (instancetype)filter
-{
-    return [[self alloc] init];
-}
-
 - (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
     kscrash_callCompletion(onCompletion, reports, nil);
@@ -439,11 +434,6 @@
 
 @implementation KSCrashReportFilterDataToString
 
-+ (instancetype)filter
-{
-    return [[self alloc] init];
-}
-
 - (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
     NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
@@ -467,11 +457,6 @@
 @end
 
 @implementation KSCrashReportFilterStringToData
-
-+ (instancetype)filter
-{
-    return [[self alloc] init];
-}
 
 - (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {

--- a/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
@@ -51,11 +51,11 @@
 
 @implementation KSCrashReportFilterCombine
 
-- (instancetype)initWithFilters:(NSArray *)filters keys:(NSArray<NSString *> *)keys
+- (instancetype)initWithFilterDictionary:(NSDictionary<NSString *, id> *)filterDictionary
 {
     if ((self = [super init])) {
-        _filters = [filters copy];
-        _keys = [keys copy];
+        _filters = [filterDictionary.allValues copy];
+        _keys = [filterDictionary.allKeys copy];
     }
     return self;
 }
@@ -72,7 +72,7 @@
             }
         } else {
             if ([entry isKindOfClass:[NSArray class]]) {
-                entry = [KSCrashReportFilterPipeline filterWithFilters:entry, nil];
+                entry = [[KSCrashReportFilterPipeline alloc] initWithFilters:@[ entry ]];
             }
             if (![entry conformsToProtocol:@protocol(KSCrashReportFilter)]) {
                 KSLOG_ERROR(@"Not a filter: %@", entry);

--- a/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
@@ -44,8 +44,8 @@
 
 @interface KSCrashReportFilterCombine ()
 
-@property(nonatomic, readwrite, copy) NSArray<id<KSCrashReportFilter>>*filters;
-@property(nonatomic, readwrite, copy) NSArray<NSString *>*keys;
+@property(nonatomic, readwrite, copy) NSArray<id<KSCrashReportFilter>> *filters;
+@property(nonatomic, readwrite, copy) NSArray<NSString *> *keys;
 
 @end
 
@@ -58,33 +58,6 @@
         _keys = [filterDictionary.allKeys copy];
     }
     return self;
-}
-
-+ (KSVA_Block)argBlockWithFilters:(NSMutableArray *)filters andKeys:(NSMutableArray *)keys
-{
-    __block BOOL isKey = FALSE;
-    KSVA_Block block = ^(id entry) {
-        if (isKey) {
-            if (entry == nil) {
-                KSLOG_ERROR(@"key entry was nil");
-            } else {
-                [keys addObject:entry];
-            }
-        } else {
-            if ([entry isKindOfClass:[NSArray class]]) {
-                entry = [[KSCrashReportFilterPipeline alloc] initWithFilters:@[ entry ]];
-            }
-            if (![entry conformsToProtocol:@protocol(KSCrashReportFilter)]) {
-                KSLOG_ERROR(@"Not a filter: %@", entry);
-                // Cause next key entry to fail as well.
-                return;
-            } else {
-                [filters addObject:entry];
-            }
-        }
-        isKey = !isKey;
-    };
-    return [block copy];
 }
 
 - (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
@@ -306,7 +279,7 @@
 
 @implementation KSCrashReportFilterSubset
 
-- (instancetype)initWithKeysArray:(NSArray<NSString *> *)keyPaths
+- (instancetype)initWithKeys:(NSArray<NSString *> *)keyPaths
 {
     if ((self = [super init])) {
         NSMutableArray *realKeyPaths = [NSMutableArray array];

--- a/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
@@ -44,14 +44,14 @@
 
 @interface KSCrashReportFilterCombine ()
 
-@property(nonatomic, readwrite, copy) NSArray *filters;
-@property(nonatomic, readwrite, copy) NSArray *keys;
+@property(nonatomic, readwrite, copy) NSArray<id<KSCrashReportFilter>>*filters;
+@property(nonatomic, readwrite, copy) NSArray<NSString *>*keys;
 
 @end
 
 @implementation KSCrashReportFilterCombine
 
-- (instancetype)initWithFilterDictionary:(NSDictionary<NSString *, id> *)filterDictionary
+- (instancetype)initWithFilters:(NSDictionary<NSString *, id<KSCrashReportFilter>> *)filterDictionary
 {
     if ((self = [super init])) {
         _filters = [filterDictionary.allValues copy];

--- a/Sources/KSCrashFilters/KSCrashReportFilterGZip.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterGZip.m
@@ -39,11 +39,6 @@
 
 @implementation KSCrashReportFilterGZipCompress
 
-+ (instancetype)filterWithCompressionLevel:(NSInteger)compressionLevel
-{
-    return [[self alloc] initWithCompressionLevel:compressionLevel];
-}
-
 - (instancetype)initWithCompressionLevel:(NSInteger)compressionLevel
 {
     if ((self = [super init])) {

--- a/Sources/KSCrashFilters/KSCrashReportFilterGZip.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterGZip.m
@@ -80,11 +80,6 @@
 
 @implementation KSCrashReportFilterGZipDecompress
 
-+ (instancetype)filter
-{
-    return [[self alloc] init];
-}
-
 - (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
     NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];

--- a/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
@@ -46,6 +46,11 @@
     return self;
 }
 
+- (instancetype)init
+{
+    return [self initWithOptions:KSJSONEncodeOptionNone];
+}
+
 - (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
     NSMutableArray<id<KSCrashReport>> *filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
@@ -84,6 +89,11 @@
         _decodeOptions = options;
     }
     return self;
+}
+
+- (instancetype)init
+{
+    return [self initWithOptions:KSJSONDecodeOptionNone];
 }
 
 - (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion

--- a/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterJSON.m
@@ -38,11 +38,6 @@
 
 @implementation KSCrashReportFilterJSONEncode
 
-+ (instancetype)filterWithOptions:(KSJSONEncodeOption)options
-{
-    return [[self alloc] initWithOptions:options];
-}
-
 - (instancetype)initWithOptions:(KSJSONEncodeOption)options
 {
     if ((self = [super init])) {
@@ -82,11 +77,6 @@
 @end
 
 @implementation KSCrashReportFilterJSONDecode
-
-+ (instancetype)filterWithOptions:(KSJSONDecodeOption)options
-{
-    return [[self alloc] initWithOptions:options];
-}
 
 - (instancetype)initWithOptions:(KSJSONDecodeOption)options
 {

--- a/Sources/KSCrashFilters/KSCrashReportFilterSets.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterSets.m
@@ -41,7 +41,7 @@
     id<KSCrashReportFilter> userSystemFilter = [self createUserSystemFilterPipeline];
 
     id<KSCrashReportFilter> combineFilter = [[KSCrashReportFilterCombine alloc]
-        initWithFilterDictionary:@{ kAppleReportName : appleFilter, kUserSystemDataName : userSystemFilter }];
+        initWithFilters:@{ kAppleReportName : appleFilter, kUserSystemDataName : userSystemFilter }];
 
     id<KSCrashReportFilter> concatenateFilter =
         [[KSCrashReportFilterConcatenate alloc] initWithSeparatorFmt:@"\n\n-------- %@ --------\n\n"

--- a/Sources/KSCrashFilters/KSCrashReportFilterSets.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterSets.m
@@ -39,7 +39,7 @@
         filterWithFilters:[KSCrashReportFilterSubset filterWithKeys:KSCrashField_System, KSCrashField_User, nil],
                           [KSCrashReportFilterJSONEncode
                               filterWithOptions:KSJSONEncodeOptionPretty | KSJSONEncodeOptionSorted],
-                          [KSCrashReportFilterDataToString filter], nil];
+                          [KSCrashReportFilterDataToString new], nil];
 
     NSString *appleName = @"Apple Report";
     NSString *userSystemName = @"User & System Data";
@@ -52,7 +52,7 @@
                          nil];
 
     if (compressed) {
-        [filters addObject:[KSCrashReportFilterStringToData filter]];
+        [filters addObject:[KSCrashReportFilterStringToData new]];
         [filters addObject:[KSCrashReportFilterGZipCompress filterWithCompressionLevel:-1]];
     }
 

--- a/Sources/KSCrashFilters/KSCrashReportFilterSets.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterSets.m
@@ -60,7 +60,7 @@
 + (id<KSCrashReportFilter>)createUserSystemFilterPipeline
 {
     return [[KSCrashReportFilterPipeline alloc] initWithFilters:@[
-        [[KSCrashReportFilterSubset alloc] initWithKeysArray:@[ KSCrashField_System, KSCrashField_User ]],
+        [[KSCrashReportFilterSubset alloc] initWithKeys:@[ KSCrashField_System, KSCrashField_User ]],
         [[KSCrashReportFilterJSONEncode alloc] initWithOptions:KSJSONEncodeOptionPretty | KSJSONEncodeOptionSorted],
         [KSCrashReportFilterDataToString new]
     ]];

--- a/Sources/KSCrashFilters/KSCrashReportFilterSets.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterSets.m
@@ -34,29 +34,36 @@
 
 + (id<KSCrashReportFilter>)appleFmtWithUserAndSystemData:(KSAppleReportStyle)reportStyle compressed:(BOOL)compressed
 {
-    id<KSCrashReportFilter> appleFilter = [KSCrashReportFilterAppleFmt filterWithReportStyle:reportStyle];
-    id<KSCrashReportFilter> userSystemFilter = [KSCrashReportFilterPipeline
-        filterWithFilters:[KSCrashReportFilterSubset filterWithKeys:KSCrashField_System, KSCrashField_User, nil],
-                          [KSCrashReportFilterJSONEncode
-                              filterWithOptions:KSJSONEncodeOptionPretty | KSJSONEncodeOptionSorted],
-                          [KSCrashReportFilterDataToString new], nil];
+    NSString *const kAppleReportName = @"Apple Report";
+    NSString *const kUserSystemDataName = @"User & System Data";
 
-    NSString *appleName = @"Apple Report";
-    NSString *userSystemName = @"User & System Data";
+    id<KSCrashReportFilter> appleFilter = [[KSCrashReportFilterAppleFmt alloc] initWithReportStyle:reportStyle];
+    id<KSCrashReportFilter> userSystemFilter = [self createUserSystemFilterPipeline];
 
-    NSMutableArray *filters = [NSMutableArray
-        arrayWithObjects:[KSCrashReportFilterCombine
-                             filterWithFiltersAndKeys:appleFilter, appleName, userSystemFilter, userSystemName, nil],
-                         [KSCrashReportFilterConcatenate filterWithSeparatorFmt:@"\n\n-------- %@ --------\n\n"
-                                                                           keys:appleName, userSystemName, nil],
-                         nil];
+    id<KSCrashReportFilter> combineFilter = [[KSCrashReportFilterCombine alloc]
+        initWithFilterDictionary:@{ kAppleReportName : appleFilter, kUserSystemDataName : userSystemFilter }];
+
+    id<KSCrashReportFilter> concatenateFilter =
+        [[KSCrashReportFilterConcatenate alloc] initWithSeparatorFmt:@"\n\n-------- %@ --------\n\n"
+                                                                keys:@[ kAppleReportName, kUserSystemDataName ]];
+
+    NSMutableArray *mainFilters = [NSMutableArray arrayWithObjects:combineFilter, concatenateFilter, nil];
 
     if (compressed) {
-        [filters addObject:[KSCrashReportFilterStringToData new]];
-        [filters addObject:[KSCrashReportFilterGZipCompress filterWithCompressionLevel:-1]];
+        [mainFilters addObject:[KSCrashReportFilterStringToData new]];
+        [mainFilters addObject:[[KSCrashReportFilterGZipCompress alloc] initWithCompressionLevel:-1]];
     }
 
-    return [KSCrashReportFilterPipeline filterWithFilters:filters, nil];
+    return [[KSCrashReportFilterPipeline alloc] initWithFilters:mainFilters];
+}
+
++ (id<KSCrashReportFilter>)createUserSystemFilterPipeline
+{
+    return [[KSCrashReportFilterPipeline alloc] initWithFilters:@[
+        [[KSCrashReportFilterSubset alloc] initWithKeysArray:@[ KSCrashField_System, KSCrashField_User ]],
+        [[KSCrashReportFilterJSONEncode alloc] initWithOptions:KSJSONEncodeOptionPretty | KSJSONEncodeOptionSorted],
+        [KSCrashReportFilterDataToString new]
+    ]];
 }
 
 @end

--- a/Sources/KSCrashFilters/KSCrashReportFilterStringify.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterStringify.m
@@ -31,11 +31,6 @@
 
 @implementation KSCrashReportFilterStringify
 
-+ (instancetype)filter
-{
-    return [[self alloc] init];
-}
-
 - (NSString *)stringifyReport:(id<KSCrashReport>)report
 {
     if ([report isKindOfClass:[KSCrashReportString class]]) {

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterAlert.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterAlert.h
@@ -49,18 +49,6 @@ NS_SWIFT_NAME(CrashReportFilterAlert)
  * @param noAnswer The text to put in the "no" button. If nil, the filter will
  *                 proceed unconditionally.
  */
-+ (instancetype)filterWithTitle:(NSString *)title
-                        message:(nullable NSString *)message
-                      yesAnswer:(NSString *)yesAnswer
-                       noAnswer:(nullable NSString *)noAnswer;
-
-/**
- * @param title The title of the alert.
- * @param message The contents of the alert.
- * @param yesAnswer The text to put in the "yes" button.
- * @param noAnswer The text to put in the "no" button. If nil, the filter will
- *                 proceed unconditionally.
- */
 - (instancetype)initWithTitle:(NSString *)title
                       message:(nullable NSString *)message
                     yesAnswer:(NSString *)yesAnswer

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterAlert.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterAlert.h
@@ -42,6 +42,9 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(CrashReportFilterAlert)
 @interface KSCrashReportFilterAlert : NSObject <KSCrashReportFilter>
 
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 /**
  * @param title The title of the alert.
  * @param message The contents of the alert.

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterAppleFmt.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterAppleFmt.h
@@ -107,6 +107,9 @@ typedef NS_ENUM(NSInteger, KSAppleReportStyle) {
 NS_SWIFT_NAME(CrashReportFilterAppleFmt)
 @interface KSCrashReportFilterAppleFmt : NSObject <KSCrashReportFilter>
 
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithReportStyle:(KSAppleReportStyle)reportStyle;
 
 - (NSString *)headerStringForSystemInfo:(NSDictionary<NSString *, id> *)system

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterAppleFmt.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterAppleFmt.h
@@ -107,8 +107,6 @@ typedef NS_ENUM(NSInteger, KSAppleReportStyle) {
 NS_SWIFT_NAME(CrashReportFilterAppleFmt)
 @interface KSCrashReportFilterAppleFmt : NSObject <KSCrashReportFilter>
 
-+ (instancetype)filterWithReportStyle:(KSAppleReportStyle)reportStyle;
-
 - (instancetype)initWithReportStyle:(KSAppleReportStyle)reportStyle;
 
 - (NSString *)headerStringForSystemInfo:(NSDictionary<NSString *, id> *)system

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterAppleFmt.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterAppleFmt.h
@@ -107,11 +107,25 @@ typedef NS_ENUM(NSInteger, KSAppleReportStyle) {
 NS_SWIFT_NAME(CrashReportFilterAppleFmt)
 @interface KSCrashReportFilterAppleFmt : NSObject <KSCrashReportFilter>
 
-- (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)new NS_UNAVAILABLE;
-
+/** Initialize with a specific Apple report style.
+ * @param reportStyle The Apple report style to use for symbolication.
+ * @return The initialized instance.
+ * @see KSAppleReportStyle for detailed information on symbolication options.
+ */
 - (instancetype)initWithReportStyle:(KSAppleReportStyle)reportStyle;
 
+/** Default initializer.
+ * @return The initialized instance with KSAppleReportStyleSymbolicated.
+ * @note This style symbolicates all stack trace entries.
+ */
+- (instancetype)init;
+
+/** Generate a header string for the Apple-style crash report.
+ * @param system Dictionary containing system information (e.g., device, OS, app details).
+ * @param reportID Unique identifier for the crash report.
+ * @param crashTime Timestamp of when the crash occurred.
+ * @return Formatted header string including incident identifier, hardware model, process info, OS version, etc.
+ */
 - (NSString *)headerStringForSystemInfo:(NSDictionary<NSString *, id> *)system
                                reportID:(nullable NSString *)reportID
                               crashTime:(nullable NSDate *)crashTime;

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
@@ -51,16 +51,20 @@ NS_SWIFT_NAME(CrashReportFilterPassthrough)
 NS_SWIFT_NAME(CrashReportFilterCombine)
 @interface KSCrashReportFilterCombine : NSObject <KSCrashReportFilter>
 
-/** Initializer.
+/**
+ * Initializer.
  *
- * @param filters An array of filters to apply. Each filter should conform to the
- *                KSCrashReportFilter protocol. If a filter is an NSArray, it will
- *                be wrapped in a pipeline filter.
- * @param keys    An array of keys corresponding to each filter. Each key will be
- *                used to store the output of its respective filter in the final
- *                report dictionary.
+ * @param filterDictionary A dictionary where each key-value pair represents a filter
+ *                         and its corresponding key. The keys are strings that will
+ *                         be used to store the output of their respective filters in
+ *                         the final report dictionary. The values are the filters to
+ *                         apply. Each filter should conform to the KSCrashReportFilter
+ *                         protocol. If a filter value is an NSArray, it will be wrapped
+ *                         in a pipeline filter.
+ *
+ * @return An initialized instance of the class.
  */
-- (instancetype)initWithFilters:(NSArray *)filters keys:(NSArray<NSString *> *)keys;
+- (instancetype)initWithFilterDictionary:(NSDictionary<NSString *, id> *)filterDictionary;
 
 @end
 

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
@@ -64,7 +64,7 @@ NS_SWIFT_NAME(CrashReportFilterCombine)
  *
  * @return An initialized instance of the class.
  */
-- (instancetype)initWithFilterDictionary:(NSDictionary<NSString *, id> *)filterDictionary;
+- (instancetype)initWithFilters:(NSDictionary<NSString *, id<KSCrashReportFilter>> *)filterDictionary;
 
 @end
 

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
@@ -51,33 +51,6 @@ NS_SWIFT_NAME(CrashReportFilterPassthrough)
 NS_SWIFT_NAME(CrashReportFilterCombine)
 @interface KSCrashReportFilterCombine : NSObject <KSCrashReportFilter>
 
-/** Constructor.
- *
- * @param firstFilter The first filter, followed by key, filter, key, ...
- *                    Each "filter" can be id<KSCrashReportFilter> or an NSArray
- *                    of filters (which gets wrapped in a pipeline filter).
- */
-+ (instancetype)filterWithFiltersAndKeys:(nullable id)firstFilter, ... NS_REQUIRES_NIL_TERMINATION;
-
-/** Constructor.
- *
- * @param filters An array of filters to apply. Each filter should conform to the
- *                KSCrashReportFilter protocol. If a filter is an NSArray, it will
- *                be wrapped in a pipeline filter.
- * @param keys    An array of keys corresponding to each filter. Each key will be
- *                used to store the output of its respective filter in the final
- *                report dictionary.
- */
-+ (instancetype)filterWithFilters:(NSArray *)filters keys:(NSArray<NSString *> *)keys;
-
-/** Initializer.
- *
- * @param firstFilter The first filter, followed by key, filter, key, ...
- *                    Each "filter" can be id<KSCrashReportFilter> or an NSArray
- *                    of filters (which gets wrapped in a pipeline filter).
- */
-- (instancetype)initWithFiltersAndKeys:(nullable id)firstFilter, ... NS_REQUIRES_NIL_TERMINATION;
-
 /** Initializer.
  *
  * @param filters An array of filters to apply. Each filter should conform to the
@@ -103,37 +76,13 @@ NS_SWIFT_NAME(CrashReportFilterPipeline)
 /** The filters in this pipeline. */
 @property(nonatomic, readonly, copy) NSArray<id<KSCrashReportFilter>> *filters;
 
-/** Constructor.
- *
- * @param firstFilter The first filter, followed by filter, filter, ...
- *                    Each "filter" can be an id<KSCrashReportFilter> or an NSArray
- *                    containing filters or locations of filters (which get wrapped in a pipeline filter).
- */
-+ (instancetype)filterWithFilters:(nullable id)firstFilter, ... NS_REQUIRES_NIL_TERMINATION;
-
-/** Constructor using an array of filters.
- *
- * @param filters An array where each element can be a filter conforming to
- *                the KSCrashReportFilter protocol or a location of filters.
- *                Arrays of filters will be wrapped in a pipeline filter.
- */
-+ (instancetype)filterWithFiltersArray:(NSArray *)filters;
-
-/** Initializer.
- *
- * @param firstFilter The first filter, followed by filter, filter, ...
- *                    Each "filter" can be an id<KSCrashReportFilter> or an NSArray
- *                    containing filters or locations of filters (which get wrapped in a pipeline filter).
- */
-- (instancetype)initWithFilters:(nullable id)firstFilter, ... NS_REQUIRES_NIL_TERMINATION;
-
 /** Initializer using an array of filters.
  *
  * @param filters An array where each element can be a filter conforming to
  *                the KSCrashReportFilter protocol or a location of filters.
  *                Arrays of filters will be wrapped in a pipeline filter.
  */
-- (instancetype)initWithFiltersArray:(NSArray *)filters;
+- (instancetype)initWithFilters:(NSArray *)filters;
 
 /** Adds a filter to the beginning of the pipeline.
  *
@@ -154,31 +103,6 @@ NS_SWIFT_NAME(CrashReportFilterPipeline)
 NS_SWIFT_NAME(CrashReportFilterConcatenate)
 @interface KSCrashReportFilterConcatenate : NSObject <KSCrashReportFilter>
 
-/** Constructor.
- *
- * @param separatorFmt Formatting text to use when separating the values. You may include
- *                     %@ in the formatting text to include the key name as well.
- * @param firstKey Series of keys to extract from the source report.
- */
-+ (instancetype)filterWithSeparatorFmt:(NSString *)separatorFmt keys:(id)firstKey, ... NS_REQUIRES_NIL_TERMINATION;
-
-/** Constructor using an array of keys.
- *
- * @param separatorFmt Formatting text to use when separating the values. You may include
- *                     %@ in the formatting text to include the key name as well.
- * @param keys         An array of keys whose corresponding values will be concatenated
- *                     from the source report.
- */
-+ (instancetype)filterWithSeparatorFmt:(NSString *)separatorFmt keysArray:(NSArray<NSString *> *)keys;
-
-/** Initializer.
- *
- * @param separatorFmt Formatting text to use when separating the values. You may include
- *                     %@ in the formatting text to include the key name as well.
- * @param firstKey Series of keys to extract from the source report.
- */
-- (instancetype)initWithSeparatorFmt:(NSString *)separatorFmt keys:(id)firstKey, ... NS_REQUIRES_NIL_TERMINATION;
-
 /** Initializer using an array of keys.
  *
  * @param separatorFmt Formatting text to use when separating the values. You may include
@@ -186,7 +110,7 @@ NS_SWIFT_NAME(CrashReportFilterConcatenate)
  * @param keys         An array of keys whose corresponding values will be concatenated
  *                     from the source report.
  */
-- (instancetype)initWithSeparatorFmt:(NSString *)separatorFmt keysArray:(NSArray<NSString *> *)keys;
+- (instancetype)initWithSeparatorFmt:(NSString *)separatorFmt keys:(NSArray<NSString *> *)keys;
 
 @end
 
@@ -198,25 +122,6 @@ NS_SWIFT_NAME(CrashReportFilterConcatenate)
  */
 NS_SWIFT_NAME(CrashReportFilterSubset)
 @interface KSCrashReportFilterSubset : NSObject <KSCrashReportFilter>
-
-/** Constructor.
- *
- * @param firstKeyPath Series of key paths to search in the source reports.
- */
-+ (instancetype)filterWithKeys:(id)firstKeyPath, ... NS_REQUIRES_NIL_TERMINATION;
-
-/** Constructor using an array of key paths.
- *
- * @param keyPaths An array of key paths to search for in the source reports.
- *                 Each key path will extract a subset of data from the reports.
- */
-+ (instancetype)filterWithKeysArray:(NSArray<NSString *> *)keyPaths;
-
-/** Initializer.
- *
- * @param firstKeyPath Series of key paths to search in the source reports.
- */
-- (instancetype)initWithKeys:(id)firstKeyPath, ... NS_REQUIRES_NIL_TERMINATION;
 
 /** Initializer using an array of key paths.
  *

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
@@ -82,11 +82,10 @@ NS_SWIFT_NAME(CrashReportFilterPipeline)
 
 /** Initializer using an array of filters.
  *
- * @param filters An array where each element can be a filter conforming to
- *                the KSCrashReportFilter protocol or a location of filters.
- *                Arrays of filters will be wrapped in a pipeline filter.
+ * @param filters An array of filters, where each filter conforms to
+ *                the KSCrashReportFilter protocol.
  */
-- (instancetype)initWithFilters:(NSArray *)filters;
+- (instancetype)initWithFilters:(NSArray<KSCrashReportFilter> *)filters;
 
 /** Adds a filter to the beginning of the pipeline.
  *

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(CrashReportFilterPassthrough)
 @interface KSCrashReportFilterPassthrough : NSObject <KSCrashReportFilter>
 
-+ (instancetype)filter;
+@property(class, readonly) KSCrashReportFilterPassthrough *filter NS_SWIFT_NAME(filter);
 
 @end
 
@@ -238,7 +238,7 @@ NS_SWIFT_NAME(CrashReportFilterSubset)
 NS_SWIFT_NAME(CrashReportFilterDataToString)
 @interface KSCrashReportFilterDataToString : NSObject <KSCrashReportFilter>
 
-+ (instancetype)filter;
+@property(class, readonly) KSCrashReportFilterDataToString *filter NS_SWIFT_NAME(filter);
 
 @end
 
@@ -251,7 +251,7 @@ NS_SWIFT_NAME(CrashReportFilterDataToString)
 NS_SWIFT_NAME(CrashReportFilterStringToData)
 @interface KSCrashReportFilterStringToData : NSObject <KSCrashReportFilter>
 
-+ (instancetype)filter;
+@property(class, readonly) KSCrashReportFilterStringToData *filter NS_SWIFT_NAME(filter);
 
 @end
 

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
@@ -39,8 +39,6 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(CrashReportFilterPassthrough)
 @interface KSCrashReportFilterPassthrough : NSObject <KSCrashReportFilter>
 
-@property(class, readonly) KSCrashReportFilterPassthrough *filter;
-
 @end
 
 /**
@@ -238,8 +236,6 @@ NS_SWIFT_NAME(CrashReportFilterSubset)
 NS_SWIFT_NAME(CrashReportFilterDataToString)
 @interface KSCrashReportFilterDataToString : NSObject <KSCrashReportFilter>
 
-@property(class, readonly) KSCrashReportFilterDataToString *filter;
-
 @end
 
 /**
@@ -250,8 +246,6 @@ NS_SWIFT_NAME(CrashReportFilterDataToString)
  */
 NS_SWIFT_NAME(CrashReportFilterStringToData)
 @interface KSCrashReportFilterStringToData : NSObject <KSCrashReportFilter>
-
-@property(class, readonly) KSCrashReportFilterStringToData *filter;
 
 @end
 

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
@@ -51,6 +51,9 @@ NS_SWIFT_NAME(CrashReportFilterPassthrough)
 NS_SWIFT_NAME(CrashReportFilterCombine)
 @interface KSCrashReportFilterCombine : NSObject <KSCrashReportFilter>
 
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 /**
  * Initializer.
  *
@@ -59,8 +62,7 @@ NS_SWIFT_NAME(CrashReportFilterCombine)
  *                         be used to store the output of their respective filters in
  *                         the final report dictionary. The values are the filters to
  *                         apply. Each filter should conform to the KSCrashReportFilter
- *                         protocol. If a filter value is an NSArray, it will be wrapped
- *                         in a pipeline filter.
+ *                         protocol.
  *
  * @return An initialized instance of the class.
  */
@@ -106,6 +108,9 @@ NS_SWIFT_NAME(CrashReportFilterPipeline)
 NS_SWIFT_NAME(CrashReportFilterConcatenate)
 @interface KSCrashReportFilterConcatenate : NSObject <KSCrashReportFilter>
 
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 /** Initializer using an array of keys.
  *
  * @param separatorFmt Formatting text to use when separating the values. You may include
@@ -125,6 +130,9 @@ NS_SWIFT_NAME(CrashReportFilterConcatenate)
  */
 NS_SWIFT_NAME(CrashReportFilterSubset)
 @interface KSCrashReportFilterSubset : NSObject <KSCrashReportFilter>
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
 
 /** Initializer using an array of key paths.
  *

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
@@ -85,7 +85,7 @@ NS_SWIFT_NAME(CrashReportFilterPipeline)
  * @param filters An array of filters, where each filter conforms to
  *                the KSCrashReportFilter protocol.
  */
-- (instancetype)initWithFilters:(NSArray<KSCrashReportFilter> *)filters;
+- (instancetype)initWithFilters:(NSArray<id<KSCrashReportFilter>> *)filters;
 
 /** Adds a filter to the beginning of the pipeline.
  *
@@ -131,7 +131,7 @@ NS_SWIFT_NAME(CrashReportFilterSubset)
  * @param keyPaths An array of key paths to search for in the source reports.
  *                 Each key path will extract a subset of data from the reports.
  */
-- (instancetype)initWithKeysArray:(NSArray<NSString *> *)keyPaths;
+- (instancetype)initWithKeys:(NSArray<NSString *> *)keyPaths;
 
 @end
 

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterBasic.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(CrashReportFilterPassthrough)
 @interface KSCrashReportFilterPassthrough : NSObject <KSCrashReportFilter>
 
-@property(class, readonly) KSCrashReportFilterPassthrough *filter NS_SWIFT_NAME(filter);
+@property(class, readonly) KSCrashReportFilterPassthrough *filter;
 
 @end
 
@@ -238,7 +238,7 @@ NS_SWIFT_NAME(CrashReportFilterSubset)
 NS_SWIFT_NAME(CrashReportFilterDataToString)
 @interface KSCrashReportFilterDataToString : NSObject <KSCrashReportFilter>
 
-@property(class, readonly) KSCrashReportFilterDataToString *filter NS_SWIFT_NAME(filter);
+@property(class, readonly) KSCrashReportFilterDataToString *filter;
 
 @end
 
@@ -251,7 +251,7 @@ NS_SWIFT_NAME(CrashReportFilterDataToString)
 NS_SWIFT_NAME(CrashReportFilterStringToData)
 @interface KSCrashReportFilterStringToData : NSObject <KSCrashReportFilter>
 
-@property(class, readonly) KSCrashReportFilterStringToData *filter NS_SWIFT_NAME(filter);
+@property(class, readonly) KSCrashReportFilterStringToData *filter;
 
 @end
 

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterGZip.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterGZip.h
@@ -89,12 +89,6 @@ NS_SWIFT_NAME(CrashReportFilterGZipCompress)
 NS_SWIFT_NAME(CrashReportFilterGZipDecompress)
 @interface KSCrashReportFilterGZipDecompress : NSObject <KSCrashReportFilter>
 
-/** Constructor.
- *
- * Creates an instance of the filter for Gzip decompression.
- */
-@property(class, readonly) KSCrashReportFilterGZipDecompress *filter;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterGZip.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterGZip.h
@@ -93,7 +93,7 @@ NS_SWIFT_NAME(CrashReportFilterGZipDecompress)
  *
  * Creates an instance of the filter for Gzip decompression.
  */
-@property(class, readonly) KSCrashReportFilterGZipDecompress *filter NS_SWIFT_NAME(filter);
+@property(class, readonly) KSCrashReportFilterGZipDecompress *filter;
 
 @end
 

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterGZip.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterGZip.h
@@ -93,7 +93,7 @@ NS_SWIFT_NAME(CrashReportFilterGZipDecompress)
  *
  * Creates an instance of the filter for Gzip decompression.
  */
-+ (instancetype)filter;
+@property(class, readonly) KSCrashReportFilterGZipDecompress *filter NS_SWIFT_NAME(filter);
 
 @end
 

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterGZip.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterGZip.h
@@ -57,17 +57,6 @@ static KSCrashReportCompressionLevel const KSCrashReportCompressionLevelDefault 
 NS_SWIFT_NAME(CrashReportFilterGZipCompress)
 @interface KSCrashReportFilterGZipCompress : NSObject <KSCrashReportFilter>
 
-/** Constructor.
- *
- * @param compressionLevel Compression level for Gzip compression. It can be
- *                         one of the following `KSCrashReportCompressionLevel` values:
- *                         - `KSCrashReportCompressionLevelNone` (0): No compression.
- *                         - `KSCrashReportCompressionLevelBest` (9): Best compression.
- *                         - `KSCrashReportCompressionLevelDefault` (-1): Default compression level.
- *                         The compression level can be any integer value between 0 and 9.
- */
-+ (instancetype)filterWithCompressionLevel:(KSCrashReportCompressionLevel)compressionLevel;
-
 /** Initializer.
  *
  * @param compressionLevel Compression level for Gzip compression. It can be

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterGZip.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterGZip.h
@@ -57,6 +57,9 @@ static KSCrashReportCompressionLevel const KSCrashReportCompressionLevelDefault 
 NS_SWIFT_NAME(CrashReportFilterGZipCompress)
 @interface KSCrashReportFilterGZipCompress : NSObject <KSCrashReportFilter>
 
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 /** Initializer.
  *
  * @param compressionLevel Compression level for Gzip compression. It can be

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterJSON.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterJSON.h
@@ -39,10 +39,16 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(CrashReportFilterJSONEncode)
 @interface KSCrashReportFilterJSONEncode : NSObject <KSCrashReportFilter>
 
-- (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)new NS_UNAVAILABLE;
-
+/** Initialize with encoding options.
+ * @param options The JSON encoding options to use.
+ * @return The initialized instance.
+ */
 - (instancetype)initWithOptions:(KSJSONEncodeOption)options;
+
+/** Default initializer.
+ * @return The initialized instance with KSJSONEncodeOptionNone.
+ */
+- (instancetype)init;
 
 @end
 
@@ -54,10 +60,16 @@ NS_SWIFT_NAME(CrashReportFilterJSONEncode)
 NS_SWIFT_NAME(CrashReportFilterJSONDecode)
 @interface KSCrashReportFilterJSONDecode : NSObject <KSCrashReportFilter>
 
-- (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)new NS_UNAVAILABLE;
-
+/** Initialize with decoding options.
+ * @param options The JSON decoding options to use.
+ * @return The initialized instance.
+ */
 - (instancetype)initWithOptions:(KSJSONDecodeOption)options;
+
+/** Default initializer.
+ * @return The initialized instance with KSJSONDecodeOptionNone.
+ */
+- (instancetype)init;
 
 @end
 

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterJSON.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterJSON.h
@@ -39,8 +39,6 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(CrashReportFilterJSONEncode)
 @interface KSCrashReportFilterJSONEncode : NSObject <KSCrashReportFilter>
 
-+ (instancetype)filterWithOptions:(KSJSONEncodeOption)options;
-
 - (instancetype)initWithOptions:(KSJSONEncodeOption)options;
 
 @end
@@ -52,8 +50,6 @@ NS_SWIFT_NAME(CrashReportFilterJSONEncode)
  */
 NS_SWIFT_NAME(CrashReportFilterJSONDecode)
 @interface KSCrashReportFilterJSONDecode : NSObject <KSCrashReportFilter>
-
-+ (instancetype)filterWithOptions:(KSJSONDecodeOption)options;
 
 - (instancetype)initWithOptions:(KSJSONDecodeOption)options;
 

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterJSON.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterJSON.h
@@ -39,6 +39,9 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(CrashReportFilterJSONEncode)
 @interface KSCrashReportFilterJSONEncode : NSObject <KSCrashReportFilter>
 
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithOptions:(KSJSONEncodeOption)options;
 
 @end
@@ -50,6 +53,9 @@ NS_SWIFT_NAME(CrashReportFilterJSONEncode)
  */
 NS_SWIFT_NAME(CrashReportFilterJSONDecode)
 @interface KSCrashReportFilterJSONDecode : NSObject <KSCrashReportFilter>
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
 
 - (instancetype)initWithOptions:(KSJSONDecodeOption)options;
 

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterSets.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterSets.h
@@ -37,6 +37,9 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(CrashFilterSets)
 @interface KSCrashFilterSets : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 /** Create an Apple format filter that includes system and user data in JSON format.
  */
 + (id<KSCrashReportFilter>)appleFmtWithUserAndSystemData:(KSAppleReportStyle)reportStyle compressed:(BOOL)compressed;

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterStringify.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterStringify.h
@@ -34,8 +34,6 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(CrashReportFilterStringify)
 @interface KSCrashReportFilterStringify : NSObject <KSCrashReportFilter>
 
-@property(class, readonly) KSCrashReportFilterStringify *filter;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterStringify.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterStringify.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(CrashReportFilterStringify)
 @interface KSCrashReportFilterStringify : NSObject <KSCrashReportFilter>
 
-+ (instancetype)filter;
+@property(class, readonly) KSCrashReportFilterStringify *filter NS_SWIFT_NAME(filter);
 
 @end
 

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterStringify.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterStringify.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(CrashReportFilterStringify)
 @interface KSCrashReportFilterStringify : NSObject <KSCrashReportFilter>
 
-@property(class, readonly) KSCrashReportFilterStringify *filter NS_SWIFT_NAME(filter);
+@property(class, readonly) KSCrashReportFilterStringify *filter;
 
 @end
 

--- a/Sources/KSCrashInstallations/KSCrashInstallation.m
+++ b/Sources/KSCrashInstallations/KSCrashInstallation.m
@@ -151,7 +151,7 @@ static CrashHandlerData *g_crashHandlerData;
                                           sizeof(*self.crashHandlerData->reportFields) * kMaxProperties];
         _fields = [NSMutableDictionary dictionary];
         _requiredProperties = [requiredProperties copy];
-        _prependedFilters = [KSCrashReportFilterPipeline filterWithFilters:nil];
+        _prependedFilters = [KSCrashReportFilterPipeline new];
     }
     return self;
 }
@@ -320,7 +320,7 @@ static CrashHandlerData *g_crashHandlerData;
     if (self.isDemangleEnabled) {
         [sinkFilters insertObject:[KSCrashReportFilterDemangle new] atIndex:0];
     }
-    sink = [KSCrashReportFilterPipeline filterWithFiltersArray:sinkFilters];
+    sink = [[KSCrashReportFilterPipeline alloc] initWithFilters:sinkFilters];
 
     KSCrashReportStore *store = [KSCrash sharedInstance].reportStore;
     if (store == nil) {
@@ -351,10 +351,10 @@ static CrashHandlerData *g_crashHandlerData;
                            yesAnswer:(NSString *)yesAnswer
                             noAnswer:(NSString *)noAnswer
 {
-    [self addPreFilter:[KSCrashReportFilterAlert filterWithTitle:title
-                                                         message:message
-                                                       yesAnswer:yesAnswer
-                                                        noAnswer:noAnswer]];
+    [self addPreFilter:[[KSCrashReportFilterAlert alloc] initWithTitle:title
+                                                               message:message
+                                                             yesAnswer:yesAnswer
+                                                              noAnswer:noAnswer]];
 
     KSCrashReportStore *store = [KSCrash sharedInstance].reportStore;
     if (store.reportCleanupPolicy == KSCrashReportCleanupPolicyOnSuccess) {
@@ -368,10 +368,10 @@ static CrashHandlerData *g_crashHandlerData;
                                message:(NSString *)message
                      dismissButtonText:(NSString *)dismissButtonText
 {
-    [self addPreFilter:[KSCrashReportFilterAlert filterWithTitle:title
-                                                         message:message
-                                                       yesAnswer:dismissButtonText
-                                                        noAnswer:nil]];
+    [self addPreFilter:[[KSCrashReportFilterAlert alloc] initWithTitle:title
+                                                               message:message
+                                                             yesAnswer:dismissButtonText
+                                                              noAnswer:nil]];
 }
 
 @end

--- a/Sources/KSCrashInstallations/KSCrashInstallationConsole.m
+++ b/Sources/KSCrashInstallations/KSCrashInstallationConsole.m
@@ -56,15 +56,15 @@
 {
     id<KSCrashReportFilter> formatFilter;
     if (self.printAppleFormat) {
-        formatFilter = [KSCrashReportFilterAppleFmt filterWithReportStyle:KSAppleReportStyleSymbolicated];
+        formatFilter = [[KSCrashReportFilterAppleFmt alloc] initWithReportStyle:KSAppleReportStyleSymbolicated];
     } else {
-        formatFilter = [KSCrashReportFilterPipeline
-            filterWithFilters:[KSCrashReportFilterJSONEncode
-                                  filterWithOptions:KSJSONEncodeOptionPretty | KSJSONEncodeOptionSorted],
-                              [KSCrashReportFilterStringify new], nil];
+        formatFilter = [[KSCrashReportFilterPipeline alloc] initWithFilters:@[
+            [[KSCrashReportFilterJSONEncode alloc] initWithOptions:KSJSONEncodeOptionPretty | KSJSONEncodeOptionSorted],
+            [KSCrashReportFilterStringify new],
+        ]];
     }
 
-    return [KSCrashReportFilterPipeline filterWithFilters:formatFilter, [KSCrashReportSinkConsole new], nil];
+    return [[KSCrashReportFilterPipeline alloc] initWithFilters:@[ formatFilter, [KSCrashReportSinkConsole new] ]];
 }
 
 @end

--- a/Sources/KSCrashInstallations/KSCrashInstallationEmail.m
+++ b/Sources/KSCrashInstallations/KSCrashInstallationEmail.m
@@ -75,10 +75,10 @@
 
 - (id<KSCrashReportFilter>)sink
 {
-    KSCrashReportSinkEMail *sink = [KSCrashReportSinkEMail sinkWithRecipients:self.recipients
-                                                                      subject:self.subject
-                                                                      message:self.message
-                                                                  filenameFmt:self.filenameFmt];
+    KSCrashReportSinkEMail *sink = [[KSCrashReportSinkEMail alloc] initWithRecipients:self.recipients
+                                                                              subject:self.subject
+                                                                              message:self.message
+                                                                          filenameFmt:self.filenameFmt];
 
     switch (self.reportStyle) {
         case KSCrashEmailReportStyleApple:

--- a/Sources/KSCrashInstallations/KSCrashInstallationStandard.m
+++ b/Sources/KSCrashInstallations/KSCrashInstallationStandard.m
@@ -49,7 +49,7 @@
 
 - (id<KSCrashReportFilter>)sink
 {
-    KSCrashReportSinkStandard *sink = [KSCrashReportSinkStandard sinkWithURL:self.url];
+    KSCrashReportSinkStandard *sink = [[KSCrashReportSinkStandard alloc] initWithURL:self.url];
     return [[KSCrashReportFilterPipeline alloc] initWithFilters:@[ sink.defaultCrashReportFilterSet ]];
 }
 

--- a/Sources/KSCrashInstallations/KSCrashInstallationStandard.m
+++ b/Sources/KSCrashInstallations/KSCrashInstallationStandard.m
@@ -50,7 +50,7 @@
 - (id<KSCrashReportFilter>)sink
 {
     KSCrashReportSinkStandard *sink = [KSCrashReportSinkStandard sinkWithURL:self.url];
-    return [KSCrashReportFilterPipeline filterWithFilters:[sink defaultCrashReportFilterSet], nil];
+    return [[KSCrashReportFilterPipeline alloc] initWithFilters:@[ sink.defaultCrashReportFilterSet ]];
 }
 
 @end

--- a/Sources/KSCrashRecording/KSCrashConfiguration.m
+++ b/Sources/KSCrashRecording/KSCrashConfiguration.m
@@ -70,6 +70,17 @@
     return self;
 }
 
+- (void)setReportStoreConfiguration:(KSCrashReportStoreConfiguration *)reportStoreConfiguration
+{
+    if (reportStoreConfiguration == nil) {
+        @throw [NSException exceptionWithName:NSInvalidArgumentException
+                                       reason:@"reportStoreConfiguration cannot be set to nil"
+                                     userInfo:nil];
+    }
+
+    _reportStoreConfiguration = reportStoreConfiguration;
+}
+
 - (KSCrashCConfiguration)toCConfiguration
 {
     KSCrashCConfiguration config = KSCrashCConfiguration_Default();

--- a/Sources/KSCrashRecording/include/KSCrashAppMemory.h
+++ b/Sources/KSCrashRecording/include/KSCrashAppMemory.h
@@ -92,6 +92,17 @@ typedef NS_ENUM(NSUInteger, KSCrashAppMemoryState) {
 } NS_SWIFT_NAME(AppMemoryState);
 
 /**
+ * Helpers to convert to and from pressure/level and strings.
+ * `KSCrashAppMemoryStateToString` returns a `const char*`
+ * because it needs to be async safe.
+ */
+FOUNDATION_EXPORT const char *KSCrashAppMemoryStateToString(KSCrashAppMemoryState state)
+    NS_SWIFT_NAME(AppMemoryState.cString(self:));
+
+FOUNDATION_EXPORT KSCrashAppMemoryState KSCrashAppMemoryStateFromString(NSString *const string)
+    NS_SWIFT_NAME(AppMemoryState.fromString(_:));
+
+/**
  * AppMemory is a simple container object for everything important on Apple platforms
  * surrounding memory.
  */
@@ -127,15 +138,5 @@ NS_SWIFT_NAME(AppMemory)
 @property(readonly, nonatomic, assign) BOOL isOutOfMemory;
 
 @end
-
-/**
- * Helpers to convert to and from pressure/level and strings.
- * `KSCrashAppMemoryStateToString` returns a `const char*`
- * because it needs to be async safe.
- */
-FOUNDATION_EXPORT const char *KSCrashAppMemoryStateToString(KSCrashAppMemoryState state) NS_SWIFT_NAME(string(from:));
-
-FOUNDATION_EXPORT KSCrashAppMemoryState KSCrashAppMemoryStateFromString(NSString *const string)
-    NS_SWIFT_NAME(memoryState(from:));
 
 NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashRecording/include/KSCrashAppTransitionState.h
+++ b/Sources/KSCrashRecording/include/KSCrashAppTransitionState.h
@@ -67,12 +67,13 @@ typedef uint8_t KSCrashAppTransitionState;
  * Returns true if the transition state is user perceptible.
  */
 bool ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionState state)
-    NS_SWIFT_NAME(isUserPerceptible(transitionState:));
+    NS_SWIFT_NAME(AppTransitionState.isUserPerceptible(self:));
 
 /**
  * Returns a string for the app state passed in.
  */
-const char *ksapp_transitionStateToString(KSCrashAppTransitionState state) NS_SWIFT_NAME(string(for:));
+const char *ksapp_transitionStateToString(KSCrashAppTransitionState state)
+    NS_SWIFT_NAME(AppTransitionState.cString(self:));
 
 #ifdef __cplusplus
 }

--- a/Sources/KSCrashRecording/include/KSCrashConfiguration.h
+++ b/Sources/KSCrashRecording/include/KSCrashConfiguration.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** The configuration for report store.
  * @note See `KSCrashStoreConfiguration` for more details.
  */
-@property(nonatomic, strong, readonly) KSCrashReportStoreConfiguration *reportStoreConfiguration;
+@property(nonatomic, strong) KSCrashReportStoreConfiguration *reportStoreConfiguration;
 
 /** The crash types that will be handled.
  * Some crash types may not be enabled depending on circumstances (e.g., running in a debugger).

--- a/Sources/KSCrashRecording/include/KSCrashReportFilter.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportFilter.h
@@ -65,6 +65,7 @@ NS_SWIFT_NAME(CrashReportFilter)
 static inline void kscrash_callCompletion(KSCrashReportFilterCompletion _Nullable onCompletion,
                                           NSArray<id<KSCrashReport>> *_Nullable filteredReports,
                                           NSError *_Nullable error)
+    NS_SWIFT_NAME(KSCrash.callCompletion(_:filteredReports:error:))
 {
     if (onCompletion) {
         onCompletion(filteredReports, error);

--- a/Sources/KSCrashSinks/KSCrashReportSinkConsole.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkConsole.m
@@ -36,9 +36,10 @@
 
 - (id<KSCrashReportFilter>)defaultCrashReportFilterSet
 {
-    return [KSCrashReportFilterPipeline
-        filterWithFilters:[KSCrashReportFilterAppleFmt filterWithReportStyle:KSAppleReportStyleSymbolicated], self,
-                          nil];
+    return [[KSCrashReportFilterPipeline alloc] initWithFilters:@[
+        [[KSCrashReportFilterAppleFmt alloc] initWithReportStyle:KSAppleReportStyleSymbolicated],
+        self,
+    ]];
 }
 
 - (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion

--- a/Sources/KSCrashSinks/KSCrashReportSinkConsole.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkConsole.m
@@ -34,11 +34,6 @@
 
 @implementation KSCrashReportSinkConsole
 
-+ (instancetype)filter
-{
-    return [[self alloc] init];
-}
-
 - (id<KSCrashReportFilter>)defaultCrashReportFilterSet
 {
     return [KSCrashReportFilterPipeline

--- a/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
@@ -281,18 +281,21 @@
 
 - (id<KSCrashReportFilter>)defaultCrashReportFilterSet
 {
-    return [KSCrashReportFilterPipeline
-        filterWithFilters:[KSCrashReportFilterJSONEncode
-                              filterWithOptions:KSJSONEncodeOptionSorted | KSJSONEncodeOptionPretty],
-                          [KSCrashReportFilterGZipCompress filterWithCompressionLevel:-1], self, nil];
+    return [[KSCrashReportFilterPipeline alloc] initWithFilters:@[
+        [[KSCrashReportFilterJSONEncode alloc] initWithOptions:KSJSONEncodeOptionSorted | KSJSONEncodeOptionPretty],
+        [[KSCrashReportFilterGZipCompress alloc] initWithCompressionLevel:-1],
+        self,
+    ]];
 }
 
 - (id<KSCrashReportFilter>)defaultCrashReportFilterSetAppleFmt
 {
-    return [KSCrashReportFilterPipeline
-        filterWithFilters:[KSCrashReportFilterAppleFmt filterWithReportStyle:KSAppleReportStyleSymbolicatedSideBySide],
-                          [KSCrashReportFilterStringToData filter],
-                          [KSCrashReportFilterGZipCompress filterWithCompressionLevel:-1], self, nil];
+    return [[KSCrashReportFilterPipeline alloc] initWithFilters:@[
+        [[KSCrashReportFilterAppleFmt alloc] initWithReportStyle:KSAppleReportStyleSymbolicatedSideBySide],
+        [KSCrashReportFilterStringToData new],
+        [[KSCrashReportFilterGZipCompress alloc] initWithCompressionLevel:-1],
+        self,
+    ]];
 }
 
 @end

--- a/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
@@ -204,7 +204,7 @@
 {
     return [KSCrashReportFilterPipeline
         filterWithFilters:[KSCrashReportFilterAppleFmt filterWithReportStyle:KSAppleReportStyleSymbolicatedSideBySide],
-                          [KSCrashReportFilterStringToData filter],
+                          [KSCrashReportFilterStringToData new],
                           [KSCrashReportFilterGZipCompress filterWithCompressionLevel:-1], self, nil];
 }
 

--- a/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
@@ -170,14 +170,6 @@
 
 @implementation KSCrashReportSinkEMail
 
-+ (instancetype)sinkWithRecipients:(NSArray<NSString *> *)recipients
-                           subject:(NSString *)subject
-                           message:(nullable NSString *)message
-                       filenameFmt:(NSString *)filenameFmt
-{
-    return [[self alloc] initWithRecipients:recipients subject:subject message:message filenameFmt:filenameFmt];
-}
-
 - (instancetype)initWithRecipients:(NSArray<NSString *> *)recipients
                            subject:(NSString *)subject
                            message:(nullable NSString *)message

--- a/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
@@ -194,18 +194,21 @@
 
 - (id<KSCrashReportFilter>)defaultCrashReportFilterSet
 {
-    return [KSCrashReportFilterPipeline
-        filterWithFilters:[KSCrashReportFilterJSONEncode
-                              filterWithOptions:KSJSONEncodeOptionSorted | KSJSONEncodeOptionPretty],
-                          [KSCrashReportFilterGZipCompress filterWithCompressionLevel:-1], self, nil];
+    return [[KSCrashReportFilterPipeline alloc] initWithFilters:@[
+        [[KSCrashReportFilterJSONEncode alloc] initWithOptions:KSJSONEncodeOptionSorted | KSJSONEncodeOptionPretty],
+        [[KSCrashReportFilterGZipCompress alloc] initWithCompressionLevel:-1],
+        self,
+    ]];
 }
 
 - (id<KSCrashReportFilter>)defaultCrashReportFilterSetAppleFmt
 {
-    return [KSCrashReportFilterPipeline
-        filterWithFilters:[KSCrashReportFilterAppleFmt filterWithReportStyle:KSAppleReportStyleSymbolicatedSideBySide],
-                          [KSCrashReportFilterStringToData new],
-                          [KSCrashReportFilterGZipCompress filterWithCompressionLevel:-1], self, nil];
+    return [[KSCrashReportFilterPipeline alloc] initWithFilters:@[
+        [[KSCrashReportFilterAppleFmt alloc] initWithReportStyle:KSAppleReportStyleSymbolicatedSideBySide],
+        [KSCrashReportFilterStringToData new],
+        [[KSCrashReportFilterGZipCompress alloc] initWithCompressionLevel:-1],
+        self,
+    ]];
 }
 
 - (void)filterReports:(NSArray<id<KSCrashReport>> *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion

--- a/Sources/KSCrashSinks/KSCrashReportSinkStandard.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkStandard.m
@@ -46,11 +46,6 @@
 
 @implementation KSCrashReportSinkStandard
 
-+ (instancetype)sinkWithURL:(NSURL *)url
-{
-    return [[self alloc] initWithURL:url];
-}
-
 - (instancetype)initWithURL:(NSURL *)url
 {
     if ((self = [super init])) {

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkConsole.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkConsole.h
@@ -43,7 +43,7 @@ NS_SWIFT_NAME(CrashReportSinkConsole)
 @property(class, readonly) KSCrashReportSinkConsole *filter;
 
 /** Returns the default crash report filter set. */
-- (id<KSCrashReportFilter>)defaultCrashReportFilterSet;
+@property(nonatomic, readonly) id<KSCrashReportFilter> defaultCrashReportFilterSet;
 
 @end
 

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkConsole.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkConsole.h
@@ -40,7 +40,7 @@ NS_SWIFT_NAME(CrashReportSinkConsole)
 @interface KSCrashReportSinkConsole : NSObject <KSCrashReportFilter>
 
 /** Creates a new filter for printing reports to the console. */
-+ (instancetype)filter;
+@property(class, readonly) KSCrashReportSinkConsole *filter NS_SWIFT_NAME(filter);
 
 /** Returns the default crash report filter set. */
 - (id<KSCrashReportFilter>)defaultCrashReportFilterSet;

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkConsole.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkConsole.h
@@ -40,7 +40,7 @@ NS_SWIFT_NAME(CrashReportSinkConsole)
 @interface KSCrashReportSinkConsole : NSObject <KSCrashReportFilter>
 
 /** Creates a new filter for printing reports to the console. */
-@property(class, readonly) KSCrashReportSinkConsole *filter NS_SWIFT_NAME(filter);
+@property(class, readonly) KSCrashReportSinkConsole *filter;
 
 /** Returns the default crash report filter set. */
 - (id<KSCrashReportFilter>)defaultCrashReportFilterSet;

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkConsole.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkConsole.h
@@ -39,9 +39,6 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(CrashReportSinkConsole)
 @interface KSCrashReportSinkConsole : NSObject <KSCrashReportFilter>
 
-/** Creates a new filter for printing reports to the console. */
-@property(class, readonly) KSCrashReportSinkConsole *filter;
-
 /** Returns the default crash report filter set. */
 @property(nonatomic, readonly) id<KSCrashReportFilter> defaultCrashReportFilterSet;
 

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkEMail.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkEMail.h
@@ -37,6 +37,9 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(CrashReportSinkEmail)
 @interface KSCrashReportSinkEMail : NSObject <KSCrashReportFilter>
 
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 /**
  * @param recipients List of email addresses to send to.
  * @param subject What to put in the subject field.

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkEMail.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkEMail.h
@@ -44,20 +44,6 @@ NS_SWIFT_NAME(CrashReportSinkEmail)
  * @param filenameFmt How to name the attachments. You may use "%d" to differentiate
  *                    when multiple reports are sent at once.
  *                    Note: With the default filter set, files are gzipped text.
- * @return A new instance of KSCrashReportSinkEMail configured with the specified parameters.
- */
-+ (instancetype)sinkWithRecipients:(NSArray<NSString *> *)recipients
-                           subject:(NSString *)subject
-                           message:(nullable NSString *)message
-                       filenameFmt:(NSString *)filenameFmt;
-
-/**
- * @param recipients List of email addresses to send to.
- * @param subject What to put in the subject field.
- * @param message A message to accompany the reports (optional - nil = ignore).
- * @param filenameFmt How to name the attachments. You may use "%d" to differentiate
- *                    when multiple reports are sent at once.
- *                    Note: With the default filter set, files are gzipped text.
  */
 - (instancetype)initWithRecipients:(NSArray<NSString *> *)recipients
                            subject:(NSString *)subject

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkEMail.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkEMail.h
@@ -64,8 +64,8 @@ NS_SWIFT_NAME(CrashReportSinkEmail)
                            message:(nullable NSString *)message
                        filenameFmt:(NSString *)filenameFmt;
 
-- (id<KSCrashReportFilter>)defaultCrashReportFilterSet;
-- (id<KSCrashReportFilter>)defaultCrashReportFilterSetAppleFmt;
+@property(nonatomic, readonly) id<KSCrashReportFilter> defaultCrashReportFilterSet;
+@property(nonatomic, readonly) id<KSCrashReportFilter> defaultCrashReportFilterSetAppleFmt;
 
 @end
 

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkStandard.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkStandard.h
@@ -51,7 +51,7 @@ NS_SWIFT_NAME(CrashReportSinkStandard)
  */
 - (instancetype)initWithURL:(NSURL *)url;
 
-- (id<KSCrashReportFilter>)defaultCrashReportFilterSet;
+@property(nonatomic, readonly) id<KSCrashReportFilter> defaultCrashReportFilterSet;
 
 @end
 

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkStandard.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkStandard.h
@@ -39,6 +39,9 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(CrashReportSinkStandard)
 @interface KSCrashReportSinkStandard : NSObject <KSCrashReportFilter>
 
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 /** Constructor.
  *
  * @param url The URL to connect to.

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkStandard.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkStandard.h
@@ -43,12 +43,6 @@ NS_SWIFT_NAME(CrashReportSinkStandard)
  *
  * @param url The URL to connect to.
  */
-+ (instancetype)sinkWithURL:(NSURL *)url;
-
-/** Constructor.
- *
- * @param url The URL to connect to.
- */
 - (instancetype)initWithURL:(NSURL *)url;
 
 @property(nonatomic, readonly) id<KSCrashReportFilter> defaultCrashReportFilterSet;

--- a/Tests/KSCrashFiltersTests/KSCrashReportFilterAlert_Tests.m
+++ b/Tests/KSCrashFiltersTests/KSCrashReportFilterAlert_Tests.m
@@ -35,10 +35,10 @@
 
 - (void)testAlert
 {
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterAlert filterWithTitle:@"title"
-                                                                       message:@"message"
-                                                                     yesAnswer:@"YES"
-                                                                      noAnswer:@"NO"];
+    id<KSCrashReportFilter> filter = [[KSCrashReportFilterAlert alloc] initWithTitle:@"title"
+                                                                             message:@"message"
+                                                                           yesAnswer:@"YES"
+                                                                            noAnswer:@"NO"];
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"Filter completion"];
     [filter filterReports:[NSArray array]

--- a/Tests/KSCrashFiltersTests/KSCrashReportFilterGZip_Tests.m
+++ b/Tests/KSCrashFiltersTests/KSCrashReportFilterGZip_Tests.m
@@ -58,7 +58,7 @@
 
 - (void)testFilterGZipCompress
 {
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterGZipCompress filterWithCompressionLevel:-1];
+    id<KSCrashReportFilter> filter = [[KSCrashReportFilterGZipCompress alloc] initWithCompressionLevel:-1];
     [filter filterReports:self.decompressedReports
              onCompletion:^(NSArray *filteredReports, NSError *error2) {
                  XCTAssertNil(error2, @"");
@@ -68,7 +68,7 @@
 
 - (void)testFilterGZipDecompress
 {
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterGZipDecompress filter];
+    id<KSCrashReportFilter> filter = [KSCrashReportFilterGZipDecompress new];
     [filter filterReports:self.compressedReports
              onCompletion:^(NSArray *filteredReports, NSError *error2) {
                  XCTAssertNil(error2, @"");

--- a/Tests/KSCrashFiltersTests/KSCrashReportFilterJSON_Tests.m
+++ b/Tests/KSCrashFiltersTests/KSCrashReportFilterJSON_Tests.m
@@ -54,7 +54,7 @@
 
 - (void)testFilterJSONEncode
 {
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterJSONEncode filterWithOptions:0];
+    id<KSCrashReportFilter> filter = [[KSCrashReportFilterJSONEncode alloc] initWithOptions:0];
     [filter filterReports:self.decodedReports
              onCompletion:^(NSArray *filteredReports, NSError *error2) {
                  XCTAssertNil(error2, @"");
@@ -68,7 +68,7 @@
         [KSCrashReportDictionary reportWithValue:@{ @1 : @2 }],  // Not a JSON
     ];
 
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterJSONEncode filterWithOptions:0];
+    id<KSCrashReportFilter> filter = [[KSCrashReportFilterJSONEncode alloc] initWithOptions:0];
     [filter filterReports:decoded
              onCompletion:^(__unused NSArray *filteredReports, NSError *error2) {
                  XCTAssertNotNil(error2, @"");
@@ -77,7 +77,7 @@
 
 - (void)testFilterJSONDencode
 {
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterJSONDecode filterWithOptions:0];
+    id<KSCrashReportFilter> filter = [[KSCrashReportFilterJSONDecode alloc] initWithOptions:0];
     [filter filterReports:self.encodedReports
              onCompletion:^(NSArray *filteredReports, NSError *error2) {
                  XCTAssertNil(error2, @"");
@@ -91,7 +91,7 @@
         [KSCrashReportData reportWithValue:[@"[\"1\"\",\"2\",\"3\"]" dataUsingEncoding:NSUTF8StringEncoding]],
     ];
 
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterJSONDecode filterWithOptions:0];
+    id<KSCrashReportFilter> filter = [[KSCrashReportFilterJSONDecode alloc] initWithOptions:0];
     [filter filterReports:encoded
              onCompletion:^(__unused NSArray *filteredReports, NSError *error2) {
                  XCTAssertNotNil(error2, @"");

--- a/Tests/KSCrashFiltersTests/KSCrashReportFilter_Tests.m
+++ b/Tests/KSCrashFiltersTests/KSCrashReportFilter_Tests.m
@@ -38,11 +38,6 @@
 
 @implementation KSCrash_TestNilFilter
 
-+ (KSCrash_TestNilFilter *)filter
-{
-    return [[self alloc] init];
-}
-
 - (void)filterReports:(__unused NSArray *)reports onCompletion:(KSCrashReportFilterCompletion)onCompletion
 {
     onCompletion(nil, nil);
@@ -138,7 +133,7 @@
     __block NSArray *reports = @[ [KSCrashReportString reportWithValue:@""] ];
     __weak id weakRef = reports;
 
-    __block KSCrashReportFilterPassthrough *filter = [KSCrashReportFilterPassthrough filter];
+    __block KSCrashReportFilterPassthrough *filter = [KSCrashReportFilterPassthrough new];
     [filter filterReports:reports
              onCompletion:^(__unused NSArray *filteredReports, __unused NSError *error) {
                  filter = nil;
@@ -151,8 +146,10 @@
 
 - (void)testPipeline
 {
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterPipeline
-        filterWithFilters:[KSCrashReportFilterPassthrough filter], [KSCrashReportFilterPassthrough filter], nil];
+    id<KSCrashReportFilter> filter = [[KSCrashReportFilterPipeline alloc] initWithFilters:@[
+        [KSCrashReportFilterPassthrough new],
+        [KSCrashReportFilterPassthrough new],
+    ]];
 
     [filter filterReports:self.reports
              onCompletion:^(NSArray *filteredReports, NSError *error) {
@@ -163,8 +160,10 @@
 
 - (void)testPipelineInit
 {
-    id<KSCrashReportFilter> filter = [[KSCrashReportFilterPipeline alloc]
-        initWithFilters:[KSCrashReportFilterPassthrough filter], [KSCrashReportFilterPassthrough filter], nil];
+    id<KSCrashReportFilter> filter = [[KSCrashReportFilterPipeline alloc] initWithFilters:@[
+        [KSCrashReportFilterPassthrough new],
+        [KSCrashReportFilterPassthrough new],
+    ]];
     filter = filter;
 
     [filter filterReports:self.reports
@@ -176,7 +175,7 @@
 
 - (void)testPipelineNoFilters
 {
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterPipeline filterWithFilters:nil];
+    id<KSCrashReportFilter> filter = [KSCrashReportFilterPipeline new];
 
     [filter filterReports:self.reports
              onCompletion:^(NSArray *filteredReports, NSError *error) {
@@ -187,8 +186,8 @@
 
 - (void)testFilterPipelineError
 {
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterPipeline
-        filterWithFilters:[KSCrash_TestFilter filterWithDelay:0 error:self.testError], nil];
+    id<KSCrashReportFilter> filter = [[KSCrashReportFilterPipeline alloc]
+        initWithFilters:@[ [KSCrash_TestFilter filterWithDelay:0 error:self.testError] ]];
 
     [filter filterReports:self.reports
              onCompletion:^(NSArray *filteredReports, NSError *error) {
@@ -200,7 +199,7 @@
 - (void)testFilterPipelineNilReports
 {
     id<KSCrashReportFilter> filter =
-        [KSCrashReportFilterPipeline filterWithFilters:[KSCrash_TestNilFilter filter], nil];
+        [[KSCrashReportFilterPipeline alloc] initWithFilters:@[ [KSCrash_TestNilFilter new] ]];
 
     [filter filterReports:self.reports
              onCompletion:^(NSArray *filteredReports, NSError *error) {
@@ -217,7 +216,7 @@
     __weak id weakReports = reports;
     __weak id weakFilter = filter;
 
-    __block KSCrashReportFilterPipeline *pipeline = [KSCrashReportFilterPipeline filterWithFilters:filter, nil];
+    __block KSCrashReportFilterPipeline *pipeline = [[KSCrashReportFilterPipeline alloc] initWithFilters:@[ filter ]];
     [pipeline filterReports:reports
                onCompletion:^(__unused NSArray *filteredReports, __unused NSError *error) {
                    reports = nil;
@@ -238,7 +237,7 @@
     __weak id weakReports = reports;
     __weak id weakFilter = filter;
 
-    __block KSCrashReportFilterPipeline *pipeline = [KSCrashReportFilterPipeline filterWithFilters:filter, nil];
+    __block KSCrashReportFilterPipeline *pipeline = [[KSCrashReportFilterPipeline alloc] initWithFilters:@[ filter ]];
     [pipeline filterReports:reports
                onCompletion:^(__unused NSArray *filteredReports, __unused NSError *error) {
                    reports = nil;
@@ -255,7 +254,7 @@
 
 - (void)testFilterPassthrough
 {
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterPassthrough filter];
+    id<KSCrashReportFilter> filter = [KSCrashReportFilterPassthrough new];
 
     [filter filterReports:self.reports
              onCompletion:^(NSArray *filteredReports, NSError *error) {
@@ -266,7 +265,7 @@
 
 - (void)testFilterStringToData
 {
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterStringToData filter];
+    id<KSCrashReportFilter> filter = [KSCrashReportFilterStringToData new];
 
     [filter filterReports:self.reports
              onCompletion:^(NSArray *filteredReports, NSError *error) {
@@ -277,7 +276,7 @@
 
 - (void)testFilterDataToString
 {
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterDataToString filter];
+    id<KSCrashReportFilter> filter = [KSCrashReportFilterDataToString new];
 
     [filter filterReports:self.reportsWithData
              onCompletion:^(NSArray *filteredReports, NSError *error) {
@@ -288,8 +287,8 @@
 
 - (void)testFilterPipeline
 {
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterPipeline
-        filterWithFilters:[KSCrashReportFilterStringToData filter], [KSCrashReportFilterDataToString filter], nil];
+    id<KSCrashReportFilter> filter = [[KSCrashReportFilterPipeline alloc]
+        initWithFilters:@[ [KSCrashReportFilterStringToData new], [KSCrashReportFilterDataToString new] ]];
 
     [filter filterReports:self.reports
              onCompletion:^(NSArray *filteredReports, NSError *error) {
@@ -300,9 +299,10 @@
 
 - (void)testFilterCombine
 {
-    id<KSCrashReportFilter> filter =
-        [KSCrashReportFilterCombine filterWithFiltersAndKeys:[KSCrashReportFilterPassthrough filter], @"normal",
-                                                             [KSCrashReportFilterStringToData filter], @"data", nil];
+    id<KSCrashReportFilter> filter = [[KSCrashReportFilterCombine alloc] initWithFilters:@{
+        @"normal" : [KSCrashReportFilterPassthrough new],
+        @"data" : [KSCrashReportFilterStringToData new],
+    }];
 
     [filter filterReports:self.reports
              onCompletion:^(NSArray *filteredReports, NSError *error) {
@@ -321,33 +321,9 @@
              }];
 }
 
-- (void)testFilterCombineInit
-{
-    id<KSCrashReportFilter> filter = [[KSCrashReportFilterCombine alloc]
-        initWithFiltersAndKeys:[KSCrashReportFilterPassthrough filter], @"normal",
-                               [KSCrashReportFilterStringToData filter], @"data", nil];
-    filter = filter;
-
-    [filter filterReports:self.reports
-             onCompletion:^(NSArray *filteredReports, NSError *error) {
-                 XCTAssertNil(error, @"");
-                 for (NSUInteger i = 0; i < [self.reports count]; i++) {
-                     id exp1 = [[self.reports objectAtIndex:i] value];
-                     id exp2 = [[self.reportsWithData objectAtIndex:i] value];
-                     KSCrashReportDictionary *entry = [filteredReports objectAtIndex:i];
-                     id result1 = entry.value[@"normal"];
-                     id result2 = entry.value[@"data"];
-                     XCTAssertNotNil(result1);
-                     XCTAssertNotNil(result2);
-                     XCTAssertEqualObjects(result1, exp1, @"");
-                     XCTAssertEqualObjects(result2, exp2, @"");
-                 }
-             }];
-}
-
 - (void)testFilterCombineNoFilters
 {
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterCombine filterWithFiltersAndKeys:nil];
+    id<KSCrashReportFilter> filter = [KSCrashReportFilterCombine new];
 
     [filter filterReports:self.reports
              onCompletion:^(NSArray *filteredReports, NSError *error) {
@@ -362,8 +338,8 @@
 
 - (void)testFilterCombineIncomplete
 {
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterCombine
-        filterWithFiltersAndKeys:[KSCrash_TestFilter filterWithDelay:0 error:self.testError], @"Blah", nil];
+    id<KSCrashReportFilter> filter = [[KSCrashReportFilterCombine alloc]
+        initWithFilters:@{ @"Blah" : [KSCrash_TestFilter filterWithDelay:0 error:self.testError] }];
 
     [filter filterReports:self.reports
              onCompletion:^(NSArray *filteredReports, NSError *error) {
@@ -375,7 +351,7 @@
 - (void)testFilterCombineNilReports
 {
     id<KSCrashReportFilter> filter =
-        [KSCrashReportFilterCombine filterWithFiltersAndKeys:[KSCrash_TestNilFilter filter], @"Blah", nil];
+        [[KSCrashReportFilterCombine alloc] initWithFilters:@{ @"Blah" : [KSCrash_TestNilFilter new] }];
 
     [filter filterReports:self.reports
              onCompletion:^(NSArray *filteredReports, NSError *error) {
@@ -384,48 +360,11 @@
              }];
 }
 
-- (void)testFilterCombineArray
-{
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterCombine
-        filterWithFiltersAndKeys:[NSArray arrayWithObject:[KSCrashReportFilterPassthrough filter]], @"normal",
-                                 [NSArray arrayWithObject:[KSCrashReportFilterStringToData filter]], @"data", nil];
-
-    [filter filterReports:self.reports
-             onCompletion:^(NSArray *filteredReports, NSError *error) {
-                 XCTAssertNil(error, @"");
-                 for (NSUInteger i = 0; i < [self.reports count]; i++) {
-                     id exp1 = [[self.reports objectAtIndex:i] value];
-                     id exp2 = [[self.reportsWithData objectAtIndex:i] value];
-                     KSCrashReportDictionary *entry = [filteredReports objectAtIndex:i];
-                     id result1 = entry.value[@"normal"];
-                     id result2 = entry.value[@"data"];
-                     XCTAssertNotNil(result1);
-                     XCTAssertNotNil(result2);
-                     XCTAssertEqualObjects(result1, exp1, @"");
-                     XCTAssertEqualObjects(result2, exp2, @"");
-                 }
-             }];
-}
-
-- (void)testFilterCombineMissingKey
-{
-    id<KSCrashReportFilter> filter =
-        [KSCrashReportFilterCombine filterWithFiltersAndKeys:[KSCrashReportFilterPassthrough filter], @"normal",
-                                                             [KSCrashReportFilterStringToData filter],
-                                                             // Missing key
-                                                             nil];
-
-    [filter filterReports:self.reports
-             onCompletion:^(__unused NSArray *filteredReports, NSError *error) {
-                 XCTAssertNotNil(error, @"");
-             }];
-}
-
 - (void)testConcatenate
 {
     NSString *expected = @"1,a";
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterConcatenate filterWithSeparatorFmt:@","
-                                                                                       keys:@"first", @"second", nil];
+    id<KSCrashReportFilter> filter =
+        [[KSCrashReportFilterConcatenate alloc] initWithSeparatorFmt:@"," keys:@[ @"first", @"second" ]];
 
     [filter filterReports:self.reportsWithDict
              onCompletion:^(NSArray *filteredReports, NSError *error) {
@@ -438,7 +377,7 @@
 {
     NSString *expected = @"1,a";
     id<KSCrashReportFilter> filter =
-        [[KSCrashReportFilterConcatenate alloc] initWithSeparatorFmt:@"," keys:@"first", @"second", nil];
+        [[KSCrashReportFilterConcatenate alloc] initWithSeparatorFmt:@"," keys:@[ @"first", @"second" ]];
     filter = filter;
 
     [filter filterReports:self.reportsWithDict
@@ -454,7 +393,7 @@
         @"first" : @"1",
         @"third" : @"b",
     }];
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterSubset filterWithKeys:@"first", @"third", nil];
+    id<KSCrashReportFilter> filter = [[KSCrashReportFilterSubset alloc] initWithKeys:@[ @"first", @"third" ]];
 
     [filter filterReports:self.reportsWithDict
              onCompletion:^(NSArray *filteredReports, NSError *error) {
@@ -465,7 +404,7 @@
 
 - (void)testSubsetBadKeyPath
 {
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterSubset filterWithKeys:@"first", @"aaa", nil];
+    id<KSCrashReportFilter> filter = [[KSCrashReportFilterSubset alloc] initWithKeys:@[ @"first", @"aaa" ]];
 
     [filter filterReports:self.reportsWithDict
              onCompletion:^(__unused NSArray *filteredReports, NSError *error) {
@@ -479,7 +418,7 @@
         @"first" : @"1",
         @"third" : @"b",
     }];
-    id<KSCrashReportFilter> filter = [[KSCrashReportFilterSubset alloc] initWithKeys:@"first", @"third", nil];
+    id<KSCrashReportFilter> filter = [[KSCrashReportFilterSubset alloc] initWithKeys:@[ @"first", @"third" ]];
     filter = filter;
 
     [filter filterReports:self.reportsWithDict

--- a/Tests/KSCrashFiltersTests/KSCrashReportFilter_Tests.m
+++ b/Tests/KSCrashFiltersTests/KSCrashReportFilter_Tests.m
@@ -323,7 +323,7 @@
 
 - (void)testFilterCombineNoFilters
 {
-    id<KSCrashReportFilter> filter = [KSCrashReportFilterCombine new];
+    id<KSCrashReportFilter> filter = [[KSCrashReportFilterCombine alloc] initWithFilters:@{}];
 
     [filter filterReports:self.reports
              onCompletion:^(NSArray *filteredReports, NSError *error) {


### PR DESCRIPTION
This PR conducts a comprehensive API review of the KSCrash library, focusing on improving consistency and safety. Key changes include:

1. Removing class constructor methods like `+filter`, `+filterWithOptions:`, and `+sinkWithURL:` across various classes including KSCrashReportFilterGZip, KSCrashReportFilterJSON, and KSCrashReportSinkStandard.
2. Standardizing initializer patterns, replacing variadic methods with array-based initializers in classes like KSCrashReportFilterCombine and KSCrashReportFilterSubset.
3. Converting method-based properties to actual property declarations, such as `defaultCrashReportFilterSet` in KSCrashReportSinkConsole and KSCrashReportSinkEMail.
4. Updating method signatures for better type safety, particularly in filter classes like KSCrashReportFilterPipeline and KSCrashReportFilterConcatenate.
5. Renaming methods for consistency, e.g., `initWithKeysArray:` to `initWithKeys:` in KSCrashReportFilterSubset.
6. Adding unavailable initializers (`init` and `new`) to force use of designated initializers across multiple classes.
7. Enhancing Swift naming conventions for better interoperability, affecting classes like KSCrashAppMemoryState and KSCrashAppTransitionState.
