### PR TITLE
Added missing Foundation.h header

### DIFF
--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException+Private.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException+Private.h
@@ -24,6 +24,8 @@
 // THE SOFTWARE.
 //
 
+#import <Foundation/Foundation.h>
+
 #import "KSCrashMonitor_NSException.h"
 
 typedef void KSCrashCustomNSExceptionReporter(NSException *exception, BOOL logAllThreads);


### PR DESCRIPTION
Although the code will compile as things were, there's a missing import of `Foundation.h` that only incidentally worked due to the order of the import statements.
