### PR TITLE
Add os_unfair_lock for thread safety in KSCrashMonitor

### DIFF
--- a/Sources/KSCrashRecordingCore/KSCrashMonitor.c
+++ b/Sources/KSCrashRecordingCore/KSCrashMonitor.c
@@ -28,6 +28,7 @@
 
 #include <memory.h>
 #include <stdlib.h>
+#include <os/lock.h>
 
 #include "KSCrashMonitorContext.h"
 #include "KSCrashMonitorHelper.h"
@@ -61,6 +62,7 @@ getMonitorNameForLogging(const KSCrashMonitorAPI *api)
 // ============================================================================
 
 static MonitorList g_monitors = {};
+static os_unfair_lock g_monitorsLock = OS_UNFAIR_LOCK_INIT;
 
 static bool g_areMonitorsInitialized = false;
 static bool g_handlingFatalException = false;
@@ -128,7 +130,10 @@ static void freeMonitorFuncList(MonitorList *list)
 __attribute__((unused)) // For tests. Declared as extern in TestCase
 void kscm_resetState(void)
 {
+    os_unfair_lock_lock(&g_monitorsLock);
     freeMonitorFuncList(&g_monitors);
+    os_unfair_lock_unlock(&g_monitorsLock);
+    
     g_handlingFatalException = false;
     g_crashedDuringExceptionHandling = false;
     g_requiresAsyncSafety = false;
@@ -165,6 +170,8 @@ bool kscm_activateMonitors(void)
         KSLOG_DEBUG("Async-safe environment detected. Masking out unsafe monitors.");
     }
 
+    os_unfair_lock_lock(&g_monitorsLock);
+    
     // Enable or disable monitors
     for (size_t i = 0; i < g_monitors.count; i++) {
         KSCrashMonitorAPI *api = g_monitors.apis[i];
@@ -202,15 +209,19 @@ bool kscm_activateMonitors(void)
         kscm_notifyPostSystemEnable(api);
     }
 
+    os_unfair_lock_unlock(&g_monitorsLock);
+    
     return anyMonitorActive;
 }
 
 void kscm_disableAllMonitors(void)
 {
+    os_unfair_lock_lock(&g_monitorsLock);
     for (size_t i = 0; i < g_monitors.count; i++) {
         KSCrashMonitorAPI *api = g_monitors.apis[i];
         kscm_setMonitorEnabled(api, false);
     }
+    os_unfair_lock_unlock(&g_monitorsLock);
     KSLOG_DEBUG("All monitors have been disabled.");
 }
 
@@ -232,6 +243,8 @@ bool kscm_addMonitor(KSCrashMonitorAPI *api)
         g_areMonitorsInitialized = true;
     }
 
+    os_unfair_lock_lock(&g_monitorsLock);
+
     // Check for duplicate monitors
     for (size_t i = 0; i < g_monitors.count; i++) {
         KSCrashMonitorAPI *existingApi = g_monitors.apis[i];
@@ -239,12 +252,15 @@ bool kscm_addMonitor(KSCrashMonitorAPI *api)
 
         if (ksstring_safeStrcmp(existingMonitorId, newMonitorId) == 0) {
             KSLOG_DEBUG("Monitor %s already exists. Skipping addition.", getMonitorNameForLogging(api));
+            os_unfair_lock_unlock(&g_monitorsLock);
             return false;
         }
     }
 
     addMonitor(&g_monitors, api);
     KSLOG_DEBUG("Monitor %s injected.", getMonitorNameForLogging(api));
+    
+    os_unfair_lock_unlock(&g_monitorsLock);
     return true;
 }
 
@@ -255,7 +271,11 @@ void kscm_removeMonitor(const KSCrashMonitorAPI *api)
         return;
     }
 
+    os_unfair_lock_lock(&g_monitorsLock);
+    
     removeMonitor(&g_monitors, api);
+    
+    os_unfair_lock_unlock(&g_monitorsLock);
 }
 
 // KSCrashMonitorType kscm_getActiveMonitors(void)
@@ -292,6 +312,12 @@ void kscm_handleException(struct KSCrash_MonitorContext *context)
         context->crashedDuringCrashHandling = true;
     }
 
+    // If the crash happened during monitor registration, skip handling
+    if (os_unfair_lock_trylock(&g_monitorsLock) == false) {
+        KSLOG_ERROR("Unable to acquire lock for monitor list. Skipping exception handling.");
+        return;
+    }
+
     // Add contextual info to the event for all enabled monitors
     for (size_t i = 0; i < g_monitors.count; i++) {
         KSCrashMonitorAPI *api = g_monitors.apis[i];
@@ -299,6 +325,8 @@ void kscm_handleException(struct KSCrash_MonitorContext *context)
             kscm_addContextualInfoToEvent(api, context);
         }
     }
+
+    os_unfair_lock_unlock(&g_monitorsLock);
 
     // Call the exception event handler if it exists
     if (g_onExceptionEvent) {

--- a/Sources/KSCrashRecordingCore/KSCrashMonitor.c
+++ b/Sources/KSCrashRecordingCore/KSCrashMonitor.c
@@ -198,6 +198,9 @@ bool kscm_activateMonitors(void)
 
     if (monitorsCount > 0) {
         enabledMonitors = (KSCrashMonitorAPI **)malloc(monitorsCount * sizeof(KSCrashMonitorAPI *));
+        if (enabledMonitors == NULL) {
+            KSLOG_ERROR("Failed to allocate memory for enabled monitors.");
+        }
     }
 
     KSLOG_DEBUG("Active monitors are now:");

--- a/Sources/KSCrashRecordingCore/KSCrashMonitor.c
+++ b/Sources/KSCrashRecordingCore/KSCrashMonitor.c
@@ -190,12 +190,12 @@ bool kscm_activateMonitors(void)
     }
 
     bool anyMonitorActive = false;
-    
+
     // Create a copy of enabled monitors to avoid holding the lock during notification
     size_t enabledCount = 0;
     KSCrashMonitorAPI **enabledMonitors = NULL;
     size_t monitorsCount = g_monitors.count;
-    
+
     if (monitorsCount > 0) {
         enabledMonitors = (KSCrashMonitorAPI **)malloc(monitorsCount * sizeof(KSCrashMonitorAPI *));
     }
@@ -213,7 +213,7 @@ bool kscm_activateMonitors(void)
             KSLOG_DEBUG("Monitor %s is disabled.", getMonitorNameForLogging(api));
         }
     }
-    
+
     // Release the lock before calling notifyPostSystemEnable
     os_unfair_lock_unlock(&g_monitorsLock);
 
@@ -221,7 +221,7 @@ bool kscm_activateMonitors(void)
     for (size_t i = 0; i < enabledCount; i++) {
         kscm_notifyPostSystemEnable(enabledMonitors[i]);
     }
-    
+
     if (enabledMonitors) {
         free(enabledMonitors);
     }

--- a/Sources/KSCrashRecordingCore/KSCrashMonitor.c
+++ b/Sources/KSCrashRecordingCore/KSCrashMonitor.c
@@ -208,7 +208,7 @@ bool kscm_activateMonitors(void)
         KSCrashMonitorAPI *api = g_monitors.apis[i];
         if (kscm_isMonitorEnabled(api)) {
             KSLOG_DEBUG("Monitor %s is enabled.", getMonitorNameForLogging(api));
-            if (enabledMonitors) {
+            if (enabledMonitors != NULL) {
                 enabledMonitors[enabledCount++] = api;
             }
             anyMonitorActive = true;
@@ -225,7 +225,7 @@ bool kscm_activateMonitors(void)
         kscm_notifyPostSystemEnable(enabledMonitors[i]);
     }
 
-    if (enabledMonitors) {
+    if (enabledMonitors != NULL) {
         free(enabledMonitors);
     }
 

--- a/Sources/KSCrashRecordingCore/KSCrashMonitor.c
+++ b/Sources/KSCrashRecordingCore/KSCrashMonitor.c
@@ -27,8 +27,8 @@
 #include "KSCrashMonitor.h"
 
 #include <memory.h>
-#include <stdlib.h>
 #include <os/lock.h>
+#include <stdlib.h>
 
 #include "KSCrashMonitorContext.h"
 #include "KSCrashMonitorHelper.h"
@@ -133,7 +133,7 @@ void kscm_resetState(void)
     os_unfair_lock_lock(&g_monitorsLock);
     freeMonitorFuncList(&g_monitors);
     os_unfair_lock_unlock(&g_monitorsLock);
-    
+
     g_handlingFatalException = false;
     g_crashedDuringExceptionHandling = false;
     g_requiresAsyncSafety = false;
@@ -171,7 +171,7 @@ bool kscm_activateMonitors(void)
     }
 
     os_unfair_lock_lock(&g_monitorsLock);
-    
+
     // Enable or disable monitors
     for (size_t i = 0; i < g_monitors.count; i++) {
         KSCrashMonitorAPI *api = g_monitors.apis[i];
@@ -210,7 +210,7 @@ bool kscm_activateMonitors(void)
     }
 
     os_unfair_lock_unlock(&g_monitorsLock);
-    
+
     return anyMonitorActive;
 }
 
@@ -259,7 +259,7 @@ bool kscm_addMonitor(KSCrashMonitorAPI *api)
 
     addMonitor(&g_monitors, api);
     KSLOG_DEBUG("Monitor %s injected.", getMonitorNameForLogging(api));
-    
+
     os_unfair_lock_unlock(&g_monitorsLock);
     return true;
 }
@@ -272,9 +272,9 @@ void kscm_removeMonitor(const KSCrashMonitorAPI *api)
     }
 
     os_unfair_lock_lock(&g_monitorsLock);
-    
+
     removeMonitor(&g_monitors, api);
-    
+
     os_unfair_lock_unlock(&g_monitorsLock);
 }
 


### PR DESCRIPTION
This pull request focuses on improving thread safety within the `KSCrashMonitor.c` file by introducing the use of `os_unfair_lock` to protect access to shared resources. The most important changes include adding the lock, ensuring it is used around critical sections, and managing the lock during exception handling.

Thread safety improvements:

* Added `os_unfair_lock` to protect the `g_monitors` structure and initialized it with `OS_UNFAIR_LOCK_INIT`. (`Sources/KSCrashRecordingCore/KSCrashMonitor.c`) [[1]](diffhunk://#diff-c5b45d53155aed7eb751285e8ab25086f1d3031b9c16899f84e8a75bfed63758R30) [[2]](diffhunk://#diff-c5b45d53155aed7eb751285e8ab25086f1d3031b9c16899f84e8a75bfed63758R65)
* Wrapped critical sections with `os_unfair_lock_lock` and `os_unfair_lock_unlock` to ensure exclusive access when modifying or accessing the `g_monitors` structure. (`Sources/KSCrashRecordingCore/KSCrashMonitor.c`) [[1]](diffhunk://#diff-c5b45d53155aed7eb751285e8ab25086f1d3031b9c16899f84e8a75bfed63758R133-R136) [[2]](diffhunk://#diff-c5b45d53155aed7eb751285e8ab25086f1d3031b9c16899f84e8a75bfed63758R173-R174) [[3]](diffhunk://#diff-c5b45d53155aed7eb751285e8ab25086f1d3031b9c16899f84e8a75bfed63758R264-R281) [[4]](diffhunk://#diff-c5b45d53155aed7eb751285e8ab25086f1d3031b9c16899f84e8a75bfed63758R292-R296)
* Modified the `kscm_activateMonitors` function to create a copy of enabled monitors to avoid holding the lock during monitor notifications. (`Sources/KSCrashRecordingCore/KSCrashMonitor.c`)
* Added a check in `kscm_handleException` to skip handling if the lock cannot be acquired, ensuring that crash handling does not interfere with monitor registration. (`Sources/KSCrashRecordingCore/KSCrashMonitor.c`) [[1]](diffhunk://#diff-c5b45d53155aed7eb751285e8ab25086f1d3031b9c16899f84e8a75bfed63758R333-R338) [[2]](diffhunk://#diff-c5b45d53155aed7eb751285e8ab25086f1d3031b9c16899f84e8a75bfed63758R347-R348)