### PR TITLE
Fix Xcode 26 beta 1 warning about VLA folding

### DIFF
--- a/Sources/KSCrashRecordingCore/KSCxaThrowSwapper.c
+++ b/Sources/KSCrashRecordingCore/KSCxaThrowSwapper.c
@@ -108,18 +108,18 @@ static uintptr_t findAddress(void *address)
 
 static void __cxa_throw_decorator(void *thrown_exception, void *tinfo, void (*dest)(void *))
 {
-    const int k_requiredFrames = 2;
+#define REQUIRED_FRAMES 2
 
     KSLOG_TRACE("Decorating __cxa_throw");
 
     g_cxa_throw_handler(thrown_exception, tinfo, dest);
 
-    void *backtraceArr[k_requiredFrames];
-    int count = backtrace(backtraceArr, k_requiredFrames);
+    void *backtraceArr[REQUIRED_FRAMES];
+    int count = backtrace(backtraceArr, REQUIRED_FRAMES);
 
     Dl_info info;
-    if (count >= k_requiredFrames) {
-        if (dladdr(backtraceArr[k_requiredFrames - 1], &info) != 0) {
+    if (count >= REQUIRED_FRAMES) {
+        if (dladdr(backtraceArr[REQUIRED_FRAMES - 1], &info) != 0) {
             uintptr_t function = findAddress(info.dli_fbase);
             if (function != (uintptr_t)NULL) {
                 KSLOG_TRACE("Calling original __cxa_throw function at %p", (void *)function);
@@ -128,6 +128,7 @@ static void __cxa_throw_decorator(void *thrown_exception, void *tinfo, void (*de
             }
         }
     }
+#undef REQUIRED_FRAMES
 }
 
 static void perform_rebinding_with_section(const section_t *dataSection, intptr_t slide, nlist_t *symtab, char *strtab,


### PR DESCRIPTION
## Summary
- Fixed compiler warning in Xcode 26 beta 1 about variable length array folding to constant array as a GNU extension
- Replaced `const int` with preprocessor macro `REQUIRED_FRAMES` to ensure compile-time constant array size

## Details
When compiling with Xcode 26 beta 1, the following warning appeared:
```
KSCxaThrowSwapper.c:117:24: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
```

The issue was that `k_requiredFrames` was declared as a `const int`, which in C is not a compile-time constant (unlike C++). The compiler was treating the array as a VLA and then folding it to a constant array as a GNU extension.

## Changes
- Changed from `const int k_requiredFrames = 2;` to `#define REQUIRED_FRAMES 2`
- Updated all references to use the macro
- Added `#undef REQUIRED_FRAMES` at the end of the function to clean up

## Test Plan
- [x] Built with Xcode 26 beta 1 - warning is resolved
- [x] Built all framework components successfully
- [x] Built and launched sample app on both macOS and iOS

🤖 Generated with [Claude Code](https://claude.ai/code)