### PR TITLE
Add reportCleanupPolicy to KSCrashReportStoreConfiguration

### DIFF
--- a/Sources/KSCrashRecording/KSCrashConfiguration.m
+++ b/Sources/KSCrashRecording/KSCrashConfiguration.m
@@ -170,6 +170,7 @@
     if (self != nil) {
         _appName = nil;
         _reportsPath = nil;
+        _reportCleanupPolicy = KSCrashReportCleanupPolicyAlways;
 
         KSCrashReportStoreCConfiguration cConfig = KSCrashReportStoreCConfiguration_Default();
         _maxReportCount = (NSInteger)cConfig.maxReportCount;
@@ -204,6 +205,7 @@
     copy.reportsPath = [self.reportsPath copyWithZone:zone];
     copy.appName = [self.appName copyWithZone:zone];
     copy.maxReportCount = self.maxReportCount;
+    copy.reportCleanupPolicy = self.reportCleanupPolicy;
     return copy;
 }
 

--- a/Sources/KSCrashRecording/KSCrashReportStore.m
+++ b/Sources/KSCrashRecording/KSCrashReportStore.m
@@ -61,8 +61,9 @@
 {
     self = [super init];
     if (self != nil) {
-        _cConfig = [(configuration ?: [KSCrashReportStoreConfiguration new]) toCConfiguration];
-        _reportCleanupPolicy = KSCrashReportCleanupPolicyAlways;
+        KSCrashReportStoreConfiguration *resolvedConfiguration = configuration ?: [KSCrashReportStoreConfiguration new];
+        _cConfig = [resolvedConfiguration toCConfiguration];
+        _reportCleanupPolicy = resolvedConfiguration.reportCleanupPolicy;
 
         kscrs_initialize(&_cConfig);
     }

--- a/Sources/KSCrashRecording/include/KSCrashConfiguration.h
+++ b/Sources/KSCrashRecording/include/KSCrashConfiguration.h
@@ -26,6 +26,7 @@
 
 #import <Foundation/Foundation.h>
 #import "KSCrashMonitorType.h"
+#import "KSCrashReportStore.h"
 #import "KSCrashReportWriter.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -190,6 +191,19 @@ NS_SWIFT_NAME(CrashReportStoreConfiguration)
  * **Default**: 5
  */
 @property(nonatomic, assign) NSInteger maxReportCount;
+
+/** What to do after sending reports via `-[KSCrashReportStore sendAllReportsWithCompletion:]`.
+ *
+ * - Use `KSCrashReportCleanupPolicyNever` if you manually manage the reports.
+ * - Use `KSCrashReportCleanupPolicyAlways` if you are using an alert confirmation
+ *   (otherwise it will nag the user incessantly until he selects "yes").
+ * - Use `KSCrashReportCleanupPolicyOnSucess` for all other situations.
+ *
+ * Can be updated after creation of report store / installation of KSCrash.
+ *
+ * **Default**: `KSCrashReportCleanupPolicyAlways`
+ */
+@property(nonatomic, assign) KSCrashReportCleanupPolicy reportCleanupPolicy;
 
 @end
 

--- a/Sources/KSCrashRecording/include/KSCrashReportStore.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportStore.h
@@ -80,14 +80,15 @@ NS_SWIFT_NAME(CrashReportStore)
  */
 @property(nonatomic, readwrite, strong, nullable) id<KSCrashReportFilter> sink;
 
-/** What to do after sending reports via sendAllReportsWithCompletion:
+/** What to do after sending reports via `-[KSCrashReportStore sendAllReportsWithCompletion:]`.
  *
- * - Use KSCrashReportCleanupPolicyNever if you manually manage the reports.
- * - Use KSCrashReportCleanupPolicyAlways if you are using an alert confirmation
+ * - Use `KSCrashReportCleanupPolicyNever` if you manually manage the reports.
+ * - Use `KSCrashReportCleanupPolicyAlways` if you are using an alert confirmation
  *   (otherwise it will nag the user incessantly until he selects "yes").
- * - Use KSCrashReportCleanupPolicyOnSucess for all other situations.
+ * - Use `KSCrashReportCleanupPolicyOnSucess` for all other situations.
  *
- * Default: KSCrashReportCleanupPolicyAlways
+ * Initial value is provided from store configuration.
+ * If no configuration is provided, the default value from `KSCrashReportStoreConfiguration` is used.
  */
 @property(nonatomic, assign) KSCrashReportCleanupPolicy reportCleanupPolicy;
 


### PR DESCRIPTION
Resolves #582.

Without `reportCleanupPolicy` in store config it's not clear how to set it up in Installation API.