### PR TITLE
fix include in KSCrashCConfiguration.h

### DIFF
--- a/Sources/KSCrashRecording/include/KSCrashCConfiguration.h
+++ b/Sources/KSCrashRecording/include/KSCrashCConfiguration.h
@@ -28,10 +28,10 @@
 #define KSCrashCConfiguration_h
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "KSCrashMonitorType.h"
 #include "KSCrashReportWriter.h"
-#include "string.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
If `#include "string.h"` is used, then building a React Native app fails with the error:

```
.../Pods/RCT-Folly/folly/portability/String.h:22:10: 'folly/portability/Config.h' file not found
```

This happens because the `RCT-Folly` library contains the `String.h` file, which is why the wrong header is selected.

With `#include <string.h>` everything builds successfully.