### PR TITLE
Update release workflow: Remove test functionality and add `publish_only` option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ on:
         type: boolean
         default: false
         required: false
-      test_fail:
-        description: 'Intentionally fail at a specific stage (for testing)'
-        type: string
-        default: 'none'
+      skip_tag:
+        description: 'Skip creating a new tag (publish from current commit)'
+        type: boolean
+        default: false
         required: false
 
 jobs:
@@ -51,12 +51,6 @@ jobs:
             xcodebuild -downloadPlatform $platform
             xcodebuild -runFirstLaunch
           done
-
-      - name: Test failure - Early stage
-        if: ${{ github.event.inputs.test_fail == 'early' }}
-        run: |
-          echo "Intentionally failing at early stage for testing"
-          exit 1
           
       - name: Update version in podspec
         run: sed -i '' 's/s.version      = "[^"]*"/s.version      = "${{ github.event.inputs.version }}"/' KSCrash.podspec
@@ -98,15 +92,10 @@ jobs:
         run: |
           COMMIT_SHA=$(git rev-parse HEAD)
           echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
-          
-      - name: Test failure - After commit
-        if: ${{ github.event.inputs.test_fail == 'mid' }}
-        run: |
-          echo "Intentionally failing after commit but before tag for testing"
-          exit 1
 
       - name: Create git tag
         id: create_tag
+        if: ${{ !github.event.inputs.skip_tag }}
         run: |
           if [[ "${{ github.event.inputs.dry_run }}" == "true" ]]; then
             TAG_NAME="${{ github.event.inputs.version }}-dryrun"
@@ -117,29 +106,23 @@ jobs:
           git tag $TAG_NAME
           git push origin $TAG_NAME
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
-          
-      - name: Test failure - After tag
-        if: ${{ github.event.inputs.test_fail == 'late' }}
+      
+      - name: Skip creating tag
+        if: ${{ github.event.inputs.skip_tag }}
         run: |
-          echo "Intentionally failing after tag but before publishing for testing"
-          exit 1
+          echo "Skipping tag creation - using current commit for release"
+          echo "tag_name=" >> $GITHUB_OUTPUT
 
       - name: Publish to CocoaPods
-        if: ${{ !github.event.inputs.dry_run && github.event.inputs.test_fail != 'any' }}
+        if: ${{ !github.event.inputs.dry_run }}
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_PASSWORD }}
         run: pod trunk push KSCrash.podspec --verbose
         
       - name: Skip publishing
-        if: ${{ github.event.inputs.dry_run || github.event.inputs.test_fail != 'none' }}
+        if: ${{ github.event.inputs.dry_run }}
         run: |
-          echo "Publishing skipped - running in test or dry-run mode"
-          
-      - name: Test failure - During publishing
-        if: ${{ github.event.inputs.test_fail == 'publish' }}
-        run: |
-          echo "Intentionally failing during publishing stage for testing"
-          exit 1
+          echo "Publishing skipped - running in dry-run mode"
 
   rollback:
     runs-on: macos-15
@@ -156,6 +139,7 @@ jobs:
           git fetch --tags
 
       - name: Delete git tag locally
+        if: ${{ !github.event.inputs.skip_tag }}
         run: |
           # Use tag from outputs or construct it
           if [[ -n "${{ needs.release.outputs.tag_name }}" ]]; then
@@ -170,6 +154,7 @@ jobs:
           echo "TAG_TO_DELETE=$TAG_TO_DELETE" >> $GITHUB_ENV
 
       - name: Delete git tag remotely
+        if: ${{ !github.event.inputs.skip_tag }}
         run: |
           git push --delete origin ${{ env.TAG_TO_DELETE }} || echo "Tag not found on remote"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   release:
-    runs-on: macos-latest
+    runs-on: macos-15
     outputs:
       commit_sha: ${{ steps.save_commit_info.outputs.commit_sha }}
       version: ${{ github.event.inputs.version }}
@@ -27,7 +27,7 @@ jobs:
       tag_name: ${{ steps.create_tag.outputs.tag_name }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,15 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version number for this release'
+        description: "Version number for this release"
         required: true
       dry_run:
-        description: 'Test workflow without publishing to CocoaPods'
+        description: "Test workflow without publishing to CocoaPods"
         type: boolean
         default: false
         required: false
       publish_only:
-        description: 'Publish to CocoaPods without version updates or tagging'
+        description: "Publish to CocoaPods without version updates or tagging"
         type: boolean
         default: false
         required: false
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2.2'
+          ruby-version: "3.2.2"
 
       - name: Install Ruby Gems
         run: sudo bundle install
@@ -51,24 +51,21 @@ jobs:
             xcodebuild -downloadPlatform $platform
             xcodebuild -runFirstLaunch
           done
-          
+
       - name: Update version in podspec
-        if: ${{ !github.event.inputs.publish_only }}
         run: sed -i '' 's/s.version      = "[^"]*"/s.version      = "${{ github.event.inputs.version }}"/' KSCrash.podspec
 
       - name: Update version in source code
-        if: ${{ !github.event.inputs.publish_only }}
         run: |
           formatted_version_number=$(echo "${{ github.event.inputs.version }}" | awk -F. '{printf("%d.%02d%02d\n", $1, $2, $3)}')
           sed -i '' 's/const double KSCrashFrameworkVersionNumber = [^;]*/const double KSCrashFrameworkVersionNumber = '"$formatted_version_number"'/' Sources/KSCrashRecording/KSCrash.m
           sed -i '' 's/const unsigned char KSCrashFrameworkVersionString\[\] = "[^"]*"/const unsigned char KSCrashFrameworkVersionString[] = "${{ github.event.inputs.version }}"/' Sources/KSCrashRecording/KSCrash.m
 
       - name: Update README
-        if: ${{ !github.event.inputs.publish_only }}
         run: |
           # Update SPM version
           sed -i '' "s/\.package(url: \"https:\/\/github.com\/kstenerud\/KSCrash.git\", .upToNextMajor(from: \"[^\"]*\"))/\.package(url: \"https:\/\/github.com\/kstenerud\/KSCrash.git\", .upToNextMajor(from: \"${{ github.event.inputs.version }}\"))/" README.md
-          
+
           # Update CocoaPods version
           VERSION="${{ github.event.inputs.version }}"
           if [[ "$VERSION" == *"-"* ]]; then
@@ -78,60 +75,50 @@ jobs:
             # It's a release version, use major.minor
             sed -i '' "s/pod 'KSCrash'.*$/pod 'KSCrash', '~> ${VERSION%.*}'/" README.md
           fi
-          
+
           echo "README.md updated with version ${{ github.event.inputs.version }}"
 
       - name: Commit version update
         id: commit_version
-        if: ${{ !github.event.inputs.publish_only }}
+        if: ${{ github.event.inputs.publish_only != 'true' }}
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add .
           git commit -m "Update version to ${{ github.event.inputs.version }}"
           git push
-          
+
       - name: Save commit information
         id: save_commit_info
+        if: ${{ github.event.inputs.publish_only != 'true' }}
         run: |
           COMMIT_SHA=$(git rev-parse HEAD)
           echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
 
       - name: Create git tag
         id: create_tag
-        if: ${{ !github.event.inputs.publish_only }}
+        if: ${{ github.event.inputs.publish_only != 'true' }}
         run: |
           if [[ "${{ github.event.inputs.dry_run }}" == "true" ]]; then
             TAG_NAME="${{ github.event.inputs.version }}-dryrun"
           else
             TAG_NAME="${{ github.event.inputs.version }}"
           fi
-          
+
           git tag $TAG_NAME
           git push origin $TAG_NAME
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
-      
-      - name: Skip version update and tagging
-        if: ${{ github.event.inputs.publish_only }}
-        run: |
-          echo "Publishing to CocoaPods only - skipping version update, commit and tag creation"
-          echo "tag_name=" >> $GITHUB_OUTPUT
 
       - name: Publish to CocoaPods
-        if: ${{ !github.event.inputs.dry_run }}
+        if: ${{ github.event.inputs.dry_run != 'true' }}
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_PASSWORD }}
         run: pod trunk push KSCrash.podspec --verbose
-        
-      - name: Skip publishing
-        if: ${{ github.event.inputs.dry_run }}
-        run: |
-          echo "Publishing to CocoaPods skipped - running in dry-run mode"
 
   rollback:
     runs-on: macos-15
     needs: release
-    if: failure() && !github.event.inputs.publish_only
+    if: failure() && github.event.inputs.publish_only != 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -152,7 +139,7 @@ jobs:
           else
             TAG_TO_DELETE="${{ needs.release.outputs.version }}"
           fi
-          
+
           git tag -d $TAG_TO_DELETE || echo "Tag not found locally"
           echo "TAG_TO_DELETE=$TAG_TO_DELETE" >> $GITHUB_ENV
 
@@ -175,7 +162,7 @@ jobs:
             # Fallback: search by commit message
             SEARCH_MSG="Update version to ${{ needs.release.outputs.version || github.event.inputs.version }}"
             FOUND_COMMIT=$(git log --format="%H" --grep="$SEARCH_MSG" -n 1)
-            
+
             if [[ -n "$FOUND_COMMIT" ]]; then
               echo "Found commit by message: $FOUND_COMMIT"
               echo "SHOULD_REVERT=true" >> $GITHUB_ENV
@@ -191,10 +178,10 @@ jobs:
         run: |
           echo "Reverting commit ${{ env.COMMIT_SHA }}..."
           git log --oneline -n 3
-          
+
           git revert --no-commit ${{ env.COMMIT_SHA }}
           git status -s
-          
+
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git commit -m "Revert version update due to failed release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,15 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release'
+        description: 'Version number for this release'
         required: true
       dry_run:
-        description: 'Run in dry-run mode (do not push to CocoaPods)'
+        description: 'Test workflow without publishing to CocoaPods'
         type: boolean
         default: false
         required: false
-      skip_tag:
-        description: 'Skip creating a new tag (publish from current commit)'
+      publish_only:
+        description: 'Publish to CocoaPods without version updates or tagging'
         type: boolean
         default: false
         required: false
@@ -53,15 +53,18 @@ jobs:
           done
           
       - name: Update version in podspec
+        if: ${{ !github.event.inputs.publish_only }}
         run: sed -i '' 's/s.version      = "[^"]*"/s.version      = "${{ github.event.inputs.version }}"/' KSCrash.podspec
 
       - name: Update version in source code
+        if: ${{ !github.event.inputs.publish_only }}
         run: |
           formatted_version_number=$(echo "${{ github.event.inputs.version }}" | awk -F. '{printf("%d.%02d%02d\n", $1, $2, $3)}')
           sed -i '' 's/const double KSCrashFrameworkVersionNumber = [^;]*/const double KSCrashFrameworkVersionNumber = '"$formatted_version_number"'/' Sources/KSCrashRecording/KSCrash.m
           sed -i '' 's/const unsigned char KSCrashFrameworkVersionString\[\] = "[^"]*"/const unsigned char KSCrashFrameworkVersionString[] = "${{ github.event.inputs.version }}"/' Sources/KSCrashRecording/KSCrash.m
 
       - name: Update README
+        if: ${{ !github.event.inputs.publish_only }}
         run: |
           # Update SPM version
           sed -i '' "s/\.package(url: \"https:\/\/github.com\/kstenerud\/KSCrash.git\", .upToNextMajor(from: \"[^\"]*\"))/\.package(url: \"https:\/\/github.com\/kstenerud\/KSCrash.git\", .upToNextMajor(from: \"${{ github.event.inputs.version }}\"))/" README.md
@@ -80,6 +83,7 @@ jobs:
 
       - name: Commit version update
         id: commit_version
+        if: ${{ !github.event.inputs.publish_only }}
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
@@ -95,7 +99,7 @@ jobs:
 
       - name: Create git tag
         id: create_tag
-        if: ${{ !github.event.inputs.skip_tag }}
+        if: ${{ !github.event.inputs.publish_only }}
         run: |
           if [[ "${{ github.event.inputs.dry_run }}" == "true" ]]; then
             TAG_NAME="${{ github.event.inputs.version }}-dryrun"
@@ -107,10 +111,10 @@ jobs:
           git push origin $TAG_NAME
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
       
-      - name: Skip creating tag
-        if: ${{ github.event.inputs.skip_tag }}
+      - name: Skip version update and tagging
+        if: ${{ github.event.inputs.publish_only }}
         run: |
-          echo "Skipping tag creation - using current commit for release"
+          echo "Publishing to CocoaPods only - skipping version update, commit and tag creation"
           echo "tag_name=" >> $GITHUB_OUTPUT
 
       - name: Publish to CocoaPods
@@ -122,12 +126,12 @@ jobs:
       - name: Skip publishing
         if: ${{ github.event.inputs.dry_run }}
         run: |
-          echo "Publishing skipped - running in dry-run mode"
+          echo "Publishing to CocoaPods skipped - running in dry-run mode"
 
   rollback:
     runs-on: macos-15
     needs: release
-    if: failure()
+    if: failure() && !github.event.inputs.publish_only
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -139,7 +143,6 @@ jobs:
           git fetch --tags
 
       - name: Delete git tag locally
-        if: ${{ !github.event.inputs.skip_tag }}
         run: |
           # Use tag from outputs or construct it
           if [[ -n "${{ needs.release.outputs.tag_name }}" ]]; then
@@ -154,7 +157,6 @@ jobs:
           echo "TAG_TO_DELETE=$TAG_TO_DELETE" >> $GITHUB_ENV
 
       - name: Delete git tag remotely
-        if: ${{ !github.event.inputs.skip_tag }}
         run: |
           git push --delete origin ${{ env.TAG_TO_DELETE }} || echo "Tag not found on remote"
 


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yml` file to improve the release workflow by refining input parameters, updating dependencies, and simplifying the logic. The most important changes include replacing the `test_fail` input with a new `publish_only` input, updating dependencies, and adding conditional checks to streamline the workflow.

### Input Parameter Updates:
* Replaced the `test_fail` input with a new `publish_only` input, which allows publishing to CocoaPods without version updates or tagging. Updated descriptions for `version` and `dry_run` inputs for clarity. (`[.github/workflows/release.ymlL7-R35](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L7-R35)`)

### Dependency Updates:
* Updated `runs-on` to `macos-15` and upgraded the `actions/checkout` dependency from `v2` to `v4`. (`[.github/workflows/release.ymlL7-R35](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L7-R35)`)

### Workflow Logic Simplifications:
* Removed all test failure steps (`test_fail` logic) for various stages of the workflow, simplifying the process. (`[[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L55-L60)`, `[[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L121-R121)`)
* Added conditional checks to skip version commits, saving commit information, and creating git tags when `publish_only` is set to `true`. (`[[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R83)`, `[[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R93-R100)`, `[[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R93-R100)`)