### PR TITLE
Add thread run state string to report

### DIFF
--- a/Samples/Tests/Core/PartialCrashReport.swift
+++ b/Samples/Tests/Core/PartialCrashReport.swift
@@ -87,6 +87,7 @@ struct PartialCrashReport: Decodable {
             }
 
             var index: Int
+            var state: String
             var crashed: Bool
             var backtrace: Backtrace
         }

--- a/Samples/Tests/IntegrationTests.swift
+++ b/Samples/Tests/IntegrationTests.swift
@@ -129,6 +129,12 @@ final class OtherTests: IntegrationTestBase {
         })
         XCTAssertNotNil(expectedFrame)
 
+        var threadStates = ["TH_STATE_RUNNING", "TH_STATE_STOPPED", "TH_STATE_WAITING",
+                            "TH_STATE_UNINTERRUPTIBLE", "TH_STATE_HALTED"]
+        for thread in rawReport.crash?.threads  ?? [] {
+            XCTAssertTrue(threadStates.contains(thread.state))
+        }
+
         let appleReport = try launchAndReportCrash()
         XCTAssertTrue(appleReport.contains(KSCrashStacktraceCheckFuncName))
     }

--- a/Sources/KSCrashRecording/include/KSCrashReportFields.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportFields.h
@@ -136,6 +136,7 @@ KSCRF_DEFINE_CONSTANT(KSCrashField, NotableAddresses, notableAddresses, "notable
 KSCRF_DEFINE_CONSTANT(KSCrashField, Registers, registers, "registers")
 KSCRF_DEFINE_CONSTANT(KSCrashField, Skipped, skipped, "skipped")
 KSCRF_DEFINE_CONSTANT(KSCrashField, Stack, stack, "stack")
+KSCRF_DEFINE_CONSTANT(KSCrashField, State, state, "state")
 
 #pragma mark - Binary Image -
 

--- a/Sources/KSCrashRecordingCore/KSThread.c
+++ b/Sources/KSCrashRecordingCore/KSThread.c
@@ -32,10 +32,30 @@
 // #define KSLogger_LocalLevel TRACE
 #include <dispatch/dispatch.h>
 #include <mach/mach.h>
+#include <mach/thread_info.h>
 #include <pthread.h>
 #include <sys/sysctl.h>
 
 #include "KSLogger.h"
+
+static const char* thread_state_names[] = {
+    // Defined in mach/thread_info.h
+    NULL,
+    "TH_STATE_RUNNING",
+    "TH_STATE_STOPPED",
+    "TH_STATE_WAITING",
+    "TH_STATE_UNINTERRUPTIBLE",
+    "TH_STATE_HALTED",
+};
+
+static const int thread_state_names_count = sizeof(thread_state_names) / sizeof(*thread_state_names);
+
+const char *ksthread_state_name(int state) {
+    if (state < 1 || state >= thread_state_names_count) {
+        return NULL;
+    }
+    return thread_state_names[state];
+}
 
 KSThread ksthread_self(void)
 {
@@ -50,6 +70,34 @@ bool ksthread_getThreadName(const KSThread thread, char *const buffer, int bufLe
 
     const pthread_t pthread = pthread_from_mach_thread_np((thread_t)thread);
     return pthread_getname_np(pthread, buffer, (unsigned)bufLength) == 0;
+}
+
+int ksthread_getThreadState(const KSThread thread)
+{
+    int threadState = TH_STATE_UNSET;
+
+    integer_t infoBuffer[THREAD_BASIC_INFO_COUNT] = {0};
+    thread_info_t info = infoBuffer;
+    mach_msg_type_number_t inOutSize = THREAD_BASIC_INFO_COUNT;
+    kern_return_t kr = 0;
+
+    kr = thread_info((thread_t)thread, THREAD_BASIC_INFO, info, &inOutSize);
+    if (kr != KERN_SUCCESS) {
+        KSLOG_TRACE("Error getting thread_info with flavor "
+                        "THREAD_BASIC_INFO from mach thread : %s",
+                        mach_error_string(kr));
+        return threadState;
+    }
+
+
+    thread_basic_info_t basicInfo = (thread_basic_info_t)info;
+    if (!ksmem_isMemoryReadable(basicInfo, sizeof(*basicInfo))) {
+        KSLOG_DEBUG("Thread %p has an invalid thread basic info %p", thread, basicInfo);
+        return threadState;
+    }
+    threadState = basicInfo->run_state;
+
+    return threadState;
 }
 
 bool ksthread_getQueueName(const KSThread thread, char *const buffer, int bufLength)

--- a/Sources/KSCrashRecordingCore/include/KSThread.h
+++ b/Sources/KSCrashRecordingCore/include/KSThread.h
@@ -34,14 +34,26 @@
 extern "C" {
 #endif
 
+/** Default value for the thread state
+ */
+#define TH_STATE_UNSET 0
+
 typedef uintptr_t KSThread;
+
+/** Convert thread state code to a state string.
+ *
+ * @param state The thread state code.
+ *
+ * @return thread state name.
+ */
+const char *ksthread_state_name(int state);
 
 /** Get a thread's name. Internally, a thread name will
  * never be more than 64 characters long.
  *
  * @param thread The thread whose name to get.
  *
- * @oaram buffer Buffer to hold the name.
+ * @param buffer Buffer to hold the name.
  *
  * @param bufLength The length of the buffer.
  *
@@ -49,12 +61,20 @@ typedef uintptr_t KSThread;
  */
 bool ksthread_getThreadName(const KSThread thread, char *const buffer, int bufLength);
 
+/** Get a thread's state.
+ *
+ * @param thread The thread whose state to get.
+ *
+ * @return Thread state integer code, default value is TH_STATE_UNSET
+ */
+int ksthread_getThreadState(const KSThread thread);
+
 /** Get the name of a thread's dispatch queue. Internally, a queue name will
  * never be more than 64 characters long.
  *
  * @param thread The thread whose queue name to get.
  *
- * @oaram buffer Buffer to hold the name.
+ * @param buffer Buffer to hold the name.
  *
  * @param bufLength The length of the buffer.
  *

--- a/Tests/KSCrashRecordingCoreTests/KSThread_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSThread_Tests.m
@@ -62,4 +62,19 @@
     XCTAssertTrue(success, @"");
 }
 
+- (void) testStateName
+{
+    int state = 0;
+    const char* stateName = ksthread_state_name(state);
+    XCTAssertEqual(stateName, NULL);
+
+    state = 8;
+    stateName = ksthread_state_name(state);
+    XCTAssertEqual(stateName, NULL);
+
+    state = 2;
+    stateName = ksthread_state_name(state);
+    NSString *stateString = @"TH_STATE_STOPPED";
+    XCTAssertEqual(strcmp(stateName,  stateString.UTF8String), 0);
+}
 @end


### PR DESCRIPTION
Added a new field to a report with string representation of thread's state.
Adjusted integration tests to check new field.