### PR TITLE
Make monitor API functions properly idempotent using atomics

### DIFF
--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
@@ -44,6 +44,7 @@
 
 #import <Foundation/Foundation.h>
 #import <os/lock.h>
+#import <stdatomic.h>
 
 #import "KSLogger.h"
 
@@ -81,8 +82,8 @@ static void ksmemory_map(const char *path);
 #pragma mark - Globals -
 // ============================================================================
 
-static volatile bool g_isEnabled = 0;
-static volatile bool g_hasPostEnable = 0;
+static atomic_bool g_isEnabled = false;
+static atomic_bool g_hasPostEnable = false;
 
 // What we're reporting
 static uint8_t g_MinimumNonFatalReportingLevel = KSCrash_Memory_NonFatalReportLevelNone;
@@ -244,25 +245,28 @@ static const char *monitorId(void) { return "MemoryTermination"; }
 
 static void setEnabled(bool isEnabled)
 {
-    if (isEnabled != g_isEnabled) {
-        g_isEnabled = isEnabled;
-        if (isEnabled) {
-            g_memoryTracker = [[_KSCrashMonitor_MemoryTracker alloc] init];
+    bool expectEnabled = !isEnabled;
+    if (!atomic_compare_exchange_strong(&g_isEnabled, &expectEnabled, isEnabled)) {
+        // We were already in the expected state
+        return;
+    }
 
-            ksmemory_map(g_memoryURL.path.UTF8String);
+    if (isEnabled) {
+        g_memoryTracker = [[_KSCrashMonitor_MemoryTracker alloc] init];
 
-            g_appStateObserver = [KSCrashAppStateTracker.sharedInstance
-                addObserverWithBlock:^(KSCrashAppTransitionState transitionState) {
-                    _ks_memory_update(^(KSCrash_Memory *mem) {
-                        mem->state = transitionState;
-                    });
-                }];
+        ksmemory_map(g_memoryURL.path.UTF8String);
 
-        } else {
-            g_memoryTracker = nil;
-            [KSCrashAppStateTracker.sharedInstance removeObserver:g_appStateObserver];
-            g_appStateObserver = nil;
-        }
+        g_appStateObserver =
+            [KSCrashAppStateTracker.sharedInstance addObserverWithBlock:^(KSCrashAppTransitionState transitionState) {
+                _ks_memory_update(^(KSCrash_Memory *mem) {
+                    mem->state = transitionState;
+                });
+            }];
+
+    } else {
+        g_memoryTracker = nil;
+        [KSCrashAppStateTracker.sharedInstance removeObserver:g_appStateObserver];
+        g_appStateObserver = nil;
     }
 }
 
@@ -371,10 +375,11 @@ static void kscm_memory_check_for_oom_in_previous_session(void)
  */
 static void notifyPostSystemEnable(void)
 {
-    if (g_hasPostEnable) {
+    bool expectEnabled = false;
+    if (!atomic_compare_exchange_strong(&g_hasPostEnable, &expectEnabled, isEnabled)) {
+        // We were already in the expected state
         return;
     }
-    g_hasPostEnable = 1;
 
     // Usually we'd do something like this `setEnabled`,
     // but in this case not all monitors are ready in `seEnabled`

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
@@ -375,8 +375,8 @@ static void kscm_memory_check_for_oom_in_previous_session(void)
  */
 static void notifyPostSystemEnable(void)
 {
-    bool expectEnabled = false;
-    if (!atomic_compare_exchange_strong(&g_hasPostEnable, &expectEnabled, isEnabled)) {
+    bool expectPostEnable = false;
+    if (!atomic_compare_exchange_strong(&g_hasPostEnable, &expectPostEnable, true)) {
         // We were already in the expected state
         return;
     }

--- a/Sources/KSCrashRecordingCore/include/KSCrashMonitor.h
+++ b/Sources/KSCrashRecordingCore/include/KSCrashMonitor.h
@@ -42,6 +42,10 @@ extern "C" {
 
 struct KSCrash_MonitorContext;
 
+/**
+ * Monitor API.
+ * WARNING: All functions MUST be idempotent!
+ */
 typedef struct {
     /**
      * Initialize the monitor.


### PR DESCRIPTION
Volatile doesn't guarantee concurrent safety, so switch the "enabled" boolean flags to atomic.

Also added a comment to the monitor API struct that all functions must be idempotent (calling them multiple times won't cause any negative side effects).
