### PR TITLE
Try to fix macOS integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   integration-tests:
-    runs-on: macos-15
+    runs-on: macos-15@20250408.1132 
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/Samples/Tests/Core/IntegrationTestBase.swift
+++ b/Samples/Tests/Core/IntegrationTestBase.swift
@@ -103,7 +103,7 @@ class IntegrationTestBase: XCTestCase {
     }
 
     func waitForCrash() {
-        XCTAssert(app.wait(for: .notRunning, timeout: actionDelay + appCrashTimeout), "App crash is expected")
+        XCTAssert(app.wait(for: .notRunning, timeout: actionDelay + appCrashTimeout + 5), "App crash is expected")
     }
 
     private func waitForFile(in dir: URL, timeout: TimeInterval? = nil) throws -> URL {

--- a/Samples/Tests/Core/IntegrationTestBase.swift
+++ b/Samples/Tests/Core/IntegrationTestBase.swift
@@ -103,7 +103,7 @@ class IntegrationTestBase: XCTestCase {
     }
 
     func waitForCrash() {
-        XCTAssert(app.wait(for: .notRunning, timeout: actionDelay + appCrashTimeout + 5), "App crash is expected")
+        XCTAssert(app.wait(for: .notRunning, timeout: actionDelay + appCrashTimeout), "App crash is expected")
     }
 
     private func waitForFile(in dir: URL, timeout: TimeInterval? = nil) throws -> URL {


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/integration-tests.yml` file. The change updates the `runs-on` configuration to specify a more precise macOS version with a timestamp.