### PR TITLE
use null terminated string for userinfo

### DIFF
--- a/Sources/KSCrashRecording/KSCrash.m
+++ b/Sources/KSCrashRecording/KSCrash.m
@@ -170,9 +170,8 @@ static void currentSnapshotUserReportedExceptionHandler(NSException *exception)
         }
     }
 
-    NSString *userInfoString = userInfoJSON 
-        ? [[NSString alloc] initWithData:userInfoJSON encoding:NSUTF8StringEncoding]
-        : nil;
+    NSString *userInfoString =
+        userInfoJSON ? [[NSString alloc] initWithData:userInfoJSON encoding:NSUTF8StringEncoding] : nil;
     kscrash_setUserInfoJSON(userInfoString.UTF8String);
 }
 

--- a/Tests/KSCrashRecordingTests/KSCrash_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrash_Tests.m
@@ -35,7 +35,7 @@
 
 - (void)testUserInfo
 {
-    NSDictionary *userInfo = @{@"key1": @"value1", @"key2": @123};
+    NSDictionary *userInfo = @{ @"key1" : @"value1", @"key2" : @123 };
     [[KSCrash sharedInstance] setUserInfo:userInfo];
 
     XCTAssertEqualObjects([[KSCrash sharedInstance] userInfo], userInfo);


### PR DESCRIPTION
`userInfoCString` could be a non-null terminated string, and then `strdup` is called in the code and it sometimes crashes with the `Heap buffer overflow` error.

I wrote a unit test. Before the fix, ~2% of 10,000 runs failed. After the fix, there were no failures.