### PR TITLE
Remove KSCrash symbols from user-reported exceptions

### DIFF
--- a/Samples/Common/Sources/IntegrationTestsHelper/IntegrationTestRunner.swift
+++ b/Samples/Common/Sources/IntegrationTestsHelper/IntegrationTestRunner.swift
@@ -40,7 +40,7 @@ public final class IntegrationTestRunner {
 
     private struct Script: Codable {
         var install: InstallConfig?
-        var userReports: [UserReportConfig]?
+        var userReport: UserReportConfig?
         var crashTrigger: CrashTriggerConfig?
         var report: ReportConfig?
 
@@ -72,10 +72,8 @@ public final class IntegrationTestRunner {
             if let crashTrigger = script.crashTrigger {
                 crashTrigger.crash()
             }
-            if let userReports = script.userReports {
-                for report in userReports {
-                    report.report()
-                }
+            if let userReport = script.userReport {
+                userReport.report()
             }
             if let report = script.report {
                 report.report()
@@ -94,8 +92,8 @@ public extension IntegrationTestRunner {
         return data.base64EncodedString()
     }
 
-    static func script(userReports: [UserReportConfig], install: InstallConfig? = nil, config: RunConfig? = nil) throws -> String {
-        let data = try JSONEncoder().encode(Script(install: install, userReports: userReports, config: config))
+    static func script(userReport: UserReportConfig, install: InstallConfig? = nil, config: RunConfig? = nil) throws -> String {
+        let data = try JSONEncoder().encode(Script(install: install, userReport: userReport, config: config))
         return data.base64EncodedString()
     }
 

--- a/Samples/Tests/Core/IntegrationTestBase.swift
+++ b/Samples/Tests/Core/IntegrationTestBase.swift
@@ -211,11 +211,14 @@ class IntegrationTestBase: XCTestCase {
         waitForCrash()
     }
 
-    func launchAndMakeUserReports(_ reportTypes: [UserReportConfig.ReportType], installOverride: ((inout InstallConfig) throws -> Void)? = nil) throws {
+    func launchAndMakeUserReport(
+        userException: UserReportConfig.UserException? = nil,
+        nsException: UserReportConfig.NSExceptionReport? = nil,
+        installOverride: ((inout InstallConfig) throws -> Void)? = nil) throws {
         var installConfig = InstallConfig(installPath: installUrl.path)
         try installOverride?(&installConfig)
         app.launchEnvironment[IntegrationTestRunner.envKey] = try IntegrationTestRunner.script(
-            userReports: reportTypes.map(UserReportConfig.init(reportType:)),
+            userReport: .init(userException: userException, nsException: nsException),
             install: installConfig,
             config: runConfig
         )

--- a/Samples/Tests/IntegrationTests.swift
+++ b/Samples/Tests/IntegrationTests.swift
@@ -67,6 +67,10 @@ final class CppTests: IntegrationTestBase {
         let rawReport = try readPartialCrashReport()
         try rawReport.validate()
         XCTAssertEqual(rawReport.crash?.error?.type, "cpp_exception")
+        let topSymbol = rawReport.crashedThread?.backtrace.contents
+            .compactMap(\.symbol_name).first
+            .flatMap(CrashReportFilterDemangle.demangledCppSymbol)
+        XCTAssertEqual(topSymbol, "sample_namespace::Report::crash()")
 
         let appleReport = try launchAndReportCrash()
         XCTAssertTrue(appleReport.contains("C++ exception"))

--- a/Sources/KSCrashCore/include/KSCompilerDefines.h
+++ b/Sources/KSCrashCore/include/KSCompilerDefines.h
@@ -27,17 +27,20 @@
 #ifndef HDR_KSCompilerDefines_h
 #define HDR_KSCompilerDefines_h
 
-/// Disables optimisations to ensure a function remains in stacktrace.
-/// Usually used in pair with `KS_THWART_TAIL_CALL_OPTIMISATION`.
+/** Disables optimisations to ensure a function remains in stacktrace.
+ * Usually used in pair with `KS_THWART_TAIL_CALL_OPTIMISATION`.
+ */
 #define KS_KEEP_FUNCTION_IN_STACKTRACE __attribute__((disable_tail_calls))
 
-/// Disables inline optimisation.
-/// Usually used in pair with `KS_KEEP_FUNCTION_IN_STACKTRACE`.
+/** Disables inline optimisation.
+ * Usually used in pair with `KS_KEEP_FUNCTION_IN_STACKTRACE`.
+ */
 #define KS_NOINLINE __attribute__((noinline))
 
-/// Extra safety measure to ensure a method is not tail-call optimised.
-/// This define should be placed at the end of a function.
-/// Usually used in pair with `KS_KEEP_FUNCTION_IN_STACKTRACE`.
+/** Extra safety measure to ensure a method is not tail-call optimised.
+ * This define should be placed at the end of a function.
+ * Usually used in pair with `KS_KEEP_FUNCTION_IN_STACKTRACE`.
+ */
 #define KS_THWART_TAIL_CALL_OPTIMISATION __asm__ __volatile__("");
 
 #endif  // HDR_KSCompilerDefines_h

--- a/Sources/KSCrashCore/include/KSCompilerDefines.h
+++ b/Sources/KSCrashCore/include/KSCompilerDefines.h
@@ -1,7 +1,9 @@
 //
-//  KSStackCursor_SelfThread.c
+//  KSCompilerDefines.h
 //
-//  Copyright (c) 2016 Karl Stenerud. All rights reserved.
+//  Created by Karl Stenerud on 2024-11-03.
+//
+//  Copyright (c) 2012 Karl Stenerud. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,27 +24,16 @@
 // THE SOFTWARE.
 //
 
-#include "KSStackCursor_SelfThread.h"
+#ifndef HDR_KSCompilerDefines_h
+#define HDR_KSCompilerDefines_h
 
-#include <execinfo.h>
+/// Disables optimisations to ensure a function remains in stacktrace.
+/// Usually used in pair with `KS_THWART_TAIL_CALL_OPTIMISATION`.
+#define KS_KEEP_FUNCTION_IN_STACKTRACE __attribute__((disable_tail_calls)) __attribute__((noinline))
 
-#include "KSCompilerDefines.h"
-#include "KSStackCursor_Backtrace.h"
+/// Extra safety measure to ensure a method is not tail-call optimised.
+/// This define should be placed at the end of a function.
+/// Usually used in pair with `KS_KEEP_FUNCTION_IN_STACKTRACE`.
+#define KS_THWART_TAIL_CALL_OPTIMISATION __asm__ __volatile__("");
 
-// #define KSLogger_LocalLevel TRACE
-#include "KSLogger.h"
-
-#define MAX_BACKTRACE_LENGTH (KSSC_CONTEXT_SIZE - sizeof(KSStackCursor_Backtrace_Context) / sizeof(void *) - 1)
-
-typedef struct {
-    KSStackCursor_Backtrace_Context SelfThreadContextSpacer;
-    uintptr_t backtrace[0];
-} SelfThreadContext;
-
-void kssc_initSelfThread(KSStackCursor *cursor, int skipEntries) KS_KEEP_FUNCTION_IN_STACKTRACE
-{
-    SelfThreadContext *context = (SelfThreadContext *)cursor->context;
-    int backtraceLength = backtrace((void **)context->backtrace, MAX_BACKTRACE_LENGTH);
-    kssc_initWithBacktrace(cursor, context->backtrace, backtraceLength, skipEntries + 1);
-    KS_THWART_TAIL_CALL_OPTIMISATION
-}
+#endif  // HDR_KSCompilerDefines_h

--- a/Sources/KSCrashCore/include/KSCompilerDefines.h
+++ b/Sources/KSCrashCore/include/KSCompilerDefines.h
@@ -29,7 +29,11 @@
 
 /// Disables optimisations to ensure a function remains in stacktrace.
 /// Usually used in pair with `KS_THWART_TAIL_CALL_OPTIMISATION`.
-#define KS_KEEP_FUNCTION_IN_STACKTRACE __attribute__((disable_tail_calls)) __attribute__((noinline))
+#define KS_KEEP_FUNCTION_IN_STACKTRACE __attribute__((disable_tail_calls))
+
+/// Disables inline optimisation.
+/// Usually used in pair with `KS_KEEP_FUNCTION_IN_STACKTRACE`.
+#define KS_NOINLINE __attribute__((noinline))
 
 /// Extra safety measure to ensure a method is not tail-call optimised.
 /// This define should be placed at the end of a function.

--- a/Sources/KSCrashCore/include/KSCompilerDefines.h
+++ b/Sources/KSCrashCore/include/KSCompilerDefines.h
@@ -1,7 +1,7 @@
 //
 //  KSCompilerDefines.h
 //
-//  Created by Karl Stenerud on 2024-11-03.
+//  Created by Nikolay Volosatov on 2024-11-03.
 //
 //  Copyright (c) 2012 Karl Stenerud. All rights reserved.
 //

--- a/Sources/KSCrashRecording/KSCrash.m
+++ b/Sources/KSCrashRecording/KSCrash.m
@@ -27,6 +27,7 @@
 #import "KSCrash.h"
 #import "KSCrash+Private.h"
 
+#import "KSCompilerDefines.h"
 #import "KSCrashC.h"
 #import "KSCrashConfiguration+Private.h"
 #import "KSCrashMonitorContext.h"
@@ -266,7 +267,7 @@ static void currentSnapshotUserReportedExceptionHandler(NSException *exception)
                  lineOfCode:(NSString *)lineOfCode
                  stackTrace:(NSArray *)stackTrace
               logAllThreads:(BOOL)logAllThreads
-           terminateProgram:(BOOL)terminateProgram
+           terminateProgram:(BOOL)terminateProgram KS_KEEP_FUNCTION_IN_STACKTRACE
 {
     const char *cName = [name cStringUsingEncoding:NSUTF8StringEncoding];
     const char *cReason = [reason cStringUsingEncoding:NSUTF8StringEncoding];
@@ -286,15 +287,17 @@ static void currentSnapshotUserReportedExceptionHandler(NSException *exception)
     }
 
     kscrash_reportUserException(cName, cReason, cLanguage, cLineOfCode, cStackTrace, logAllThreads, terminateProgram);
+    KS_THWART_TAIL_CALL_OPTIMISATION
 }
 
-- (void)reportNSException:(NSException *)exception logAllThreads:(BOOL)logAllThreads
+- (void)reportNSException:(NSException *)exception logAllThreads:(BOOL)logAllThreads KS_KEEP_FUNCTION_IN_STACKTRACE
 {
     if (_customNSExceptionReporter == NULL) {
         KSLOG_ERROR(@"NSExcepttion monitor needs to be installed before reporting custom exceptions");
         return;
     }
     _customNSExceptionReporter(exception, logAllThreads);
+    KS_THWART_TAIL_CALL_OPTIMISATION
 }
 
 // ============================================================================

--- a/Sources/KSCrashRecording/KSCrashC.c
+++ b/Sources/KSCrashRecording/KSCrashC.c
@@ -26,6 +26,7 @@
 
 #include "KSCrashC.h"
 
+#include "KSCompilerDefines.h"
 #include "KSCrashCachedData.h"
 #include "KSCrashMonitorContext.h"
 #include "KSCrashMonitorType.h"
@@ -293,12 +294,14 @@ void kscrash_setUserInfoJSON(const char *const userInfoJSON) { kscrashreport_set
 const char *kscrash_getUserInfoJSON(void) { return kscrashreport_getUserInfoJSON(); }
 
 void kscrash_reportUserException(const char *name, const char *reason, const char *language, const char *lineOfCode,
-                                 const char *stackTrace, bool logAllThreads, bool terminateProgram)
+                                 const char *stackTrace, bool logAllThreads,
+                                 bool terminateProgram) KS_KEEP_FUNCTION_IN_STACKTRACE
 {
     kscm_reportUserException(name, reason, language, lineOfCode, stackTrace, logAllThreads, terminateProgram);
     if (g_shouldAddConsoleLogToReport) {
         kslog_clearLogFile();
     }
+    KS_THWART_TAIL_CALL_OPTIMISATION
 }
 
 void kscrash_notifyObjCLoad(void) { kscrashstate_notifyObjCLoad(); }

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
@@ -78,7 +78,7 @@ static KSStackCursor g_stackCursor;
 #pragma mark - Callbacks -
 // ============================================================================
 
-static void captureStackTrace(void *, std::type_info *tinfo, void (*)(void *)) KS_KEEP_FUNCTION_IN_STACKTRACE
+static KS_NOINLINE void captureStackTrace(void *, std::type_info *tinfo, void (*)(void *)) KS_KEEP_FUNCTION_IN_STACKTRACE
 {
     if (tinfo != nullptr && strcmp(tinfo->name(), "NSException") == 0) {
         return;

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
@@ -78,7 +78,8 @@ static KSStackCursor g_stackCursor;
 #pragma mark - Callbacks -
 // ============================================================================
 
-static KS_NOINLINE void captureStackTrace(void *, std::type_info *tinfo, void (*)(void *)) KS_KEEP_FUNCTION_IN_STACKTRACE
+static KS_NOINLINE void captureStackTrace(void *, std::type_info *tinfo,
+                                          void (*)(void *)) KS_KEEP_FUNCTION_IN_STACKTRACE
 {
     if (tinfo != nullptr && strcmp(tinfo->name(), "NSException") == 0) {
         return;

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException.m
@@ -56,7 +56,7 @@ static NSUncaughtExceptionHandler *g_previousUncaughtExceptionHandler;
 // ============================================================================
 
 static KS_NOINLINE void initStackCursor(KSStackCursor *cursor, NSException *exception, uintptr_t *callstack,
-                            BOOL isUserReported) KS_KEEP_FUNCTION_IN_STACKTRACE
+                                        BOOL isUserReported) KS_KEEP_FUNCTION_IN_STACKTRACE
 {
     // Use stacktrace from NSException if present,
     // otherwise use current thread (can happen for user-reported exceptions).
@@ -92,7 +92,7 @@ static KS_NOINLINE void initStackCursor(KSStackCursor *cursor, NSException *exce
  * @param exception The exception that was raised.
  */
 static KS_NOINLINE void handleException(NSException *exception, BOOL isUserReported,
-                            BOOL logAllThreads) KS_KEEP_FUNCTION_IN_STACKTRACE
+                                        BOOL logAllThreads) KS_KEEP_FUNCTION_IN_STACKTRACE
 {
     KSLOG_DEBUG(@"Trapped exception %@", exception);
     if (g_isEnabled) {

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException.m
@@ -55,7 +55,7 @@ static NSUncaughtExceptionHandler *g_previousUncaughtExceptionHandler;
 #pragma mark - Callbacks -
 // ============================================================================
 
-static void initStackCursor(KSStackCursor *cursor, NSException *exception, uintptr_t *callstack,
+static KS_NOINLINE void initStackCursor(KSStackCursor *cursor, NSException *exception, uintptr_t *callstack,
                             BOOL isUserReported) KS_KEEP_FUNCTION_IN_STACKTRACE
 {
     // Use stacktrace from NSException if present,
@@ -91,7 +91,7 @@ static void initStackCursor(KSStackCursor *cursor, NSException *exception, uintp
  *
  * @param exception The exception that was raised.
  */
-static void handleException(NSException *exception, BOOL isUserReported,
+static KS_NOINLINE void handleException(NSException *exception, BOOL isUserReported,
                             BOOL logAllThreads) KS_KEEP_FUNCTION_IN_STACKTRACE
 {
     KSLOG_DEBUG(@"Trapped exception %@", exception);

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException.m
@@ -27,6 +27,7 @@
 #import "KSCrashMonitor_NSException.h"
 
 #import <Foundation/Foundation.h>
+#import "KSCompilerDefines.h"
 #import "KSCrash+Private.h"
 #import "KSCrash.h"
 #include "KSCrashMonitorContext.h"
@@ -54,7 +55,8 @@ static NSUncaughtExceptionHandler *g_previousUncaughtExceptionHandler;
 #pragma mark - Callbacks -
 // ============================================================================
 
-static void initStackCursor(KSStackCursor *cursor, NSException *exception, uintptr_t *callstack, BOOL isUserReported)
+static void initStackCursor(KSStackCursor *cursor, NSException *exception, uintptr_t *callstack,
+                            BOOL isUserReported) KS_KEEP_FUNCTION_IN_STACKTRACE
 {
     // Use stacktrace from NSException if present,
     // otherwise use current thread (can happen for user-reported exceptions).
@@ -67,8 +69,21 @@ static void initStackCursor(KSStackCursor *cursor, NSException *exception, uintp
         }
         kssc_initWithBacktrace(cursor, callstack, (int)numFrames, 0);
     } else {
-        kssc_initSelfThread(cursor, 0);
+        /* Skip frames for user-reported:
+         * 1. `initStackCursor`
+         * 2. `handleException`
+         * 3. `customNSExceptionReporter`
+         * 4. `+[KSCrash reportNSException:logAllThreads:]`
+         *
+         * Skip frames for caught exceptions (unlikely scenario):
+         * 1. `initStackCursor`
+         * 2. `handleException`
+         * 3. `handleUncaughtException`
+         */
+        int const skipFrames = isUserReported ? 4 : 3;
+        kssc_initSelfThread(cursor, skipFrames);
     }
+    KS_THWART_TAIL_CALL_OPTIMISATION
 }
 
 /** Our custom excepetion handler.
@@ -76,7 +91,8 @@ static void initStackCursor(KSStackCursor *cursor, NSException *exception, uintp
  *
  * @param exception The exception that was raised.
  */
-static void handleException(NSException *exception, BOOL isUserReported, BOOL logAllThreads)
+static void handleException(NSException *exception, BOOL isUserReported,
+                            BOOL logAllThreads) KS_KEEP_FUNCTION_IN_STACKTRACE
 {
     KSLOG_DEBUG(@"Trapped exception %@", exception);
     if (g_isEnabled) {
@@ -127,14 +143,20 @@ static void handleException(NSException *exception, BOOL isUserReported, BOOL lo
             g_previousUncaughtExceptionHandler(exception);
         }
     }
+    KS_THWART_TAIL_CALL_OPTIMISATION
 }
 
-static void customNSExceptionReporter(NSException *exception, BOOL logAllThreads)
+static void customNSExceptionReporter(NSException *exception, BOOL logAllThreads) KS_KEEP_FUNCTION_IN_STACKTRACE
 {
     handleException(exception, YES, logAllThreads);
+    KS_THWART_TAIL_CALL_OPTIMISATION
 }
 
-static void handleUncaughtException(NSException *exception) { handleException(exception, NO, YES); }
+static void handleUncaughtException(NSException *exception) KS_KEEP_FUNCTION_IN_STACKTRACE
+{
+    handleException(exception, NO, YES);
+    KS_THWART_TAIL_CALL_OPTIMISATION
+}
 
 // ============================================================================
 #pragma mark - API -

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_User.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_User.c
@@ -24,6 +24,7 @@
 
 #include "KSCrashMonitor_User.h"
 
+#include "KSCompilerDefines.h"
 #include "KSCrashMonitorContext.h"
 #include "KSCrashMonitorContextHelper.h"
 #include "KSID.h"
@@ -41,7 +42,8 @@
 static volatile bool g_isEnabled = false;
 
 void kscm_reportUserException(const char *name, const char *reason, const char *language, const char *lineOfCode,
-                              const char *stackTrace, bool logAllThreads, bool terminateProgram)
+                              const char *stackTrace, bool logAllThreads,
+                              bool terminateProgram) KS_KEEP_FUNCTION_IN_STACKTRACE
 {
     if (!g_isEnabled) {
         KSLOG_WARN("User-reported exception monitor is not installed. Exception has not been recorded.");
@@ -60,7 +62,7 @@ void kscm_reportUserException(const char *name, const char *reason, const char *
         KSMC_NEW_CONTEXT(machineContext);
         ksmc_getContextForThread(ksthread_self(), machineContext, true);
         KSStackCursor stackCursor;
-        kssc_initSelfThread(&stackCursor, 0);
+        kssc_initSelfThread(&stackCursor, 3);
 
         KSLOG_DEBUG("Filling out context.");
         KSCrash_MonitorContext context;
@@ -86,6 +88,7 @@ void kscm_reportUserException(const char *name, const char *reason, const char *
             abort();
         }
     }
+    KS_THWART_TAIL_CALL_OPTIMISATION
 }
 
 static const char *monitorId(void) { return "UserReported"; }


### PR DESCRIPTION
A follow up on #588 to fix the content of crashed threads in user reports (both API methods).