### PR TITLE
Add Swift version setting to Tuist project configuration

### DIFF
--- a/.github/workflows/build-sample.yml
+++ b/.github/workflows/build-sample.yml
@@ -60,7 +60,7 @@ jobs:
         run: tuist generate --verbose --no-open
 
       - name: Run Build
-        uses: bamx23/xcodebuild@os-version
+        uses: mxcl/xcodebuild@v3
         timeout-minutes: 10
         with:
           action: build

--- a/Samples/Project.swift
+++ b/Samples/Project.swift
@@ -5,6 +5,9 @@ let project = Project(
     packages: [
         .local(path: "Common"),
     ],
+    settings: .settings(base: [
+        "SWIFT_VERSION": "5.0"
+    ]),
     targets: [
         .target(
             name: "Sample",


### PR DESCRIPTION
This pull request includes updates to the build configuration and project settings to ensure compatibility with the latest tools and Swift version. The most important changes are:

Build configuration updates:
* [`.github/workflows/build-sample.yml`](diffhunk://#diff-510fb661a28fc1554571c4a72998d7b5fae759cb82422176eae8805dda0122c0L63-R63): Updated the `xcodebuild` action to use version `v3` for improved compatibility and features.

Project settings updates:
* [`Samples/Project.swift`](diffhunk://#diff-43df2939d4169652eda6ba0e74aa46dc6f8c41cf43dd254e61f9751d1f4d7a5dR8-R10): Added a new project setting to specify the Swift version as `5.0` to ensure compatibility with the codebase. Without this setting, the project defaults to the outdated Swift 3 version.