### PR TITLE
Use NS_EXTENSION_UNAVAILABLE_IOS() marking all methods depending on UIApplication.sharedApplication as unavailable

### DIFF
--- a/Sources/KSCrashFilters/KSCrashReportFilterAlert.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterAlert.m
@@ -43,6 +43,7 @@
 #import <AppKit/AppKit.h>
 #endif
 
+NS_EXTENSION_UNAVAILABLE_IOS("Confirmation alert cannot be displayed in app extension")
 @interface KSCrashAlertViewProcess : NSObject
 
 @property(nonatomic, readwrite, copy) NSArray<id<KSCrashReport>> *reports;

--- a/Sources/KSCrashFilters/include/KSCrashReportFilterAlert.h
+++ b/Sources/KSCrashFilters/include/KSCrashReportFilterAlert.h
@@ -39,6 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Input: Any
  * Output: Same as input (passthrough)
  */
+NS_EXTENSION_UNAVAILABLE_IOS("Confirmation alert cannot be displayed in app extension")
 NS_SWIFT_NAME(CrashReportFilterAlert)
 @interface KSCrashReportFilterAlert : NSObject <KSCrashReportFilter>
 

--- a/Sources/KSCrashInstallations/include/KSCrashInstallationEmail.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallationEmail.h
@@ -39,6 +39,7 @@ typedef NS_ENUM(NSUInteger, KSCrashEmailReportStyle) {
  * Email installation.
  * Sends reports via email.
  */
+NS_EXTENSION_UNAVAILABLE_IOS("Confirmation alert cannot be displayed in app extension")
 NS_SWIFT_NAME(CrashInstallationEmail)
 @interface KSCrashInstallationEmail : KSCrashInstallation
 

--- a/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
+++ b/Sources/KSCrashSinks/KSCrashReportSinkEMail.m
@@ -40,6 +40,7 @@
 #if KSCRASH_HAS_MESSAGEUI
 #import <MessageUI/MessageUI.h>
 
+NS_EXTENSION_UNAVAILABLE_IOS("Confirmation alert cannot be displayed in app extension")
 @interface KSCrashMailProcess : NSObject <MFMailComposeViewControllerDelegate>
 
 @property(nonatomic, readwrite, copy) NSArray<id<KSCrashReport>> *reports;

--- a/Sources/KSCrashSinks/include/KSCrashReportSinkEMail.h
+++ b/Sources/KSCrashSinks/include/KSCrashReportSinkEMail.h
@@ -34,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Input: NSData
  * Output: Same as input (passthrough)
  */
+NS_EXTENSION_UNAVAILABLE_IOS("Confirmation alert cannot be displayed in app extension")
 NS_SWIFT_NAME(CrashReportSinkEmail)
 @interface KSCrashReportSinkEMail : NSObject <KSCrashReportFilter>
 


### PR DESCRIPTION
This allows us to add KSCrash to app extension targets not having access to `sharedApplication` (and not being able to show an `UIAlertController`) like for example the `NotificationServiceExtension`.

