### PR TITLE
Ensure crashed thread is present in the report

### DIFF
--- a/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
+++ b/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
@@ -41,10 +41,9 @@ class Report
 
 extern "C" void KSStacktraceCheckCrash() __attribute__((disable_tail_calls));
 NSString *const KSCrashStacktraceCheckFuncName = @"KSStacktraceCheckCrash";
-void KSStacktraceCheckCrash() __attribute__((disable_tail_calls)) {
-    NSException *exc = [NSException exceptionWithName:NSGenericException
-                                               reason:@"Stacktrace Check"
-                                             userInfo:nil];
+void KSStacktraceCheckCrash() __attribute__((disable_tail_calls))
+{
+    NSException *exc = [NSException exceptionWithName:NSGenericException reason:@"Stacktrace Check" userInfo:nil];
     [exc raise];
 }
 

--- a/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
+++ b/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
@@ -39,6 +39,15 @@ class Report
 };
 }  // namespace sample_namespace
 
+extern "C" void KSStacktraceCheckCrash() __attribute__((disable_tail_calls));
+NSString *const KSCrashStacktraceCheckFuncName = @"KSStacktraceCheckCrash";
+void KSStacktraceCheckCrash() __attribute__((disable_tail_calls)) {
+    NSException *exc = [NSException exceptionWithName:NSGenericException
+                                               reason:@"Stacktrace Check"
+                                             userInfo:nil];
+    [exc raise];
+}
+
 @implementation KSCrashTriggersList
 
 + (void)trigger_nsException_genericNSException
@@ -81,6 +90,33 @@ class Report
 + (void)trigger_signal_abort
 {
     abort();  // This will raise a SIGABRT signal
+}
+
++ (void)trigger_other_manyThreads
+{
+    NSUInteger const threadsCount = 200;
+    static NSMutableArray *allThreads = [NSMutableArray arrayWithCapacity:threadsCount + 1];
+
+    for (NSUInteger idx = 0; idx < threadsCount; ++idx) {
+        NSThread *thread = [[NSThread alloc] initWithBlock:^{
+            // Sleep forever by making short "sleep" calls
+            while (YES) {
+                [NSThread sleepForTimeInterval:0.01];
+            }
+        }];
+        [thread start];
+        [allThreads addObject:thread];
+    }
+
+    NSThread *thread = [[NSThread alloc] initWithBlock:^{
+        // Sleep 100ms to ensure other threads are running
+        [NSThread sleepForTimeInterval:0.1];
+
+        // And then actually crash (specifically in the last thread)
+        KSStacktraceCheckCrash();
+    }];
+    [thread start];
+    [allThreads addObject:thread];
 }
 
 + (void)trigger_other_stackOverflow

--- a/Samples/Common/Sources/CrashTriggers/include/KSCrashTriggersList.h
+++ b/Samples/Common/Sources/CrashTriggers/include/KSCrashTriggersList.h
@@ -28,6 +28,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+extern NSString *const KSCrashStacktraceCheckFuncName;
+
 #define __ALL_GROUPS                             \
     __PROCESS_GROUP(nsException, @"NSException") \
     __PROCESS_GROUP(cpp, @"C++")                 \
@@ -43,6 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
     __PROCESS_TRIGGER(mach, busError, @"EXC_BAD_ACCESS (SIGBUS)")                \
     __PROCESS_TRIGGER(mach, illegalInstruction, @"EXC_BAD_INSTRUCTION")          \
     __PROCESS_TRIGGER(signal, abort, @"Abort")                                   \
+    __PROCESS_TRIGGER(other, manyThreads, @"Many Threads")                       \
     __PROCESS_TRIGGER(other, stackOverflow, @"Stack overflow")
 
 NS_SWIFT_NAME(CrashTriggersList)

--- a/Samples/Tests/IntegrationTests.swift
+++ b/Samples/Tests/IntegrationTests.swift
@@ -26,6 +26,7 @@
 
 import XCTest
 import SampleUI
+import CrashTriggers
 
 final class NSExceptionTests: IntegrationTestBase {
     func testGenericException() throws {
@@ -109,6 +110,23 @@ final class SignalTests: IntegrationTestBase {
 }
 
 #endif
+
+final class OtherTests: IntegrationTestBase {
+    func testManyThreads() throws {
+        try launchAndCrash(.other_manyThreads)
+
+        let rawReport = try readPartialCrashReport()
+        let crashedThread = rawReport.crash?.threads?.first(where: { $0.crashed })
+        XCTAssertNotNil(crashedThread)
+        let expectedFrame = crashedThread?.backtrace.contents.first(where: {
+            $0.symbol_name?.contains(KSCrashStacktraceCheckFuncName) ?? false
+        })
+        XCTAssertNotNil(expectedFrame)
+
+        let appleReport = try launchAndReportCrash()
+        XCTAssertTrue(appleReport.contains(KSCrashStacktraceCheckFuncName))
+    }
+}
 
 extension PartialCrashReport {
     func validate() throws {

--- a/Sources/KSCrashRecordingCore/KSMachineContext.c
+++ b/Sources/KSCrashRecordingCore/KSMachineContext.c
@@ -86,6 +86,13 @@ static inline bool getThreadList(KSMachineContext *context)
     int maxThreadCount = sizeof(context->allThreads) / sizeof(context->allThreads[0]);
     if (threadCount > maxThreadCount) {
         KSLOG_ERROR("Thread count %d is higher than maximum of %d", threadCount, maxThreadCount);
+        for (mach_msg_type_number_t idx = maxThreadCount; idx < threadCount; ++idx) {
+            if (threads[idx] == context->thisThread) {
+                // If crashed thread is outside of threads limit we place it at the end of the list
+                threads[maxThreadCount - 1] = threads[idx];
+                break;
+            }
+        }
         threadCount = maxThreadCount;
     }
     for (int i = 0; i < threadCount; i++) {


### PR DESCRIPTION
Closes #533

To ensure the crashed thread is not missed in the report, it's placed last (in case of the number of threads is bigger than max and the crashed thread is outside of this limit too).