### PR TITLE
Make sure KSCrashReportFilterCombine doesn't strip report types

### DIFF
--- a/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
@@ -124,7 +124,7 @@
                 NSArray *reportSet = reportSets[iSet];
                 if (iReport < reportSet.count) {
                     id<KSCrashReport> report = reportSet[iReport];
-                    dict[key] = report.untypedValue;
+                    dict[key] = report;
                 }
             }
             id<KSCrashReport> report = [KSCrashReportDictionary reportWithValue:dict];

--- a/Tests/KSCrashFiltersTests/KSCrashReportFilter_Tests.m
+++ b/Tests/KSCrashFiltersTests/KSCrashReportFilter_Tests.m
@@ -308,8 +308,8 @@
              onCompletion:^(NSArray *filteredReports, NSError *error) {
                  XCTAssertNil(error, @"");
                  for (NSUInteger i = 0; i < self.reports.count; i++) {
-                     id exp1 = [[self.reports objectAtIndex:i] value];
-                     id exp2 = [[self.reportsWithData objectAtIndex:i] value];
+                     id exp1 = [self.reports objectAtIndex:i];
+                     id exp2 = [self.reportsWithData objectAtIndex:i];
                      KSCrashReportDictionary *entry = [filteredReports objectAtIndex:i];
                      id result1 = entry.value[@"normal"];
                      id result2 = entry.value[@"data"];


### PR DESCRIPTION
Even though KSCrashReportFilterCombine combines reports into one dictionary, we don't want to loose the typing information for those "subreports".