### PR TITLE
Enlarge Binary Image Cache Size

### DIFF
--- a/Sources/KSCrashRecordingCore/KSBinaryImageCache.c
+++ b/Sources/KSCrashRecordingCore/KSBinaryImageCache.c
@@ -35,7 +35,7 @@
 #include "KSLogger.h"
 
 #ifndef KSBIC_MAX_CACHED_IMAGES
-#define KSBIC_MAX_CACHED_IMAGES 1000
+#define KSBIC_MAX_CACHED_IMAGES 2000
 #endif
 
 typedef struct {


### PR DESCRIPTION
Fixes #638 

Binary cache can end up full (mostly while debugging) which leads to missing images in crash reports, which might mean an inability to symbolicate. This PR increments that cache size to 2000. The amount of memory used by this increment is negligible and should be enough to keep us going for years to come.