### PR TITLE
Explicitly link against zlib

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -160,6 +160,9 @@ let package = Package(
       ],
       resources: [
         .copy("Resources/PrivacyInfo.xcprivacy")
+      ],
+      linkerSettings: [
+        .linkedLibrary("z")
       ]
     ),
     .testTarget(


### PR DESCRIPTION
Because it is very hard to detect if the package links against system library like `zlib` I added explicit directive to linker. This helps with pulling this dependency using [bazel](https://bazel.build) and [rules_swift_package_manager](https://github.com/cgrindel/rules_swift_package_manager).
More specifically we are facing issue with Embrace SDK which transitively imports KSCrash see https://github.com/cgrindel/rules_swift_package_manager/issues/1279 for more details.