### PR TITLE
Fix Ruby version specification in Gemfile

### DIFF
--- a/.github/workflows/cocoapods-lint.yml
+++ b/.github/workflows/cocoapods-lint.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: 3.2.2
 
       - name: Install Ruby Gems
         run: sudo bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby ">= 3.0.0"
+ruby "3.2.2"
 
 # '>= 1.16.1': https://github.com/CocoaPods/CocoaPods/issues/12664
 gem 'cocoapods', '>= 1.16.1'


### PR DESCRIPTION
Use exact Ruby version 3.2.2 instead of version range to resolve RVM's warning:
```
Unknown ruby interpreter version (do not know how to handle): >=3.0.0.
```