### PR TITLE
[CI] Ensure simulators are ready before running Xcode-related tasks

### DIFF
--- a/.github/workflows/build-sample.yml
+++ b/.github/workflows/build-sample.yml
@@ -42,6 +42,14 @@ jobs:
         with:
           xcode-version: latest-stable
 
+      - name: Ensure the Platform is Downloaded
+        if: ${{ matrix.platform != 'macOS' }}
+        run: |
+          xcodebuild -runFirstLaunch
+          xcrun simctl list
+          xcodebuild -downloadPlatform ${{ matrix.platform }}
+          xcodebuild -runFirstLaunch
+
       - name: Install Tuist
         run: |
           brew tap tuist/tuist

--- a/.github/workflows/cocoapods-lint.yml
+++ b/.github/workflows/cocoapods-lint.yml
@@ -61,6 +61,14 @@ jobs:
         with:
           xcode-version: latest-stable
 
+      - name: Ensure the Platform is Downloaded
+        if: ${{ matrix.platform != 'macOS' }}
+        run: |
+          xcodebuild -runFirstLaunch
+          xcrun simctl list
+          xcodebuild -downloadPlatform ${{ matrix.platform }}
+          xcodebuild -runFirstLaunch
+
       - name: Lint Podspec
         id: lint
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,6 +39,14 @@ jobs:
         with:
           xcode-version: latest-stable
 
+      - name: Ensure the Platform is Downloaded
+        if: ${{ matrix.platform != 'macOS' }}
+        run: |
+          xcodebuild -runFirstLaunch
+          xcrun simctl list
+          xcodebuild -downloadPlatform ${{ matrix.platform }}
+          xcodebuild -runFirstLaunch
+
       - name: Install Tuist
         run: |
           brew tap tuist/tuist

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,7 +28,8 @@ jobs:
           # iOS integration tests are too flaky and are temporary excluded
           # - platform: iOS
           - platform: macOS
-          - platform: tvOS
+          # tvOS integration tests became flaky after Xcode 16.2
+          # - platform: tvOS
           - platform: watchOS
     steps:
       - name: Checkout Code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,14 +27,15 @@ jobs:
         with:
           xcode-version: latest-stable
 
-      - name: Install visionOS Platform
-        shell: bash
+      - name: Ensure Platforms are Downloaded
         run: |
-          # See https://github.com/actions/runner-images/issues/10692#issuecomment-2377521050
           xcodebuild -runFirstLaunch
           xcrun simctl list
-          xcodebuild -downloadPlatform visionOS
-          xcodebuild -runFirstLaunch
+          for platform in iOS watchOS tvOS visionOS; do
+            echo "Downloading $platform platform..."
+            xcodebuild -downloadPlatform $platform
+            xcodebuild -runFirstLaunch
+          done
 
       - name: Update version in podspec
         run: sed -i '' 's/s.version      = "[^"]*"/s.version      = "${{ github.event.inputs.version }}"/' KSCrash.podspec

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,30 +37,30 @@ jobs:
             macos-version: "13"
             xcode-version: "14.3.1"
 
-          - platform: watchOS
-            macos-version: "15"
-          - platform: watchOS
-            platform-version: ~9.4.0
-            macos-version: "13"
-            xcode-version: "14.3.1"
+          # - platform: watchOS
+          #   macos-version: "15"
+          # - platform: watchOS
+          #   platform-version: ~9.4.0
+          #   macos-version: "13"
+          #   xcode-version: "14.3.1"
 
-          - platform: tvOS
-            macos-version: "15"
-          - platform: tvOS
-            platform-version: ~16.4.0
-            macos-version: "13"
-            xcode-version: "14.3.1"
+          # - platform: tvOS
+          #   macos-version: "15"
+          # - platform: tvOS
+          #   platform-version: ~16.4.0
+          #   macos-version: "13"
+          #   xcode-version: "14.3.1"
 
           - platform: visionOS
             macos-version: "15"
 
-          - platform: macOS
-          - platform: macOS
-            macos-version: "13"
+          # - platform: macOS
+          # - platform: macOS
+          #   macos-version: "13"
 
-          - platform: mac-catalyst
-          - platform: mac-catalyst
-            macos-version: "13"
+          # - platform: mac-catalyst
+          # - platform: mac-catalyst
+          #   macos-version: "13"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -70,6 +70,13 @@ jobs:
         with:
           xcode-version: ${{ matrix.xcode-version || 'latest-stable' }}
 
+      - name: Ensure the platform is downloaded
+        run: |
+          xcodebuild -runFirstLaunch
+          xcrun simctl list
+          xcodebuild -downloadPlatform ${{ matrix.platform }}
+          xcodebuild -runFirstLaunch
+
       - name: Run Unit Tests
         uses: mxcl/xcodebuild@v3
         timeout-minutes: 15

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -71,6 +71,7 @@ jobs:
           xcode-version: ${{ matrix.xcode-version || 'latest-stable' }}
 
       - name: Ensure the platform is downloaded
+        if: ${{ matrix.platform != 'macOS' || matrix.platform != 'mac-catalyst' }}
         run: |
           xcodebuild -runFirstLaunch
           xcrun simctl list

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -71,7 +71,7 @@ jobs:
           xcode-version: ${{ matrix.xcode-version || 'latest-stable' }}
 
       - name: Ensure the platform is downloaded
-        if: ${{ matrix.platform != 'macOS' || matrix.platform != 'mac-catalyst' }}
+        if: ${{ matrix.platform != 'macOS' && matrix.platform != 'mac-catalyst' }}
         run: |
           xcodebuild -runFirstLaunch
           xcrun simctl list

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,30 +37,30 @@ jobs:
             macos-version: "13"
             xcode-version: "14.3.1"
 
-          # - platform: watchOS
-          #   macos-version: "15"
-          # - platform: watchOS
-          #   platform-version: ~9.4.0
-          #   macos-version: "13"
-          #   xcode-version: "14.3.1"
+          - platform: watchOS
+            macos-version: "15"
+          - platform: watchOS
+            platform-version: ~9.4.0
+            macos-version: "13"
+            xcode-version: "14.3.1"
 
-          # - platform: tvOS
-          #   macos-version: "15"
-          # - platform: tvOS
-          #   platform-version: ~16.4.0
-          #   macos-version: "13"
-          #   xcode-version: "14.3.1"
+          - platform: tvOS
+            macos-version: "15"
+          - platform: tvOS
+            platform-version: ~16.4.0
+            macos-version: "13"
+            xcode-version: "14.3.1"
 
           - platform: visionOS
             macos-version: "15"
 
-          # - platform: macOS
-          # - platform: macOS
-          #   macos-version: "13"
+          - platform: macOS
+          - platform: macOS
+            macos-version: "13"
 
-          # - platform: mac-catalyst
-          # - platform: mac-catalyst
-          #   macos-version: "13"
+          - platform: mac-catalyst
+          - platform: mac-catalyst
+            macos-version: "13"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           xcode-version: ${{ matrix.xcode-version || 'latest-stable' }}
 
-      - name: Ensure the platform is downloaded
+      - name: Ensure the Platform is Downloaded
         if: ${{ matrix.platform != 'macOS' && matrix.platform != 'mac-catalyst' }}
         run: |
           xcodebuild -runFirstLaunch


### PR DESCRIPTION
For some reason Xcode fails to use a simulator provided by UID.
This PR adds an extra safety step that runs `xcodebuild -runFirstLaunch` and `xcodebuild -downloadPlatform XXX`.
Somehow this helps and doesn't cost much in terms of CI time (~20s).