### PR TITLE
Use CocoaPods >= 1.16.1

### DIFF
--- a/.github/workflows/cocoapods-lint.yml
+++ b/.github/workflows/cocoapods-lint.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'Sources/**'
       - 'KSCrash.podspec'
+      - 'Gemfile'
       - '.github/workflows/cocoapods-lint.yml'
 
   push:

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,5 @@
 source 'https://rubygems.org'
 ruby ">= 3.0.0"
 
-# '!= 1.16.0': https://github.com/CocoaPods/CocoaPods/issues/12664
-gem 'cocoapods', '>= 1.15.2', '!= 1.16.0'
-
-# '!= 1.26.0': https://github.com/CocoaPods/Xcodeproj/issues/989
-gem 'xcodeproj', '!= 1.26.0'
+# '>= 1.16.1': https://github.com/CocoaPods/CocoaPods/issues/12664
+gem 'cocoapods', '>= 1.16.1'


### PR DESCRIPTION
A follow up on #585 as CocoaPods is expected to be fixed in 1.16.1 regarding `pod lint`.