### PR TITLE
Fake app memory limits on macOS

### DIFF
--- a/Sources/KSCrashRecording/KSCrashAppMemoryTracker.m
+++ b/Sources/KSCrashRecording/KSCrashAppMemoryTracker.m
@@ -149,7 +149,7 @@ static KSCrashAppMemory *_Nullable _ProvideCrashAppMemory(KSCrashAppMemoryState 
 #elif KSCRASH_HOST_MAC
     // macOS doesn't limit memory usage the same way as it's implemented for other OSs.
     // So we just mock limit by having a large value instead (128 GB).
-    uint64_t limit = 137438953472; // 128 GB
+    uint64_t limit = 137438953472;  // 128 GB
     uint64_t remaining = limit < info.phys_footprint ? 0 : limit - info.phys_footprint;
 #else
     uint64_t remaining = info.limit_bytes_remaining;

--- a/Sources/KSCrashRecording/KSCrashAppMemoryTracker.m
+++ b/Sources/KSCrashRecording/KSCrashAppMemoryTracker.m
@@ -146,6 +146,11 @@ static KSCrashAppMemory *_Nullable _ProvideCrashAppMemory(KSCrashAppMemoryState 
     // How about a limit of 3GB.
     uint64_t limit = 3000000000;
     uint64_t remaining = limit < info.phys_footprint ? 0 : limit - info.phys_footprint;
+#elif KSCRASH_HOST_MAC
+    // macOS doesn't limit memory usage the same way as it's implemented for other OSs.
+    // So we just mock limit by having a large value instead (128 GB).
+    uint64_t limit = 137438953472; // 128 GB
+    uint64_t remaining = limit < info.phys_footprint ? 0 : limit - info.phys_footprint;
 #else
     uint64_t remaining = info.limit_bytes_remaining;
 #endif


### PR DESCRIPTION
On macOS, we don't have memory limits provided by the `task_info` call. This causes false-positive OOM reports, as we always have a "terminal" memory state for this OS.

This PR fixes the issue by faking a large memory limit and assuming that any app reaching this limit is in an abnormal state.

cc @naftaly 