### PR TITLE
Fix user reported exceptions

### DIFF
--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_User.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_User.c
@@ -75,6 +75,7 @@ void kscm_reportUserException(const char *name, const char *reason, const char *
         context.userException.lineOfCode = lineOfCode;
         context.userException.customStackTrace = stackTrace;
         context.stackCursor = &stackCursor;
+        context.currentSnapshotUserReported = true;
 
         kscm_handleException(&context);
 

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_User_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_User_Tests.m
@@ -1,0 +1,45 @@
+//
+//  KSCrashMonitor_User_Tests.m
+//
+//  Created by Siarhei Belanovich on 02.11.2024.
+//
+//  Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "KSCrashMonitor_User.h"
+
+@interface KSCrashMonitor_User_Tests : XCTestCase
+@end
+
+@implementation KSCrashMonitor_User_Tests
+
+- (void)testInstallAndRemove
+{
+    KSCrashMonitorAPI *api = kscm_user_getAPI();
+    api->setEnabled(true);
+    XCTAssertTrue(api->isEnabled());
+    api->setEnabled(false);
+    XCTAssertFalse(api->isEnabled());
+}
+
+@end


### PR DESCRIPTION
There is an issue where manually reported user exceptions were incorrectly processed as application crashes. Previously, user-reported exceptions would be handled by the crash handling flow, which could lead to confusion in reporting and misrepresentation of error types in our monitoring system.