### PR TITLE
Use latest-stable in unit-tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,7 +30,7 @@ jobs:
           - platform: iOS
             macos-version: "15"
           - platform: iOS
-            xcode-version: "latest"
+            xcode-version: "latest-stable"
             macos-version: "15"
           - platform: iOS
             platform-version: ~16.4.0


### PR DESCRIPTION
The `latest` Xcode version (26 beta) is causing CI jobs to fail by timing out after the simulator's `lockdown` service becomes unresponsive.

Pinning to `latest-stable` ensures we use a reliable, public Xcode release, restoring build stability.