### PR TITLE
Lazy Loaded Binary Images

### DIFF
--- a/Sources/KSCrashRecording/KSCrashC.c
+++ b/Sources/KSCrashRecording/KSCrashC.c
@@ -276,8 +276,6 @@ KSCrashInstallErrorCode kscrash_install(const char *appName, const char *const i
 
     kstc_init(60);
 
-    ksbic_init();
-
     kscm_setEventCallback(onCrash);
     setMonitors(configuration->monitors);
     if (kscm_activateMonitors() == false) {

--- a/Sources/KSCrashRecordingCore/KSDynamicLinker.c
+++ b/Sources/KSCrashRecordingCore/KSDynamicLinker.c
@@ -182,7 +182,7 @@ uint32_t ksdl_imageNamed(const char *const imageName, bool exactMatch)
     return UINT32_MAX;
 }
 
-const uint8_t *ksdl_appImageUUID()
+const uint8_t *ksdl_appImageUUID(void)
 {
     const struct mach_header *header = _dyld_get_image_header(0);
     if (header != NULL) {
@@ -198,6 +198,7 @@ const uint8_t *ksdl_appImageUUID()
             }
         }
     }
+    return NULL;
 }
 
 const uint8_t *ksdl_imageUUID(const char *const imageName, bool exactMatch)

--- a/Sources/KSCrashRecordingCore/include/KSBinaryImageCache.h
+++ b/Sources/KSCrashRecordingCore/include/KSBinaryImageCache.h
@@ -35,11 +35,6 @@
 extern "C" {
 #endif
 
-/** Initialize the binary image cache.
- * Should be called during KSCrash activation.
- */
-void ksbic_init(void);
-
 /** Get the number of cached binary images.
  *
  * @return The number of cached binary images.

--- a/Sources/KSCrashRecordingCore/include/KSDynamicLinker.h
+++ b/Sources/KSCrashRecordingCore/include/KSDynamicLinker.h
@@ -99,6 +99,13 @@ uint32_t ksdl_imageNamed(const char *const imageName, bool exactMatch);
  */
 const uint8_t *ksdl_imageUUID(const char *const imageName, bool exactMatch);
 
+/** Get the UUID of the image for the main application binary.
+ *
+ * @return A pointer to the binary (16 byte) UUID of the image, or NULL if it
+ *         wasn't found.
+ */
+const uint8_t *ksdl_appImageUUID(void);
+
 /** async-safe version of dladdr.
  *
  * This method searches the dynamic loader for information about any image

--- a/Tests/KSCrashRecordingCoreTests/KSBinaryImageCache_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSBinaryImageCache_Tests.m
@@ -42,7 +42,6 @@ extern void ksbic_resetCache(void);
 {
     [super setUp];
     ksbic_resetCache();
-    ksbic_init();
     [NSThread sleepForTimeInterval:0.1];
 }
 

--- a/Tests/KSCrashRecordingCoreTests/KSDynamicLinker_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSDynamicLinker_Tests.m
@@ -34,7 +34,6 @@
 
 // Declare external function only for testing
 extern void ksbic_resetCache(void);
-extern void ksbic_init(void);
 
 @implementation KSDynamicLinker_Tests
 
@@ -42,8 +41,13 @@ extern void ksbic_init(void);
 {
     [super setUp];
     ksbic_resetCache();
-    ksbic_init();
     [NSThread sleepForTimeInterval:0.1];
+}
+
+- (void)testAppImageUUID
+{
+    const uint8_t *uuidBytes = ksdl_appImageUUID();
+    XCTAssertTrue(uuidBytes != NULL, @"");
 }
 
 - (void)testImageUUID


### PR DESCRIPTION
## Overview

This pull request introduces improvements to the handling of binary images in KSCrash by implementing a lazy loading mechanism. The changes are designed to optimize performance and only spen cycles when actually required.

## Key Changes

- **Lazy Loading of Binary Images**:  
  Binary images are now loaded on-demand rather than eagerly. This minimizes memory overhead and will speed up startup for all users.

- **Refactoring & Code Cleanup**:  
  Refactored functions related to binary image management for improved readability and maintainability. Update the jailbreak function to not use binary images and simply check for permissions outside of the sandbox. Updates the App image UUID getter by circumventing the cache which is faster and simpler.

## Motivation

Loading all binary images upfront can lead to increased memory consumption and slower startup times. By adopting a lazy approach, KSCrash becomes more efficient, particularly for apps with large numbers of binary images or running on devices with limited resources.
