### PR TITLE
Introduce KSCrashBacktrace

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,10 +52,10 @@ let package = Package(
         .target(
             name: Targets.recording,
             dependencies: [
-                .target(name: Targets.recordingCore),
+                .target(name: Targets.recordingCore)
             ],
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy"),
+                .copy("Resources/PrivacyInfo.xcprivacy")
             ],
             cSettings: [
                 .headerSearchPath("."),
@@ -70,7 +70,7 @@ let package = Package(
                 .target(name: Targets.recordingCore),
             ],
             resources: [
-                .process("Resources"),
+                .process("Resources")
             ],
             cSettings: [
                 .headerSearchPath("../../Sources/\(Targets.recording)"),
@@ -86,7 +86,7 @@ let package = Package(
                 .target(name: Targets.reportingCore),
             ],
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy"),
+                .copy("Resources/PrivacyInfo.xcprivacy")
             ]
         ),
         .testTarget(
@@ -98,7 +98,7 @@ let package = Package(
                 .target(name: Targets.reportingCore),
             ],
             resources: [
-                .process("Resources"),
+                .process("Resources")
             ]
         ),
 
@@ -109,7 +109,7 @@ let package = Package(
                 .target(name: Targets.filters),
             ],
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy"),
+                .copy("Resources/PrivacyInfo.xcprivacy")
             ]
         ),
 
@@ -122,7 +122,7 @@ let package = Package(
                 .target(name: Targets.demangleFilter),
             ],
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy"),
+                .copy("Resources/PrivacyInfo.xcprivacy")
             ]
         ),
         .testTarget(
@@ -138,10 +138,10 @@ let package = Package(
         .target(
             name: Targets.recordingCore,
             dependencies: [
-                .target(name: Targets.core),
+                .target(name: Targets.core)
             ],
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy"),
+                .copy("Resources/PrivacyInfo.xcprivacy")
             ]
         ),
         .testTarget(
@@ -155,20 +155,20 @@ let package = Package(
         .testTarget(
             name: Targets.recordingCoreSwift.tests,
             dependencies: [
-                .target(name: Targets.recordingCore),
+                .target(name: Targets.recordingCore)
             ]
         ),
 
         .target(
             name: Targets.reportingCore,
             dependencies: [
-                .target(name: Targets.core),
+                .target(name: Targets.core)
             ],
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy"),
+                .copy("Resources/PrivacyInfo.xcprivacy")
             ],
             linkerSettings: [
-                .linkedLibrary("z"),
+                .linkedLibrary("z")
             ]
         ),
         .testTarget(
@@ -182,23 +182,23 @@ let package = Package(
         .target(
             name: Targets.core,
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy"),
+                .copy("Resources/PrivacyInfo.xcprivacy")
             ]
         ),
         .testTarget(
             name: Targets.core.tests,
             dependencies: [
-                .target(name: Targets.core),
+                .target(name: Targets.core)
             ]
         ),
 
         .target(
             name: Targets.discSpaceMonitor,
             dependencies: [
-                .target(name: Targets.recordingCore),
+                .target(name: Targets.recordingCore)
             ],
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy"),
+                .copy("Resources/PrivacyInfo.xcprivacy")
             ]
         ),
         .testTarget(
@@ -212,10 +212,10 @@ let package = Package(
         .target(
             name: Targets.bootTimeMonitor,
             dependencies: [
-                .target(name: Targets.recordingCore),
+                .target(name: Targets.recordingCore)
             ],
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy"),
+                .copy("Resources/PrivacyInfo.xcprivacy")
             ]
         ),
         .testTarget(
@@ -229,10 +229,10 @@ let package = Package(
         .target(
             name: Targets.demangleFilter,
             dependencies: [
-                .target(name: Targets.recording),
+                .target(name: Targets.recording)
             ],
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy"),
+                .copy("Resources/PrivacyInfo.xcprivacy")
             ],
             cSettings: [
                 .headerSearchPath("swift"),
@@ -254,7 +254,7 @@ let package = Package(
         .target(
             name: Targets.testTools,
             dependencies: [
-                .target(name: Targets.recordingCore),
+                .target(name: Targets.recordingCore)
             ]
         ),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -52,10 +52,10 @@ let package = Package(
         .target(
             name: Targets.recording,
             dependencies: [
-                .target(name: Targets.recordingCore)
+                .target(name: Targets.recordingCore),
             ],
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy")
+                .copy("Resources/PrivacyInfo.xcprivacy"),
             ],
             cSettings: [
                 .headerSearchPath("."),
@@ -70,7 +70,7 @@ let package = Package(
                 .target(name: Targets.recordingCore),
             ],
             resources: [
-                .process("Resources")
+                .process("Resources"),
             ],
             cSettings: [
                 .headerSearchPath("../../Sources/\(Targets.recording)"),
@@ -86,7 +86,7 @@ let package = Package(
                 .target(name: Targets.reportingCore),
             ],
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy")
+                .copy("Resources/PrivacyInfo.xcprivacy"),
             ]
         ),
         .testTarget(
@@ -98,7 +98,7 @@ let package = Package(
                 .target(name: Targets.reportingCore),
             ],
             resources: [
-                .process("Resources")
+                .process("Resources"),
             ]
         ),
 
@@ -109,7 +109,7 @@ let package = Package(
                 .target(name: Targets.filters),
             ],
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy")
+                .copy("Resources/PrivacyInfo.xcprivacy"),
             ]
         ),
 
@@ -122,7 +122,7 @@ let package = Package(
                 .target(name: Targets.demangleFilter),
             ],
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy")
+                .copy("Resources/PrivacyInfo.xcprivacy"),
             ]
         ),
         .testTarget(
@@ -138,10 +138,10 @@ let package = Package(
         .target(
             name: Targets.recordingCore,
             dependencies: [
-                .target(name: Targets.core)
+                .target(name: Targets.core),
             ],
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy")
+                .copy("Resources/PrivacyInfo.xcprivacy"),
             ]
         ),
         .testTarget(
@@ -152,17 +152,23 @@ let package = Package(
                 .target(name: Targets.core),
             ]
         ),
+        .testTarget(
+            name: Targets.recordingCoreSwift.tests,
+            dependencies: [
+                .target(name: Targets.recordingCore),
+            ]
+        ),
 
         .target(
             name: Targets.reportingCore,
             dependencies: [
-                .target(name: Targets.core)
+                .target(name: Targets.core),
             ],
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy")
+                .copy("Resources/PrivacyInfo.xcprivacy"),
             ],
             linkerSettings: [
-                .linkedLibrary("z")
+                .linkedLibrary("z"),
             ]
         ),
         .testTarget(
@@ -176,23 +182,23 @@ let package = Package(
         .target(
             name: Targets.core,
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy")
+                .copy("Resources/PrivacyInfo.xcprivacy"),
             ]
         ),
         .testTarget(
             name: Targets.core.tests,
             dependencies: [
-                .target(name: Targets.core)
+                .target(name: Targets.core),
             ]
         ),
 
         .target(
             name: Targets.discSpaceMonitor,
             dependencies: [
-                .target(name: Targets.recordingCore)
+                .target(name: Targets.recordingCore),
             ],
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy")
+                .copy("Resources/PrivacyInfo.xcprivacy"),
             ]
         ),
         .testTarget(
@@ -206,10 +212,10 @@ let package = Package(
         .target(
             name: Targets.bootTimeMonitor,
             dependencies: [
-                .target(name: Targets.recordingCore)
+                .target(name: Targets.recordingCore),
             ],
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy")
+                .copy("Resources/PrivacyInfo.xcprivacy"),
             ]
         ),
         .testTarget(
@@ -223,10 +229,10 @@ let package = Package(
         .target(
             name: Targets.demangleFilter,
             dependencies: [
-                .target(name: Targets.recording)
+                .target(name: Targets.recording),
             ],
             resources: [
-                .copy("Resources/PrivacyInfo.xcprivacy")
+                .copy("Resources/PrivacyInfo.xcprivacy"),
             ],
             cSettings: [
                 .headerSearchPath("swift"),
@@ -248,7 +254,7 @@ let package = Package(
         .target(
             name: Targets.testTools,
             dependencies: [
-                .target(name: Targets.recordingCore)
+                .target(name: Targets.recordingCore),
             ]
         ),
     ],
@@ -261,6 +267,7 @@ enum Targets {
     static let sinks = "KSCrashSinks"
     static let installations = "KSCrashInstallations"
     static let recordingCore = "KSCrashRecordingCore"
+    static let recordingCoreSwift = "KSCrashRecordingCoreSwift"
     static let reportingCore = "KSCrashReportingCore"
     static let core = "KSCrashCore"
     static let discSpaceMonitor = "KSCrashDiscSpaceMonitor"

--- a/Sources/KSCrashRecordingCore/KSBacktrace.c
+++ b/Sources/KSCrashRecordingCore/KSBacktrace.c
@@ -1,0 +1,98 @@
+//
+// KSBacktrace.c
+//
+// Created by Alexander Cohen on 2025-05-27.
+//
+// Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "KSBacktrace.h"
+
+#include <sys/param.h>
+
+#include "KSBinaryImageCache.h"
+#include "KSDynamicLinker.h"
+#include "KSStackCursor.h"
+#include "KSStackCursor_MachineContext.h"
+#include "KSSymbolicator.h"
+#include "KSThread.h"
+
+int ksbt_captureBacktrace(pthread_t thread, uintptr_t *addresses, int count)
+{
+    if (!addresses || count == 0) {
+        return 0;
+    }
+
+    const thread_t machThread = pthread_mach_thread_np(thread);
+    if (machThread == MACH_PORT_NULL) {
+        return 0;
+    }
+
+    KSMC_NEW_CONTEXT(machineContext);
+    if (!ksmc_getContextForThread(machThread, machineContext, false)) {
+        return 0;
+    }
+
+    int maxFrames = MIN(count, KSSC_MAX_STACK_DEPTH);
+    KSStackCursor stackCursor = {};
+    kssc_initWithMachineContext(&stackCursor, maxFrames, machineContext);
+
+    int frameCount = 0;
+    while (frameCount < maxFrames && stackCursor.advanceCursor(&stackCursor)) {
+        addresses[frameCount++] = stackCursor.stackEntry.address;
+    }
+
+    return frameCount;
+}
+
+bool ksbt_symbolicateAddress(uintptr_t address, struct KSSymbolInformation *result)
+{
+    if (!result) {
+        return false;
+    }
+
+    // initalize the binary image cache.
+    // this has an atomic check so isn't expensive
+    // except for the first call.
+    ksbic_init();
+
+    uintptr_t untaggedAddress = kssymbolicator_callInstructionAddress(address);
+
+    Dl_info info = {};
+    if (ksdl_dladdr(untaggedAddress, &info) == false) {
+        return false;
+    }
+
+    KSBinaryImage image = {};
+    if (ksdl_getBinaryImageForHeader(info.dli_fbase, info.dli_fname, &image) == false) {
+        return false;
+    }
+
+    result->returnAddress = address;
+    result->callInstruction = untaggedAddress;
+    result->symbolAddress = (uintptr_t)info.dli_saddr;
+    result->symbolName = info.dli_sname;
+    result->imageName = info.dli_fname;
+    result->imageAddress = (uintptr_t)info.dli_fbase;
+    result->imageSize = image.size;
+    result->imageUUID = image.uuid;
+    return true;
+}

--- a/Sources/KSCrashRecordingCore/include/KSBacktrace.h
+++ b/Sources/KSCrashRecordingCore/include/KSBacktrace.h
@@ -1,0 +1,98 @@
+//
+// KSBacktrace.h
+//
+// Created by Alexander Cohen on 2025-05-27.
+//
+// Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef HDR_KSBacktrace_h
+#define HDR_KSBacktrace_h
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Captures the backtrace (call stack) for the specified pthread.
+ *
+ * @param thread      The identifier of the pthread whose backtrace should be captured. Must be a valid, non-null
+ * thread.
+ * @param addresses   A pointer to a buffer to receive the backtrace addresses. Must not be NULL.
+ * @param count       The maximum number of addresses to capture. Must be greater than zero.
+ *
+ * @return The number of frames captured and written to @c addresses, or 0 if @c addresses is NULL, @c count is zero, or
+ * an error occurs.
+ *
+ * @discussion This function is not async-signal-safe and therefore must not be called from within a signal handler.
+ *             It may also briefly suspend the target thread while unwinding its stack.
+ */
+
+int ksbt_captureBacktrace(pthread_t _Nonnull thread, uintptr_t *_Nonnull addresses, int count)
+    CF_SWIFT_NAME(captureBacktrace(thread:addresses:count:));
+
+/**
+ * Information about a symbol and the image in which it resides.
+ *
+ * @field returnAddress    The return address of the instruction being symbolicated.
+ * @field callInstruction    The call address of the instruction being symbolicated.
+ * @field symbolAddress    The start address of the resolved symbol.
+ * @field symbolName       The name of the symbol, or NULL if unavailable.
+ * @field imageName        The filename of the binary image containing this symbol.
+ * @field imageUUID        A pointer to the 16-byte UUID of the image, or NULL.
+ * @field imageAddress     The load address of the image in memory.
+ * @field imageSize        The size of the image in bytes.
+ */
+struct KSSymbolInformation {
+    uintptr_t returnAddress;
+    uintptr_t callInstruction;
+    uintptr_t symbolAddress;
+    const char *_Nullable symbolName;
+    const char *_Nullable imageName;
+    const uint8_t *_Nullable imageUUID;
+    uintptr_t imageAddress;
+    uint64_t imageSize;
+} CF_SWIFT_NAME(SymbolInformation);
+
+/**
+ * Resolves symbol information for a given instruction address.
+ *
+ * @param address  The instruction address to symbolize.
+ * @param result   A pointer to a KSSymbolInformation structure to be populated. Must not be NULL.
+ *
+ * @return @c true if symbolication succeeded and @c result is populated, @c false otherwise.
+ *
+ * @discussion On success, @c result will contain the symbol name, symbol address, image name,
+ *             image load address, image size, and image UUID associated with @c address.
+ */
+bool ksbt_symbolicateAddress(uintptr_t address, struct KSSymbolInformation *_Nonnull result)
+    CF_SWIFT_NAME(symbolicate(address:result:));
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // HDR_KSBacktrace_h

--- a/Tests/KSCrashRecordingCoreSwiftTests/KSBacktraceTests.swift
+++ b/Tests/KSCrashRecordingCoreSwiftTests/KSBacktraceTests.swift
@@ -28,7 +28,7 @@ import Darwin
 import KSCrashRecordingCore
 import XCTest
 
-#if !os(watchOS) // there are no backtraces on watchOS
+#if !os(watchOS)  // there are no backtraces on watchOS
     class KSBacktraceTests: XCTestCase {
         func testBacktrace() {
             let expectation = XCTestExpectation()
@@ -41,7 +41,7 @@ import XCTest
 
                 XCTAssert(count > 0)
                 XCTAssert(count <= entries)
-                for index in 0 ..< count {
+                for index in 0..<count {
                     XCTAssert(addresses[Int(index)] != 0)
                 }
 
@@ -64,7 +64,7 @@ import XCTest
 
                 XCTAssert(count > 0)
                 XCTAssert(count <= entries)
-                for index in 0 ..< count {
+                for index in 0..<count {
                     XCTAssert(addresses[Int(index)] != 0)
                 }
 

--- a/Tests/KSCrashRecordingCoreSwiftTests/KSBacktraceTests.swift
+++ b/Tests/KSCrashRecordingCoreSwiftTests/KSBacktraceTests.swift
@@ -1,0 +1,89 @@
+//
+//  KSBacktraceTests.swift
+//
+//  Created by Alexander Cohen on 2025-05-27.
+//
+// Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import Darwin
+import KSCrashRecordingCore
+import XCTest
+
+#if !os(watchOS) // there are no backtraces on watchOS
+    class KSBacktraceTests: XCTestCase {
+        func testBacktrace() {
+            let expectation = XCTestExpectation()
+            let thread = pthread_self()
+
+            DispatchQueue.global(qos: .default).async {
+                let entries = 512
+                var addresses: [UInt] = Array(repeating: 0, count: entries)
+                let count = captureBacktrace(thread: thread, addresses: &addresses, count: Int32(entries))
+
+                XCTAssert(count > 0)
+                XCTAssert(count <= entries)
+                for index in 0 ..< count {
+                    XCTAssert(addresses[Int(index)] != 0)
+                }
+
+                expectation.fulfill()
+            }
+
+            wait(for: [expectation], timeout: 5)
+        }
+
+        func testSymbolicate() {
+            let expectation = XCTestExpectation()
+            let thread = pthread_self()
+
+            let entries = 10
+            var addresses: [UInt] = Array(repeating: 0, count: entries)
+            var count: Int32 = 0
+
+            DispatchQueue.global(qos: .default).async {
+                count = captureBacktrace(thread: thread, addresses: &addresses, count: Int32(entries))
+
+                XCTAssert(count > 0)
+                XCTAssert(count <= entries)
+                for index in 0 ..< count {
+                    XCTAssert(addresses[Int(index)] != 0)
+                }
+
+                expectation.fulfill()
+            }
+
+            wait(for: [expectation], timeout: 5)
+
+            var result = SymbolInformation()
+            let success = symbolicate(address: addresses[0], result: &result)
+
+            XCTAssertTrue(success == true)
+            XCTAssert(result.returnAddress == addresses[0])
+            XCTAssertNotNil(result.imageName)
+            XCTAssertNotNil(result.imageUUID)
+            XCTAssertNotNil(result.symbolName)
+            XCTAssert(result.imageAddress > 0)
+            XCTAssert(result.imageSize > 0)
+            XCTAssert(result.symbolAddress > 0)
+        }
+    }
+#endif


### PR DESCRIPTION
# Summary
This pull request adds the new KSCrashBacktrace module to KSCrash and makes it publicly accessible. The primary goal is to enable other developers to obtain stack traces on demand, independent of a crash event.

## Key Changes
Introduced the ks_backtrace module for capturing stack traces.
Made the module’s functionality public so it can be used outside the crash reporter.
Enables clients to programmatically obtain backtraces whenever needed.

## Motivation
Previously, stack trace functionality was internal to crash handling. By exposing KSCrashBacktrace as a public module, this change empowers developers and other modules to capture stack traces for diagnostics, debugging, or custom monitoring at any time.