### PR TITLE
Make KSCrashMonitor.c solely responsible for event IDs

### DIFF
--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
@@ -524,13 +524,9 @@ static void ksmemory_write_possible_oom(void)
     KSStackCursor stackCursor;
     kssc_initWithMachineContext(&stackCursor, KSSC_MAX_STACK_DEPTH, &machineContext);
 
-    char eventID[37] = { 0 };
-    ksid_generate(eventID);
-
     KSCrash_MonitorContext context;
     memset(&context, 0, sizeof(context));
     ksmc_fillMonitorContext(&context, kscm_memory_getAPI());
-    context.eventID = eventID;
     context.registersAreValid = false;
     context.offendingMachineContext = &machineContext;
     context.currentSnapshotUserReported = true;

--- a/Sources/KSCrashRecordingCore/include/KSCrashMonitor.h
+++ b/Sources/KSCrashRecordingCore/include/KSCrashMonitor.h
@@ -128,11 +128,18 @@ void kscm_setEventCallback(void (*onEvent)(struct KSCrash_MonitorContext *monito
  */
 bool kscm_notifyFatalExceptionCaptured(bool isAsyncSafeEnvironment);
 
+/* Transitional APIs while converting a larger API. DO NOT CALL! These WILL go away! */
+void kscm_notifyNonFatalExceptionCaptured(bool isAsyncSafeEnvironment);
+void kscm_clearAsyncSafetyState(void);
+
 /** Start general exception processing.
  *
  * @param context Contextual information about the exception.
  */
 void kscm_handleException(struct KSCrash_MonitorContext *context);
+
+// Transitional API. This will go away in a few commits. DO NOT USE EXTERNALLY.
+void kscm_regenerateEventIDs(void);
 
 #ifdef __cplusplus
 }

--- a/Sources/KSCrashRecordingCore/include/KSCrashMonitorContext.h
+++ b/Sources/KSCrashRecordingCore/include/KSCrashMonitorContext.h
@@ -40,7 +40,7 @@ extern "C" {
 
 typedef struct KSCrash_MonitorContext {
     /** Unique identifier for this event. */
-    const char *eventID;
+    char eventID[40];
 
     /**
      If true, so reported user exception will have the current snapshot.

--- a/Tests/KSCrashRecordingCoreTests/KSCrashMonitor_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSCrashMonitor_Tests.m
@@ -26,6 +26,7 @@
 
 #import <XCTest/XCTest.h>
 #import <objc/runtime.h>
+#import <string.h>
 
 #import "KSCrashMonitor.h"
 
@@ -51,7 +52,7 @@ static bool dummyIsEnabled(void) { return g_dummyEnabledState; }
 static void dummyAddContextualInfoToEvent(struct KSCrash_MonitorContext *eventContext)
 {
     if (eventContext != NULL) {
-        eventContext->eventID = g_eventID;
+        strncpy(eventContext->eventID, g_eventID, sizeof(eventContext->eventID));
     }
 }
 
@@ -199,7 +200,7 @@ extern void kscm_resetState(void);
 
     struct KSCrash_MonitorContext context = { 0 };
     kscm_handleException(&context);  // Handle the exception
-    XCTAssertEqual(context.eventID, NULL, @"The eventID should remain NULL when addContextualInfoToEvent is NULL.");
+    // Verify no crash occurred, no assertion needed
 }
 
 - (void)testMonitorAPIWithNullNotifyPostSystemEnable
@@ -248,8 +249,8 @@ extern void kscm_resetState(void);
     kscm_addMonitor(&g_dummyMonitor);
     kscm_activateMonitors();
     struct KSCrash_MonitorContext context = { 0 };
-    context.eventID = 0;             // Initialize with a known value
-    kscm_handleException(&context);  // Handle the exception
+    memset(context.eventID, 0, sizeof(context.eventID));  // Initialize with a known value
+    kscm_handleException(&context);                       // Handle the exception
     XCTAssertEqual(strcmp(context.eventID, g_eventID), 0,
                    @"The eventID should be set to 'TestEventID' by the dummy monitor when handling exception.");
 }


### PR DESCRIPTION
This is the first in a series of PRs designed to bring back recrash handling, which has been broken for some time.

This PR moves responsibility for event IDs entirely into the purview of KSCrashMonitor.

## The Overarching Plan

Build a robust recrash handling system by giving the responsibility to KSCrashMonitor. It knows which monitors have triggered, and so it's better poised to handle recrashes.

The individual exception monitors will only be responsible for capturing exceptional states and informing KSCrashMonitor (and filling out any relevant details). They will also issue recommendations to KSCrashMonitor for what needs to be taken into account while handling this exception (async-safety, whether threads can be captured and such).

### Main Points

* Move ID generation and environment suspending into KSCrashMonitor.
* Invert the dependency graph so that monitors don't need to be aware of KSCrashMonitor at all. They will only know of the context, which KSCrashMonitor will maintan and pass back when its `notify()` callback is called.
* KSCrashMonitor will always be called in two phases: `notify()` (to let KSCrashMonitor formulate a policy) and `handle()` (to actually handle the crash). These functions will be injected into the monitors as callbacks.

```c
typedef struct {
    KSCrash_MonitorContext* (*notify)(ExceptionHandlingPolicy recommendations);
    void (*handle)();
} ExceptionHandlerCallbacks;
```

* When calling the `notify()` callback, the caller passes a policy recommendation, which KSCrashMonitor uses to help decide upon a finalized policy. This policy will be stored in the context, and also passed to the user callback to help KSCrash library users decide what kind of code should be run.

```c
/**
 * An exception handling policy can represent a recommendation or a decision about how to proceed when handling an execption.
 *
 * Crash handlers will send their recommendations to the crash monitor, which will make a final policy decision.
 */
typedef struct {
    /** Proceed with the expectation that the app will terminate when handling is done. */
    unsigned isFatal: 1;

    /** Something has gone horribly wrong. Do nothing. Touch nothing. Get Kryten! */
    unsigned exitImmediately: 1;

    /** Only async-safe functions may be called */
    unsigned asyncSafety: 1;

    /**
     * The environment should be / has been suspended (all threads stopped).
     * Note: While suspended, asyncSafety will be set to true because any locks held
     * by the stopped threads will not be released and could cause a deadlock.
     */
    unsigned suspendedEnvironment: 1;

    // Notes on suspend policies:
    // - Normally, only suspend if and while we record threads.
    // - On recrash, suspend and don't resume.
    // - On re-recrash, don't suspend

    /**
     * Should / will record all threads (not just the offending thread).
     * Note: The environment will be suspended while recording the threads.
     */
    unsigned recordThreads: 1;
    
    /** Should / will record the loaded binary images. */
    unsigned recordBinaryImages: 1;

    /**
     * Only record the barest essentials required to diagnose a recrash.
     * Note: This will cause recordThreads to become false.
     */
    unsigned recordEssentialOnly: 1;
} ExceptionHandlingPolicy;
```

* The finalized policy will be accessible via the KSCrashMonitor context.
* KSCrashMonitor will be the one to decide what kind of crash it is (non-fatal, fatal, recrash, etc), using its own information in addition to the policy recommended by the caller.
* We'll also keep track of where a crash occurs while handing a crash to help when diagnosing who is responsible for the recrash (KSCrash or the user callback):

```c
typedef enum {
    CrashHandlingPhase_None, // Not currently handling a crash
    CrashHandlingPhase_Initial, // Internal handling before the callback
    CrashHandlingPhase_Callback, // In the callback to user code
    CrashHandlingPhase_Completion, // Internal handling after the callback
    CrashHandlingPhase_Recrash, // Handling a recrash after a crash handler crashed
} CrashHandlingPhase;
```
