### PR TITLE
Add more class names to the namespacer that clang missed

### DIFF
--- a/Sources/KSCrashCore/include/KSCrashNamespace.h
+++ b/Sources/KSCrashCore/include/KSCrashNamespace.h
@@ -106,6 +106,7 @@
 #define KSCrashInstallationEmail KSCRASH_NS(KSCrashInstallationEmail)
 #define KSCrashInstallationStandard KSCRASH_NS(KSCrashInstallationStandard)
 #define KSCrashMailProcess KSCRASH_NS(KSCrashMailProcess)
+#define KSCrashMonitor_MemoryTracker KSCRASH_NS(KSCrashMonitor_MemoryTracker)
 #define KSCrashReportData KSCRASH_NS(KSCrashReportData)
 #define KSCrashReportDictionary KSCRASH_NS(KSCrashReportDictionary)
 #define KSCrashReportFilterAlert KSCRASH_NS(KSCrashReportFilterAlert)

--- a/namespacer/generate.sh
+++ b/namespacer/generate.sh
@@ -8,7 +8,7 @@ DST_HEADER_FILE="$SCRIPT_DIR/../Sources/KSCrashCore/include/KSCrashNamespace.h"
 
 cd "$SCRIPT_DIR"
 if [ ! -d "venv" ]; then
-    python -m venv venv
+    python3 -m venv venv
     source venv/bin/activate
     pip3 install -r requirements.txt
 else

--- a/namespacer/namespace-check.sh
+++ b/namespacer/namespace-check.sh
@@ -8,7 +8,7 @@ COMPARE_HEADER_FILE="$SCRIPT_DIR/../Sources/KSCrashCore/include/KSCrashNamespace
 
 cd "$SCRIPT_DIR"
 if [ ! -d "venv" ]; then
-    python -m venv venv
+    python3 -m venv venv
     source venv/bin/activate
     pip3 install -r requirements.txt
 else

--- a/namespacer/namespacer.py
+++ b/namespacer/namespacer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright (c) 2025 Karl Stenerud. All rights reserved.
 #
@@ -47,10 +47,10 @@ ALWAYS_ADDED_SYMBOLS = [
                         "i_kslog_logObjC",
                         "i_kslog_logObjCBasic",
                         "KSCrashAlertViewProcess",
-                        "KSCrashAlertViewProcess",
                         "KSCrashAppMemory",
                         "KSCrashAppMemoryTrackerDelegate",
                         "KSCrashMailProcess",
+                        "KSCrashMonitor_MemoryTracker",
                         "KSCrashReportWriter",
                         "llvm",
                        ]


### PR DESCRIPTION
Clang seems to miss a lot of the objective-c classes. Adding the missing ones to the forced list.

**Note**: There are still collisions with the following due to some Swift renaming shenanigans. Not sure how to fix those yet...

- `KSCrash_KSCrashInstallations_SWIFTPM_MODULE_BUNDLER_FINDER`
- `KSCrash_KSCrashCore_SWIFTPM_MODULE_BUNDLER_FINDER`
- `KSCrash_KSCrashRecordingCore_SWIFTPM_MODULE_BUNDLER_FINDER`
- `KSCrash_KSCrashRecording_SWIFTPM_MODULE_BUNDLER_FINDER`
- `KSCrash_KSCrashReportingCore_SWIFTPM_MODULE_BUNDLER_FINDER`
- `KSCrash_KSCrashFilters_SWIFTPM_MODULE_BUNDLER_FINDER`
- `KSCrash_KSCrashSinks_SWIFTPM_MODULE_BUNDLER_FINDER`
- `KSCrash_KSCrashDemangleFilter_SWIFTPM_MODULE_BUNDLER_FINDER`
- `KSCrash_KSCrashBootTimeMonitor_SWIFTPM_MODULE_BUNDLER_FINDER`
- `KSCrash_KSCrashDiscSpaceMonitor_SWIFTPM_MODULE_BUNDLER_FINDER`
