### PR TITLE
Report Version Based Timestamp Mixup Fix

### DIFF
--- a/Sources/KSCrashBootTimeMonitor/KSCrashMonitor_BootTime.m
+++ b/Sources/KSCrashBootTimeMonitor/KSCrashMonitor_BootTime.m
@@ -51,8 +51,8 @@ void kscm_bootTime_resetState(void)
 static const char *dateSysctl(const char *name)
 {
     struct timeval value = kssysctl_timevalForName(name);
-    char *buffer = malloc(21);
-    ksdate_utcStringFromTimestamp(value.tv_sec, buffer);
+    char *buffer = malloc(KSDATE_BUFFERSIZE);
+    ksdate_utcStringFromTimestamp(value.tv_sec, buffer, KSDATE_BUFFERSIZE);
     return buffer;
 }
 

--- a/Sources/KSCrashRecording/KSCrashReportFixer.c
+++ b/Sources/KSCrashRecording/KSCrashReportFixer.c
@@ -305,8 +305,7 @@ char *kscrf_fixupCrashReport(const char *crashReport)
 {
     // get the version out of it since a lot depends on it.
     int version[REPORT_VERSION_COMPONENTS_COUNT] = { 0 };
-    const char *result =
-        kscrf_fixupCrashReportWithVersionComponents(crashReport, version, REPORT_VERSION_COMPONENTS_COUNT);
+    char *result = kscrf_fixupCrashReportWithVersionComponents(crashReport, version, REPORT_VERSION_COMPONENTS_COUNT);
     if (!result) {
         return NULL;
     }

--- a/Sources/KSCrashRecording/KSCrashReportFixer.c
+++ b/Sources/KSCrashRecording/KSCrashReportFixer.c
@@ -26,6 +26,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <sys/param.h>
 
 #include "KSCrashReportFields.h"
 #include "KSDate.h"

--- a/Sources/KSCrashRecording/KSCrashReportStore.m
+++ b/Sources/KSCrashRecording/KSCrashReportStore.m
@@ -146,12 +146,16 @@
 - (NSArray<NSNumber *> *)reportIDs
 {
     int reportCount = kscrs_getReportCount(&_cConfig);
-    int64_t reportIDsC[reportCount];
+    if (reportCount <= 0) {
+        return @[];
+    }
+    int64_t *reportIDsC = malloc(sizeof(int64_t) * reportCount);
     reportCount = kscrs_getReportIDs(reportIDsC, reportCount, &_cConfig);
     NSMutableArray *reportIDs = [NSMutableArray arrayWithCapacity:(NSUInteger)reportCount];
     for (int i = 0; i < reportCount; i++) {
         [reportIDs addObject:[NSNumber numberWithLongLong:reportIDsC[i]]];
     }
+    free(reportIDsC);
     return [reportIDs copy];
 }
 

--- a/Sources/KSCrashRecording/KSCrashReportStore.m
+++ b/Sources/KSCrashRecording/KSCrashReportStore.m
@@ -149,7 +149,7 @@
     if (reportCount <= 0) {
         return @[];
     }
-    int64_t *reportIDsC = malloc(sizeof(int64_t) * reportCount);
+    int64_t *reportIDsC = malloc(sizeof(int64_t) * (size_t)reportCount);
     reportCount = kscrs_getReportIDs(reportIDsC, reportCount, &_cConfig);
     NSMutableArray *reportIDs = [NSMutableArray arrayWithCapacity:(NSUInteger)reportCount];
     for (int i = 0; i < reportCount; i++) {

--- a/Sources/KSCrashRecording/KSCrashReportStore.m
+++ b/Sources/KSCrashRecording/KSCrashReportStore.m
@@ -150,6 +150,9 @@
         return @[];
     }
     int64_t *reportIDsC = malloc(sizeof(int64_t) * (size_t)reportCount);
+    if (!reportIDsC) {
+        return @[];
+    }
     reportCount = kscrs_getReportIDs(reportIDsC, reportCount, &_cConfig);
     NSMutableArray *reportIDs = [NSMutableArray arrayWithCapacity:(NSUInteger)reportCount];
     for (int i = 0; i < reportCount; i++) {

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
@@ -128,8 +128,8 @@ static const char *stringSysctl(const char *name)
 
 static const char *dateString(time_t date)
 {
-    char *buffer = malloc(21);
-    ksdate_utcStringFromTimestamp(date, buffer);
+    char *buffer = malloc(KSDATE_BUFFERSIZE);
+    ksdate_utcStringFromTimestamp(date, buffer, KSDATE_BUFFERSIZE);
     return buffer;
 }
 

--- a/Sources/KSCrashRecordingCore/KSDate.c
+++ b/Sources/KSCrashRecordingCore/KSDate.c
@@ -51,7 +51,7 @@ void ksdate_utcStringFromMicroseconds(int64_t microseconds, char *buffer, size_t
     memset(buffer, 0, bufferSize);
 
     // Cannot be in the future.
-    if ((uint64_t)microseconds >= ksdate_microseconds()) {
+    if ((uint64_t)microseconds > ksdate_microseconds()) {
         return;
     }
 

--- a/Sources/KSCrashRecordingCore/KSDate.c
+++ b/Sources/KSCrashRecordingCore/KSDate.c
@@ -67,6 +67,18 @@ void ksdate_utcStringFromMicroseconds(int64_t microseconds, char *buffer, size_t
              result.tm_mday, result.tm_hour, result.tm_min, result.tm_sec, micros);
 }
 
-uint64_t ksdate_microseconds(void) { return clock_gettime_nsec_np(CLOCK_REALTIME) / 1000; }
+uint64_t ksdate_microseconds(void)
+{
+    struct timeval tp;
+    gettimeofday(&tp, NULL);
+    uint64_t microseconds = ((uint64_t)tp.tv_sec) * 1000000 + (uint64_t)tp.tv_usec;
+    return microseconds;
+}
 
-uint64_t ksdate_seconds(void) { return clock_gettime_nsec_np(CLOCK_REALTIME) / 1000000000; }
+uint64_t ksdate_seconds(void)
+{
+    struct timeval tp;
+    gettimeofday(&tp, NULL);
+    uint64_t seconds = (uint64_t)tp.tv_sec;
+    return seconds;
+}

--- a/Sources/KSCrashRecordingCore/KSDate.c
+++ b/Sources/KSCrashRecordingCore/KSDate.c
@@ -34,7 +34,7 @@ void ksdate_utcStringFromTimestamp(time_t timestamp, char *buffer, size_t buffer
     memset(buffer, 0, bufferSize);
 
     // Cannot be in the future.
-    if (timestamp > ksdate_seconds()) {
+    if ((uint64_t)timestamp > ksdate_seconds()) {
         return;
     }
 
@@ -51,7 +51,7 @@ void ksdate_utcStringFromMicroseconds(int64_t microseconds, char *buffer, size_t
     memset(buffer, 0, bufferSize);
 
     // Cannot be in the future.
-    if (microseconds >= ksdate_microseconds()) {
+    if ((uint64_t)microseconds >= ksdate_microseconds()) {
         return;
     }
 

--- a/Sources/KSCrashRecordingCore/KSJSONCodecObjC.m
+++ b/Sources/KSCrashRecordingCore/KSJSONCodecObjC.m
@@ -374,9 +374,9 @@ static int encodeObject(KSJSONCodec *codec, id object, NSString *name, KSJSONEnc
     }
 
     if ([object isKindOfClass:[NSDate class]]) {
-        char string[21];
+        char string[KSDATE_BUFFERSIZE] = { 0 };
         time_t timestamp = (time_t)((NSDate *)object).timeIntervalSince1970;
-        ksdate_utcStringFromTimestamp(timestamp, string);
+        ksdate_utcStringFromTimestamp(timestamp, string, KSDATE_BUFFERSIZE);
         NSData *data = [NSData dataWithBytes:string length:strnlen(string, 20)];
         return ksjson_addStringElement(context, cName, data.bytes, (int)data.length);
     }

--- a/Sources/KSCrashRecordingCore/KSJSONCodecObjC.m
+++ b/Sources/KSCrashRecordingCore/KSJSONCodecObjC.m
@@ -377,7 +377,7 @@ static int encodeObject(KSJSONCodec *codec, id object, NSString *name, KSJSONEnc
         char string[KSDATE_BUFFERSIZE] = { 0 };
         time_t timestamp = (time_t)((NSDate *)object).timeIntervalSince1970;
         ksdate_utcStringFromTimestamp(timestamp, string, KSDATE_BUFFERSIZE);
-        NSData *data = [NSData dataWithBytes:string length:strnlen(string, 20)];
+        NSData *data = [NSData dataWithBytes:string length:strnlen(string, KSDATE_BUFFERSIZE - 1)];
         return ksjson_addStringElement(context, cName, data.bytes, (int)data.length);
     }
 

--- a/Sources/KSCrashRecordingCore/include/KSDate.h
+++ b/Sources/KSCrashRecordingCore/include/KSDate.h
@@ -34,26 +34,40 @@
 extern "C" {
 #endif
 
+/**
+ * Use this as a buffer size for date routines.
+ */
+#ifndef KSDATE_BUFFERSIZE
+#define KSDATE_BUFFERSIZE 64
+#endif
+
 /** Convert a UNIX timestamp to an RFC3339 string representation.
  *
  * @param timestamp The date to convert.
  *
- * @param buffer21Chars A buffer of at least 21 chars to hold the RFC3339 date string.
+ * @param buffer A buffer of at least 21 chars to hold the RFC3339 date string.
+ * @param bufferSize The size of the buffer in _buffer_.
  */
-void ksdate_utcStringFromTimestamp(time_t timestamp, char *buffer21Chars);
+void ksdate_utcStringFromTimestamp(time_t timestamp, char *buffer, size_t bufferSize);
 
 /** Convert microseconds returned from `gettimeofday` to an RFC3339 string representation.
  *
  * @param microseconds The microseconds to convert.
  *
- * @param buffer28Chars A buffer of at least 28 chars to hold the RFC3339 date string with milliseconds precision.
+ * @param buffer A buffer of at least 28 chars to hold the RFC3339 date string with milliseconds precision.
+ * @param bufferSize The size of the buffer in _buffer_.
  */
-void ksdate_utcStringFromMicroseconds(int64_t microseconds, char *buffer28Chars);
+void ksdate_utcStringFromMicroseconds(int64_t microseconds, char *buffer, size_t bufferSize);
 
-/** Returns microseconds from `gettimeofday`
+/** Returns microseconds for the unix epoch.
  *
  */
 uint64_t ksdate_microseconds(void);
+
+/** Returns seconds for the unix epoch.
+ *
+ */
+uint64_t ksdate_seconds(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When running the fixups on a report, if the report.version was parsed after the report.timestamp, the version would still be 0.0.0 which would lead to the timestamp being read as seconds instead of microseconds which would make the converted times year be off by a lot ("timestamp": "54926039-06-24T13:35").

After speaking with @kstenerud , the json parser is not meant to be used to read "out-of-order", so the fix is to "mixup" twice, first to get the correct version, then to use that to ensure we pull the right info out of the report.

I also fixed a bunch of other small date related issues along the way such as possible buffer overflows, using async signal safety and so on.