### PR TITLE
Fix installations subclassing

### DIFF
--- a/Samples/Common/Sources/LibraryBridge/SampleInstallation.swift
+++ b/Samples/Common/Sources/LibraryBridge/SampleInstallation.swift
@@ -1,0 +1,52 @@
+//
+//  SampleInstallation.swift
+//
+//  Created by Nikolay Volosatov on 2024-10-27.
+//
+//  Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import KSCrashInstallations
+import KSCrashFilters
+import Logging
+
+public class SampleInstallation: CrashInstallation {
+    public enum InstallationError: String, Error {
+        case missingHeaderMessage
+    }
+    private static let logger = Logger(label: "SampleInstallation")
+
+    public var headerMessage: String? = "Hello!"
+
+    public override func validateSetup() throws {
+        if headerMessage == nil {
+            throw InstallationError.missingHeaderMessage
+        }
+    }
+
+    public override func sink() -> any CrashReportFilter {
+        Self.logger.info("Header message: \(headerMessage ?? "<undefined>")")
+        return CrashReportFilterPipeline(filters: [
+            SampleFilter(),
+            SampleSink(),
+        ])
+    }
+}

--- a/Samples/Common/Sources/SampleUI/Screens/InstallView.swift
+++ b/Samples/Common/Sources/SampleUI/Screens/InstallView.swift
@@ -81,6 +81,12 @@ struct InstallView: View {
                 }
             }
 
+            Section(header: Text("Installations")) {
+                Button("SampleInstallation") {
+                    bridge.useInstallation(SampleInstallation())
+                }
+            }
+
             Button("Only set up reports") {
                 bridge.setupReportsOnly()
             }

--- a/Samples/Common/Sources/SampleUI/Screens/MainView.swift
+++ b/Samples/Common/Sources/SampleUI/Screens/MainView.swift
@@ -32,6 +32,9 @@ struct MainView: View {
 
     @ObservedObject var bridge: InstallBridge
 
+    @State var alertMessage: String?
+    @State var alertIsPresented: Bool = false
+
     var body: some View {
         List {
             Section {
@@ -53,6 +56,21 @@ struct MainView: View {
             } else {
                 Text("Reporting is not available")
             }
+            if let installation = bridge.installation {
+                Button("Send reports via installation") {
+                    installation.sendAllReports { _, error in
+                        alertMessage = error?.localizedDescription
+                        alertIsPresented = error != nil
+                    }
+                }
+            }
+        }
+        .alert(isPresented: $alertIsPresented) {
+            Alert(
+                title: Text("Error"),
+                message: Text(alertMessage ?? ""),
+                dismissButton: .default(Text("OK"))
+            )
         }
     }
 }

--- a/Sources/KSCrashInstallations/KSCrashInstallation+Private.h
+++ b/Sources/KSCrashInstallations/KSCrashInstallation+Private.h
@@ -67,10 +67,6 @@
  */
 - (void)reportFieldForProperty:(NSString *)propertyName setValue:(id)value;
 
-/** Create a new sink. Subclasses must implement this.
- */
-- (id<KSCrashReportFilter>)sink;
-
 /** Make an absolute key path if the specified path is not already absolute. */
 - (NSString *)makeKeyPath:(NSString *)keyPath;
 

--- a/Sources/KSCrashInstallations/KSCrashInstallation+Private.h
+++ b/Sources/KSCrashInstallations/KSCrashInstallation+Private.h
@@ -53,12 +53,6 @@
 
 @interface KSCrashInstallation ()
 
-/** Initializer.
- *
- * @param requiredProperties Properties that MUST be set when sending reports.
- */
-- (id)initWithRequiredProperties:(NSArray *)requiredProperties;
-
 /** Set the key to be used for the specified report property.
  *
  * @param propertyName The name of the property.

--- a/Sources/KSCrashInstallations/KSCrashInstallationConsole.m
+++ b/Sources/KSCrashInstallations/KSCrashInstallationConsole.m
@@ -44,9 +44,9 @@
     return sharedInstance;
 }
 
-- (id)init
+- (instancetype)init
 {
-    if ((self = [super initWithRequiredProperties:nil])) {
+    if ((self = [super init])) {
         _printAppleFormat = NO;
     }
     return self;

--- a/Sources/KSCrashInstallations/KSCrashInstallationEmail.m
+++ b/Sources/KSCrashInstallations/KSCrashInstallationEmail.m
@@ -28,6 +28,7 @@
 #import "KSCrashInstallation+Private.h"
 #import "KSCrashReportFilterAlert.h"
 #import "KSCrashReportSinkEMail.h"
+#import "KSNSErrorHelper.h"
 
 @interface KSCrashInstallationEmail ()
 
@@ -48,10 +49,9 @@
     return sharedInstance;
 }
 
-- (id)init
+- (instancetype)init
 {
-    if ((self = [super
-             initWithRequiredProperties:[NSArray arrayWithObjects:@"recipients", @"subject", @"filenameFmt", nil]])) {
+    if ((self = [super init])) {
         NSString *bundleName = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleName"];
         _subject = [NSString stringWithFormat:@"Crash Report (%@)", bundleName];
         _defaultFilenameFormats = [NSDictionary
@@ -62,6 +62,42 @@
         [self setReportStyle:KSCrashEmailReportStyleJSON useDefaultFilenameFormat:YES];
     }
     return self;
+}
+
+- (BOOL)validateSetupWithError:(NSError **)error
+{
+    if ([super validateSetupWithError:error] == NO) {
+        return NO;
+    }
+
+    if (self.recipients.count == 0) {
+        if (error != NULL) {
+            *error = [KSNSErrorHelper errorWithDomain:[[self class] description]
+                                                 code:0
+                                          description:@"Empty recepients array"];
+        }
+        return NO;
+    }
+
+    if (self.subject.length == 0) {
+        if (error != NULL) {
+            *error = [KSNSErrorHelper errorWithDomain:[[self class] description]
+                                                 code:0
+                                          description:@"No email subject provided"];
+        }
+        return NO;
+    }
+
+    if (self.filenameFmt.length == 0) {
+        if (error != NULL) {
+            *error = [KSNSErrorHelper errorWithDomain:[[self class] description]
+                                                 code:0
+                                          description:@"No filename format provided"];
+        }
+        return NO;
+    }
+
+    return YES;
 }
 
 - (void)setReportStyle:(KSCrashEmailReportStyle)reportStyle useDefaultFilenameFormat:(BOOL)useDefaultFilenameFormat

--- a/Sources/KSCrashInstallations/KSCrashInstallationStandard.m
+++ b/Sources/KSCrashInstallations/KSCrashInstallationStandard.m
@@ -28,6 +28,7 @@
 #import "KSCrashInstallation+Private.h"
 #import "KSCrashReportFilterBasic.h"
 #import "KSCrashReportSinkStandard.h"
+#import "KSNSErrorHelper.h"
 
 @implementation KSCrashInstallationStandard
 
@@ -42,9 +43,20 @@
     return sharedInstance;
 }
 
-- (id)init
+- (BOOL)validateSetupWithError:(NSError *__autoreleasing _Nullable *)error
 {
-    return [super initWithRequiredProperties:[NSArray arrayWithObjects:@"url", nil]];
+    if ([super validateSetupWithError:error] == NO) {
+        return NO;
+    }
+
+    if (self.url == nil) {
+        if (error != NULL) {
+            *error = [KSNSErrorHelper errorWithDomain:[[self class] description] code:0 description:@"No URL provided"];
+        }
+        return NO;
+    }
+
+    return YES;
 }
 
 - (id<KSCrashReportFilter>)sink

--- a/Sources/KSCrashInstallations/include/KSCrashInstallation.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallation.h
@@ -122,6 +122,16 @@ NS_SWIFT_NAME(CrashInstallation)
                                message:(nullable NSString *)message
                      dismissButtonText:(NSString *)dismissButtonText;
 
+/** Validates properties of installation.
+ *
+ * Intended to be overriden in subclasses to handle properties validation
+ * in the installation logic (e.g. before sending crash reports).
+ *
+ * @param error Pointer to an error object to store validation error.
+ * @return `NO` if there is a validation error.
+ */
+- (BOOL)validateSetupWithError:(NSError **)error;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/KSCrashInstallations/include/KSCrashInstallation.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallation.h
@@ -98,6 +98,13 @@ NS_SWIFT_NAME(CrashInstallation)
  */
 - (void)addPreFilter:(id<KSCrashReportFilter>)filter;
 
+/** Creates a sink to be used for reports sending.
+ * @note Subclasses MUST implement this, otherwise `sendAllReportsWithCompletion:` will complete with error.
+ *
+ * @return An instance that implements `KSCrashReportFilter` protocol to be used as a reports sending sink.
+ */
+- (id<KSCrashReportFilter>)sink;
+
 /** Show an alert before sending any reports. Reports will only be sent if the user
  * presses the "yes" button.
  *


### PR DESCRIPTION
Resolves #581.

This PR replaces `initWithRequiredProperties` with an overridable `validateSetupWithError` method as a way to ensure installation setup. In addition to that `sink` method is now made public so that custom installations can implement it.

A sample is updated to confirm custom instalation classes work as intended.