### PR TITLE
[bugfix#493]Filter out More NSException

### DIFF
--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
@@ -108,6 +108,26 @@ void __cxa_throw(void *thrown_exception, std::type_info *tinfo, void (*dest)(voi
 }
 }
 
+static const char* kscm_nsexception_names[] = {
+    "NSException",
+    "_NSCoreDataException",
+    "__NSCFConstantString"
+};
+
+static bool kscm_nsexception_detected(const char* exception_name)
+{
+    if (exception_name == NULL) return false;
+    
+    size_t num = sizeof(kscm_nsexception_names) / sizeof(kscm_nsexception_names[0]);
+    for (size_t i = 0; i < num; i++) {
+        if (strcmp(exception_name, kscm_nsexception_names[i]) == 0) {
+            return true;
+        }
+    }
+    
+    return false;
+}
+
 static void CPPExceptionTerminate(void)
 {
     thread_act_array_t threads = NULL;
@@ -120,7 +140,7 @@ static void CPPExceptionTerminate(void)
         name = tinfo->name();
     }
 
-    if (name == NULL || strcmp(name, "NSException") != 0) {
+    if (kscm_nsexception_detected(name) == false) {
         kscm_notifyFatalExceptionCaptured(false);
         KSCrash_MonitorContext *crashContext = &g_monitorContext;
         memset(crashContext, 0, sizeof(*crashContext));


### PR DESCRIPTION
For NSException, the stack trace can be obtained through system APIs, and it is not necessary to obtain it in __cxa_throw. Therefore, this filtering is valuable and also provides some performance optimization. But only for whether the name is an NSException as a judgment basis, still let go of some Objc exceptions. To optimize this, we suggest maintaining the list through a constant array, so far we have found _NSCoreDataException and __NSCFConstantString, and there may be more in the future;