### PR TITLE
Fix ksmemory_notifyUnhandledFatalSignal memory crash

### DIFF
--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
@@ -570,4 +570,9 @@ void ksmemory_set_fatal_reports_enabled(bool enabled) { g_FatalReportsEnabled = 
 
 bool ksmemory_get_fatal_reports_enabled(void) { return g_FatalReportsEnabled; }
 
-void ksmemory_notifyUnhandledFatalSignal(void) { g_memory->fatal = true; }
+void ksmemory_notifyUnhandledFatalSignal(void)
+{
+    if (g_memory) {
+        g_memory->fatal = true;
+    }
+}

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_Memory_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_Memory_Tests.m
@@ -313,4 +313,9 @@ static KSCrashAppMemory *Memory(uint64_t footprint)
     XCTAssertEqual(ksmemory_get_nonfatal_report_level(), KSCrashAppMemoryStateUrgent);
 }
 
+- (void)testNotifyUnhandledFatalSignal
+{
+    XCTAssertNoThrow(ksmemory_notifyUnhandledFatalSignal(), @"NULL safety for g_memory");
+}
+
 @end


### PR DESCRIPTION
Added a NULL check in `ksmemory_notifyUnhandledFatalSignal` to ensure safe access to `g_memory`, preventing potential crashes.
#593 