### PR TITLE
Added a policy argument to all callbacks so that callback implementations can more intelligently decide what to do.

### DIFF
--- a/Samples/Common/Sources/CrashCallback/CrashCallback.m
+++ b/Samples/Common/Sources/CrashCallback/CrashCallback.m
@@ -9,14 +9,15 @@
 #import <stdio.h>
 #import "KSCrashC.h"
 
-static void (^g_crashCallback)(const struct KSCrashReportWriter *writer) = ^void (const struct KSCrashReportWriter *writer) {
+static void (^g_integrationTestCrashCallback)(KSCrash_ExceptionHandlingPolicy policy, const struct KSCrashReportWriter * _Nonnull writer) =
+^void (KSCrash_ExceptionHandlingPolicy policy, const struct KSCrashReportWriter * _Nonnull writer) {
     // Do nothing by default
 };
 
-void crashNotifyCallback(const struct KSCrashReportWriter *writer) {
-    g_crashCallback(writer);
+void integrationTestCrashNotifyCallback(KSCrash_ExceptionHandlingPolicy policy, const struct KSCrashReportWriter * _Nonnull writer) {
+    g_integrationTestCrashCallback(policy, writer);
 }
 
-void setCrashNotifyImplementation(void (^implementation)(const struct KSCrashReportWriter *writer)) {
-    g_crashCallback = implementation;
+void setIntegrationTestCrashNotifyImplementation(void (^implementation)(KSCrash_ExceptionHandlingPolicy policy, const struct KSCrashReportWriter * _Nonnull writer)) {
+    g_integrationTestCrashCallback = implementation;
 }

--- a/Samples/Common/Sources/CrashCallback/include/CrashCallback.h
+++ b/Samples/Common/Sources/CrashCallback/include/CrashCallback.h
@@ -7,14 +7,16 @@
 
 #pragma once
 
+#include "KSCrashExceptionHandlingPolicy.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 struct KSCrashReportWriter;
-void crashNotifyCallback(const struct KSCrashReportWriter *writer);
+void integrationTestCrashNotifyCallback(KSCrash_ExceptionHandlingPolicy policy, const struct KSCrashReportWriter * _Nonnull writer);
 
-void setCrashNotifyImplementation(void (^implementation)(const struct KSCrashReportWriter *writer));
+void setIntegrationTestCrashNotifyImplementation(void (^ _Nonnull implementation)(KSCrash_ExceptionHandlingPolicy policy, const struct KSCrashReportWriter * _Nonnull writer));
 
 #ifdef __cplusplus
 }

--- a/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
+++ b/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
@@ -168,10 +168,13 @@ NSString *const KSCrashNSExceptionStacktraceFuncName = @"exceptionWithStacktrace
     [self trigger_other_stackOverflow];
 }
 
-#define TRIGGER_MULTIPLE(TYPE_A, TYPE_B)                                       \
-    setCrashNotifyImplementation(^(const struct KSCrashReportWriter *writer) { \
-        trigger_##TYPE_B();                                                    \
-    });                                                                        \
+#define TRIGGER_MULTIPLE(TYPE_A, TYPE_B)                                                      \
+    setIntegrationTestCrashNotifyImplementation(                                              \
+        ^(KSCrash_ExceptionHandlingPolicy policy, const struct KSCrashReportWriter *writer) { \
+            if (!policy.crashedDuringExceptionHandling) {                                     \
+                trigger_##TYPE_B();                                                           \
+            }                                                                                 \
+        });                                                                                   \
     trigger_##TYPE_A()
 
 + (void)trigger_multiple_mach_mach

--- a/Samples/Common/Sources/IntegrationTestsHelper/InstallConfig.swift
+++ b/Samples/Common/Sources/IntegrationTestsHelper/InstallConfig.swift
@@ -27,7 +27,6 @@
 import CrashCallback
 import Foundation
 import KSCrashRecording
-import CrashCallback
 
 public struct InstallConfig: Codable {
     public var installPath: String

--- a/Samples/Common/Sources/IntegrationTestsHelper/InstallConfig.swift
+++ b/Samples/Common/Sources/IntegrationTestsHelper/InstallConfig.swift
@@ -27,6 +27,7 @@
 import CrashCallback
 import Foundation
 import KSCrashRecording
+import CrashCallback
 
 public struct InstallConfig: Codable {
     public var installPath: String

--- a/Samples/Common/Sources/LibraryBridge/CrashReportStore+Bridge.swift
+++ b/Samples/Common/Sources/LibraryBridge/CrashReportStore+Bridge.swift
@@ -68,6 +68,31 @@ extension CrashReportStore {
         }
     }
 
+    public func logRawToConsole() {
+        sink = CrashReportFilterPassthrough()
+        sendAllReports { reports, error in
+            if let reports {
+                Self.logger.info("Logged \(reports.count) reports")
+                for (idx, report) in reports.enumerated() {
+                    switch report {
+                    case let stringReport as CrashReportString:
+                        Self.logger.info("Report #\(idx) is a string (length is \(stringReport.value.count))")
+                    case let dictionaryReport as CrashReportDictionary:
+                        Self.logger.info(
+                            "Report #\(idx) is a dictionary (number of keys is \(dictionaryReport.value.count))")
+                        Self.logger.info("\(dictionaryReport)")
+                    case let dataReport as CrashReportData:
+                        Self.logger.info("Report #\(idx) is a binary data (size is \(dataReport.value.count) bytes)")
+                    default:
+                        Self.logger.warning("Unknown report #\(idx): \(report.debugDescription ?? "?")")
+                    }
+                }
+            } else {
+                Self.logger.error("Failed to log reports: \(error?.localizedDescription ?? "")")
+            }
+        }
+    }
+
     public func logWithAlert() {
         sink = CrashReportFilterPipeline(filters: [
             CrashReportFilterAlert(

--- a/Samples/Common/Sources/LibraryBridge/InstallBridge.swift
+++ b/Samples/Common/Sources/LibraryBridge/InstallBridge.swift
@@ -77,7 +77,24 @@ public class InstallBridge: ObservableObject {
 
     public init() {
         config = .init()
-        config.crashNotifyCallback = crashNotifyCallback
+
+        // Example of setting a crash notify callback from Swift.
+        // To see this in action, comment out the line: "config.crashNotifyCallback = integrationTestCrashNotifyCallback"
+        // Then tap "Install", "Report", "Log Raw to Console" in the sample app to see a crash report via the logs.
+        let cb: @convention(c) (KSCrash_ExceptionHandlingPolicy, UnsafePointer<ReportWriter>) -> Void = {
+            policy, writer in
+            writer.pointee.beginObject(writer, "policy")
+            writer.pointee.addBooleanElement(writer, "shouldExitImmediately", policy.shouldExitImmediately != 0)
+            writer.pointee.addBooleanElement(writer, "isFatal", policy.isFatal != 0)
+            writer.pointee.addBooleanElement(writer, "requiresAsyncSafety", policy.requiresAsyncSafety != 0)
+            writer.pointee.addBooleanElement(
+                writer, "crashedDuringExceptionHandling", policy.crashedDuringExceptionHandling != 0)
+            writer.pointee.addBooleanElement(writer, "shouldRecordThreads", policy.shouldRecordThreads != 0)
+            writer.pointee.endContainer(writer)
+        }
+        config.crashNotifyCallback = cb
+
+        config.crashNotifyCallback = integrationTestCrashNotifyCallback
 
         $basePath
             .removeDuplicates()

--- a/Samples/Common/Sources/LibraryBridge/InstallBridge.swift
+++ b/Samples/Common/Sources/LibraryBridge/InstallBridge.swift
@@ -31,6 +31,7 @@ import KSCrashInstallations
 import KSCrashRecording
 import Logging
 import SwiftUI
+import CrashCallback
 
 public enum BasePath: String, CaseIterable {
     case `default`

--- a/Samples/Common/Sources/LibraryBridge/InstallBridge.swift
+++ b/Samples/Common/Sources/LibraryBridge/InstallBridge.swift
@@ -31,7 +31,6 @@ import KSCrashInstallations
 import KSCrashRecording
 import Logging
 import SwiftUI
-import CrashCallback
 
 public enum BasePath: String, CaseIterable {
     case `default`

--- a/Samples/Common/Sources/SampleUI/Screens/ReportingView.swift
+++ b/Samples/Common/Sources/SampleUI/Screens/ReportingView.swift
@@ -37,6 +37,9 @@ struct ReportingView: View {
             Button("Log To Console") {
                 store.logToConsole()
             }
+            Button("Log Raw to Console") {
+                store.logRawToConsole()
+            }
             Button("Sample Custom Log To Console") {
                 store.sampleLogToConsole()
             }

--- a/Sources/KSCrashRecording/KSCrashC.c
+++ b/Sources/KSCrashRecording/KSCrashC.c
@@ -164,7 +164,7 @@ static void onCrash(struct KSCrash_MonitorContext *monitorContext)
         kscrashreport_writeStandardReport(monitorContext, crashReportFilePath);
 
         if (g_reportWrittenCallback) {
-            g_reportWrittenCallback(reportID);
+            g_reportWrittenCallback(monitorContext->currentPolicy, reportID);
         }
     }
 }

--- a/Sources/KSCrashRecording/KSCrashConfiguration.m
+++ b/Sources/KSCrashRecording/KSCrashConfiguration.m
@@ -94,12 +94,8 @@
     config.enableMemoryIntrospection = self.enableMemoryIntrospection;
     config.doNotIntrospectClasses.strings = [self createCStringArrayFromNSArray:self.doNotIntrospectClasses];
     config.doNotIntrospectClasses.length = (int)[self.doNotIntrospectClasses count];
-    if (self.crashNotifyCallback) {
-        config.crashNotifyCallback = (KSReportWriteCallback)imp_implementationWithBlock(self.crashNotifyCallback);
-    }
-    if (self.reportWrittenCallback) {
-        config.reportWrittenCallback = (KSReportWrittenCallback)imp_implementationWithBlock(self.reportWrittenCallback);
-    }
+    config.crashNotifyCallback = self.crashNotifyCallback;
+    config.reportWrittenCallback = self.reportWrittenCallback;
     config.addConsoleLogToReport = self.addConsoleLogToReport;
     config.printPreviousLogOnStartup = self.printPreviousLogOnStartup;
     config.enableSwapCxaThrow = self.enableSwapCxaThrow;
@@ -151,8 +147,8 @@
                                       ? [[NSArray allocWithZone:zone] initWithArray:self.doNotIntrospectClasses
                                                                           copyItems:YES]
                                       : nil;
-    copy.crashNotifyCallback = [self.crashNotifyCallback copy];
-    copy.reportWrittenCallback = [self.reportWrittenCallback copy];
+    copy.crashNotifyCallback = self.crashNotifyCallback;
+    copy.reportWrittenCallback = self.reportWrittenCallback;
     copy.addConsoleLogToReport = self.addConsoleLogToReport;
     copy.printPreviousLogOnStartup = self.printPreviousLogOnStartup;
     copy.enableSwapCxaThrow = self.enableSwapCxaThrow;

--- a/Sources/KSCrashRecording/KSCrashReportC.h
+++ b/Sources/KSCrashRecording/KSCrashReportC.h
@@ -91,7 +91,7 @@ void kscrashreport_setUserSectionWriteCallback(const KSReportWriteCallback userS
  *
  * @param path The file to write to.
  */
-void kscrashreport_writeStandardReport(const struct KSCrash_MonitorContext *const monitorContext, const char *path);
+void kscrashreport_writeStandardReport(struct KSCrash_MonitorContext *const monitorContext, const char *path);
 
 /** Write a minimal crash report to a file.
  *

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
@@ -120,7 +120,7 @@ static void CPPExceptionTerminate(void)
         thread_t thisThread = (thread_t)ksthread_self();
         // This requires async-safety because the environment is suspended.
         KSCrash_MonitorContext *crashContext = g_callbacks.notify(thisThread, (KSCrash_ExceptionHandlingPolicy) {
-                                                                                  .requiresAsyncSafety = true,
+                                                                                  .requiresAsyncSafety = 1,
                                                                                   .isFatal = true,
                                                                                   .shouldRecordThreads = true,
                                                                               });

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Deadlock.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Deadlock.m
@@ -106,7 +106,7 @@ static KSCrash_ExceptionHandlerCallbacks g_callbacks;
     thread_t thisThread = (thread_t)ksthread_self();
     // This requires async-safety because the environment is suspended.
     KSCrash_MonitorContext *crashContext = g_callbacks.notify(thisThread, (KSCrash_ExceptionHandlingPolicy) {
-                                                                              .requiresAsyncSafety = true,
+                                                                              .requiresAsyncSafety = 1,
                                                                               .isFatal = true,
                                                                               .shouldRecordThreads = true,
                                                                           });

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_MachException.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_MachException.c
@@ -411,7 +411,7 @@ static void handleException(ExceptionContext *exceptionCtx)
 {
     KSCrash_MonitorContext *monitorCtx =
         g_state.callbacks.notify(exceptionCtx->request->thread.name, (KSCrash_ExceptionHandlingPolicy) {
-                                                                         .requiresAsyncSafety = true,
+                                                                         .requiresAsyncSafety = 1,
                                                                          .isFatal = true,
                                                                          .shouldRecordThreads = true,
                                                                      });

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
@@ -532,7 +532,7 @@ static void ksmemory_write_possible_oom(void)
 
     thread_t thisThread = (thread_t)ksthread_self();
     KSCrash_MonitorContext *ctx = g_callbacks.notify(thisThread, (KSCrash_ExceptionHandlingPolicy) {
-                                                                     .requiresAsyncSafety = false,
+                                                                     .requiresAsyncSafety = 0,
                                                                      .isFatal = false,
                                                                      .shouldRecordThreads = false,
                                                                  });

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException.m
@@ -119,7 +119,7 @@ static KS_NOINLINE void handleException(NSException *exception, BOOL isUserRepor
         // Now start exception handling
         KSCrash_MonitorContext *crashContext =
             g_callbacks.notify(thisThread, (KSCrash_ExceptionHandlingPolicy) {
-                                               .requiresAsyncSafety = false,
+                                               .requiresAsyncSafety = 0,
                                                // User-reported exceptions are not considered fatal.
                                                .isFatal = !isUserReported,
                                                .shouldRecordThreads = logAllThreads != NO,

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.c
@@ -94,7 +94,7 @@ static void handleSignal(int sigNum, siginfo_t *signalInfo, void *userContext)
     if (g_isEnabled && shouldHandleSignal(sigNum)) {
         thread_t thisThread = (thread_t)ksthread_self();
         KSCrash_MonitorContext *crashContext = g_callbacks.notify(thisThread, (KSCrash_ExceptionHandlingPolicy) {
-                                                                                  .requiresAsyncSafety = true,
+                                                                                  .requiresAsyncSafety = 1,
                                                                                   .isFatal = true,
                                                                                   .shouldRecordThreads = true,
                                                                               });

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_User.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_User.c
@@ -52,7 +52,7 @@ void kscm_reportUserException(const char *name, const char *reason, const char *
     } else {
         thread_t thisThread = (thread_t)ksthread_self();
         KSCrash_MonitorContext *ctx = g_callbacks.notify(thisThread, (KSCrash_ExceptionHandlingPolicy) {
-                                                                         .requiresAsyncSafety = false,
+                                                                         .requiresAsyncSafety = 0,
                                                                          .isFatal = terminateProgram,
                                                                          .shouldRecordThreads = logAllThreads,
                                                                      });

--- a/Sources/KSCrashRecording/include/KSCrashCConfiguration.h
+++ b/Sources/KSCrashRecording/include/KSCrashCConfiguration.h
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "KSCrashExceptionHandlingPolicy.h"
 #include "KSCrashMonitorType.h"
 #include "KSCrashNamespace.h"
 #include "KSCrashReportWriter.h"
@@ -37,12 +38,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/** Callback type for when a crash report is written.
- *
- * @param reportID The ID of the report that was written.
- */
-typedef void (*KSReportWrittenCallback)(int64_t reportID);
 
 /** Configuration for managing crash reports through the report store API.
  */

--- a/Sources/KSCrashRecording/include/KSCrashConfiguration.h
+++ b/Sources/KSCrashRecording/include/KSCrashConfiguration.h
@@ -25,6 +25,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "KSCrashExceptionHandlingPolicy.h"
 #import "KSCrashMonitorType.h"
 #include "KSCrashNamespace.h"
 #import "KSCrashReportStore.h"
@@ -109,22 +110,26 @@ NS_ASSUME_NONNULL_BEGIN
 /** Callback to invoke upon a crash.
  *
  * This function is called during the crash reporting process, providing an opportunity
- * to add additional information to the crash report. Only async-safe functions should
- * be called from this function. Avoid calling Objective-C/Swift methods.
+ * to add additional information to the crash report. The `policy` parameter determines
+ * what can be safely done within the callback.
+ *
+ * @see KSCrash_ExceptionHandlingPolicy
  *
  * **Default**: NULL
  */
-@property(nonatomic, copy, nullable) void (^crashNotifyCallback)(const struct KSCrashReportWriter *writer);
+@property(nonatomic, nullable) KSReportWriteCallback crashNotifyCallback;
 
 /** Callback to invoke upon finishing writing a crash report.
  *
  * This function is called after a crash report has been written. It allows the caller
- * to react to the completion of the report. Only async-safe functions should be called
- * from this function. Avoid calling Objective-C methods.
+ * to react to the completion of the report. The `policy` parameter determines
+ * what can be safely done within the callback.
+ *
+ * @see KSCrash_ExceptionHandlingPolicy
  *
  * **Default**: NULL
  */
-@property(nonatomic, copy, nullable) void (^reportWrittenCallback)(int64_t reportID);
+@property(nonatomic, nullable) KSReportWrittenCallback reportWrittenCallback;
 
 /** If true, append KSLOG console messages to the crash report.
  *

--- a/Sources/KSCrashRecording/include/KSCrashReportWriter.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportWriter.h
@@ -65,7 +65,8 @@ typedef struct KSCrashReportWriter {
      *
      * @param value The value to add.
      */
-    void (*addBooleanElement)(const struct KSCrashReportWriter *writer, const char *name, bool value);
+    void (*_Nonnull addBooleanElement)(const struct KSCrashReportWriter *_Nonnull writer, const char *_Nullable name,
+                                       bool value);
 
     /** Add a floating point element to the report.
      *
@@ -75,7 +76,8 @@ typedef struct KSCrashReportWriter {
      *
      * @param value The value to add.
      */
-    void (*addFloatingPointElement)(const struct KSCrashReportWriter *writer, const char *name, double value);
+    void (*_Nonnull addFloatingPointElement)(const struct KSCrashReportWriter *_Nonnull writer,
+                                             const char *_Nullable name, double value);
 
     /** Add an integer element to the report.
      *
@@ -85,7 +87,8 @@ typedef struct KSCrashReportWriter {
      *
      * @param value The value to add.
      */
-    void (*addIntegerElement)(const struct KSCrashReportWriter *writer, const char *name, int64_t value);
+    void (*_Nonnull addIntegerElement)(const struct KSCrashReportWriter *_Nonnull writer, const char *_Nullable name,
+                                       int64_t value);
 
     /** Add an unsigned integer element to the report.
      *
@@ -95,7 +98,8 @@ typedef struct KSCrashReportWriter {
      *
      * @param value The value to add.
      */
-    void (*addUIntegerElement)(const struct KSCrashReportWriter *writer, const char *name, uint64_t value);
+    void (*_Nonnull addUIntegerElement)(const struct KSCrashReportWriter *_Nonnull writer, const char *_Nullable name,
+                                        uint64_t value);
 
     /** Add a string element to the report.
      *
@@ -105,7 +109,8 @@ typedef struct KSCrashReportWriter {
      *
      * @param value The value to add.
      */
-    void (*addStringElement)(const struct KSCrashReportWriter *writer, const char *name, const char *value);
+    void (*_Nonnull addStringElement)(const struct KSCrashReportWriter *_Nonnull writer, const char *_Nullable name,
+                                      const char *_Nullable value);
 
     /** Add a string element from a text file to the report.
      *
@@ -115,7 +120,8 @@ typedef struct KSCrashReportWriter {
      *
      * @param filePath The path to the file containing the value to add.
      */
-    void (*addTextFileElement)(const struct KSCrashReportWriter *writer, const char *name, const char *filePath);
+    void (*_Nonnull addTextFileElement)(const struct KSCrashReportWriter *_Nonnull writer, const char *_Nullable name,
+                                        const char *_Nonnull filePath);
 
     /** Add an array of string elements representing lines from a text file to the report.
      *
@@ -125,7 +131,8 @@ typedef struct KSCrashReportWriter {
      *
      * @param filePath The path to the file containing the value to add.
      */
-    void (*addTextFileLinesElement)(const struct KSCrashReportWriter *writer, const char *name, const char *filePath);
+    void (*_Nonnull addTextFileLinesElement)(const struct KSCrashReportWriter *_Nonnull writer,
+                                             const char *_Nullable name, const char *_Nonnull filePath);
 
     /** Add a JSON element from a text file to the report.
      *
@@ -137,8 +144,8 @@ typedef struct KSCrashReportWriter {
      *
      * @param closeLastContainer If false, do not close the last container.
      */
-    void (*addJSONFileElement)(const struct KSCrashReportWriter *writer, const char *name, const char *filePath,
-                               const bool closeLastContainer);
+    void (*_Nonnull addJSONFileElement)(const struct KSCrashReportWriter *_Nonnull writer, const char *_Nullable name,
+                                        const char *_Nonnull filePath, const bool closeLastContainer);
 
     /** Add a hex encoded data element to the report.
      *
@@ -150,8 +157,8 @@ typedef struct KSCrashReportWriter {
      *
      * @paramn length The length of the data.
      */
-    void (*addDataElement)(const struct KSCrashReportWriter *writer, const char *name, const char *value,
-                           const int length);
+    void (*_Nonnull addDataElement)(const struct KSCrashReportWriter *_Nonnull writer, const char *_Nullable name,
+                                    const char *_Nonnull value, const int length);
 
     /** Begin writing a hex encoded data element to the report.
      *
@@ -159,7 +166,7 @@ typedef struct KSCrashReportWriter {
      *
      * @param name The name to give this element.
      */
-    void (*beginDataElement)(const struct KSCrashReportWriter *writer, const char *name);
+    void (*_Nonnull beginDataElement)(const struct KSCrashReportWriter *_Nonnull writer, const char *_Nullable name);
 
     /** Append hex encoded data to the current data element in the report.
      *
@@ -169,13 +176,14 @@ typedef struct KSCrashReportWriter {
      *
      * @paramn length The length of the data.
      */
-    void (*appendDataElement)(const struct KSCrashReportWriter *writer, const char *value, const int length);
+    void (*_Nonnull appendDataElement)(const struct KSCrashReportWriter *_Nonnull writer, const char *_Nonnull value,
+                                       const int length);
 
     /** Complete writing a hex encoded data element to the report.
      *
      * @param writer This writer.
      */
-    void (*endDataElement)(const struct KSCrashReportWriter *writer);
+    void (*_Nonnull endDataElement)(const struct KSCrashReportWriter *_Nonnull writer);
 
     /** Add a UUID element to the report.
      *
@@ -185,7 +193,8 @@ typedef struct KSCrashReportWriter {
      *
      * @param value A pointer to the binary UUID data.
      */
-    void (*addUUIDElement)(const struct KSCrashReportWriter *writer, const char *name, const unsigned char *value);
+    void (*_Nonnull addUUIDElement)(const struct KSCrashReportWriter *_Nonnull writer, const char *_Nullable name,
+                                    const unsigned char *_Nullable value);
 
     /** Add a preformatted JSON element to the report.
      *
@@ -197,8 +206,8 @@ typedef struct KSCrashReportWriter {
      *
      * @param closeLastContainer If false, do not close the last container.
      */
-    void (*addJSONElement)(const struct KSCrashReportWriter *writer, const char *name, const char *jsonElement,
-                           bool closeLastContainer);
+    void (*_Nonnull addJSONElement)(const struct KSCrashReportWriter *_Nonnull writer, const char *_Nullable name,
+                                    const char *_Nonnull jsonElement, bool closeLastContainer);
 
     /** Begin a new object container.
      *
@@ -206,7 +215,7 @@ typedef struct KSCrashReportWriter {
      *
      * @param name The name to give this element.
      */
-    void (*beginObject)(const struct KSCrashReportWriter *writer, const char *name);
+    void (*_Nonnull beginObject)(const struct KSCrashReportWriter *_Nonnull writer, const char *_Nullable name);
 
     /** Begin a new array container.
      *
@@ -214,17 +223,17 @@ typedef struct KSCrashReportWriter {
      *
      * @param name The name to give this element.
      */
-    void (*beginArray)(const struct KSCrashReportWriter *writer, const char *name);
+    void (*_Nonnull beginArray)(const struct KSCrashReportWriter *_Nonnull writer, const char *_Nullable name);
 
     /** Leave the current container, returning to the next higher level
      *  container.
      *
      * @param writer This writer.
      */
-    void (*endContainer)(const struct KSCrashReportWriter *writer);
+    void (*_Nonnull endContainer)(const struct KSCrashReportWriter *_Nonnull writer);
 
     /** Internal contextual data for the writer */
-    void *context;
+    void *_Nonnull context;
 
 } NS_SWIFT_NAME(ReportWriter) KSCrashReportWriter;
 

--- a/Sources/KSCrashRecording/include/KSCrashReportWriter.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportWriter.h
@@ -34,6 +34,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "KSCrashExceptionHandlingPolicy.h"
 #include "KSCrashNamespace.h"
 
 #ifdef __OBJC__
@@ -227,8 +228,20 @@ typedef struct KSCrashReportWriter {
 
 } NS_SWIFT_NAME(ReportWriter) KSCrashReportWriter;
 
-typedef void (*KSReportWriteCallback)(const KSCrashReportWriter *writer)
-    NS_SWIFT_UNAVAILABLE("Use Swift closures instead!");
+/** Callback type for when a crash report is being written.
+ *
+ * @param policy The policy under which the report was written.
+ * @param writer The report writer.
+ */
+typedef void (*KSReportWriteCallback)(KSCrash_ExceptionHandlingPolicy policy,
+                                      const KSCrashReportWriter *_Nonnull writer);
+
+/** Callback type for when a crash report is finished writing.
+ *
+ * @param policy The policy under which the report was written.
+ * @param reportID The ID of the report that was written.
+ */
+typedef void (*KSReportWrittenCallback)(KSCrash_ExceptionHandlingPolicy policy, int64_t reportID);
 
 #ifdef __cplusplus
 }

--- a/Sources/KSCrashRecordingCore/KSMachineContext.c
+++ b/Sources/KSCrashRecordingCore/KSMachineContext.c
@@ -171,20 +171,31 @@ static inline bool isThreadInList(thread_t thread, KSThread *list, int listCount
 #endif
 
 #if KSCRASH_HAS_THREADS_API
-void ksmc_suspendEnvironment(thread_act_array_t *suspendedThreads, mach_msg_type_number_t *numSuspendedThreads)
+void ksmc_suspendEnvironment(thread_act_array_t *threadsToSuspend, mach_msg_type_number_t *threadsToSuspendCount)
 {
+    if (threadsToSuspend == NULL || threadsToSuspendCount == NULL) {
+        KSLOG_ERROR("Passed in null pointer");
+        return;
+    }
+
+    if (*threadsToSuspend != NULL) {
+        // Idempotent return, but give a debug log in case this is due to an uninitialized value.
+        KSLOG_DEBUG("passed in dirty pointer");
+        return;
+    }
+
     KSLOG_DEBUG("Suspending environment.");
     kern_return_t kr;
     const task_t thisTask = mach_task_self();
     const thread_t thisThread = (thread_t)ksthread_self();
 
-    if ((kr = task_threads(thisTask, suspendedThreads, numSuspendedThreads)) != KERN_SUCCESS) {
+    if ((kr = task_threads(thisTask, threadsToSuspend, threadsToSuspendCount)) != KERN_SUCCESS) {
         KSLOG_ERROR("task_threads: %s", mach_error_string(kr));
         return;
     }
 
-    for (mach_msg_type_number_t i = 0; i < *numSuspendedThreads; i++) {
-        thread_t thread = (*suspendedThreads)[i];
+    for (mach_msg_type_number_t i = 0; i < *threadsToSuspendCount; i++) {
+        thread_t thread = (*threadsToSuspend)[i];
         if (thread != thisThread && !isThreadInList(thread, g_reservedThreads, g_reservedThreadsCount)) {
             if ((kr = thread_suspend(thread)) != KERN_SUCCESS) {
                 // Record the error and keep going.
@@ -203,17 +214,26 @@ void ksmc_suspendEnvironment(__unused thread_act_array_t *suspendedThreads,
 #endif
 
 #if KSCRASH_HAS_THREADS_API
-void ksmc_resumeEnvironment(thread_act_array_t threads, mach_msg_type_number_t numThreads)
+void ksmc_resumeEnvironment(thread_act_array_t *threads_inOut, mach_msg_type_number_t *numThreads_inOut)
 {
+    if (threads_inOut == NULL || numThreads_inOut == NULL) {
+        KSLOG_ERROR("Passed in null pointer");
+        return;
+    }
+
     KSLOG_DEBUG("Resuming environment.");
+
+    if (*threads_inOut == NULL || *numThreads_inOut == 0) {
+        // Idempotent return
+        goto done;
+    }
+
     kern_return_t kr;
     const task_t thisTask = mach_task_self();
     const thread_t thisThread = (thread_t)ksthread_self();
 
-    if (threads == NULL || numThreads == 0) {
-        KSLOG_ERROR("we should call ksmc_suspendEnvironment() first");
-        return;
-    }
+    thread_act_array_t threads = *threads_inOut;
+    mach_msg_type_number_t numThreads = *numThreads_inOut;
 
     for (mach_msg_type_number_t i = 0; i < numThreads; i++) {
         thread_t thread = threads[i];
@@ -229,6 +249,10 @@ void ksmc_resumeEnvironment(thread_act_array_t threads, mach_msg_type_number_t n
         mach_port_deallocate(thisTask, threads[i]);
     }
     vm_deallocate(thisTask, (vm_address_t)threads, sizeof(thread_t) * numThreads);
+
+done:
+    *threads_inOut = NULL;
+    *numThreads_inOut = 0;
 
     KSLOG_DEBUG("Resume complete.");
 }

--- a/Sources/KSCrashRecordingCore/KSMachineContext.c
+++ b/Sources/KSCrashRecordingCore/KSMachineContext.c
@@ -207,8 +207,8 @@ void ksmc_suspendEnvironment(thread_act_array_t *threadsToSuspend, mach_msg_type
     KSLOG_DEBUG("Suspend complete.");
 }
 #else
-void ksmc_suspendEnvironment(__unused thread_act_array_t *suspendedThreads,
-                             __unused mach_msg_type_number_t *numSuspendedThreads)
+void ksmc_suspendEnvironment(__unused thread_act_array_t *threadsToSuspend,
+                             __unused mach_msg_type_number_t *threadsToSuspendCount)
 {
 }
 #endif
@@ -257,7 +257,10 @@ done:
     KSLOG_DEBUG("Resume complete.");
 }
 #else
-void ksmc_resumeEnvironment(__unused thread_act_array_t threads, __unused mach_msg_type_number_t numThreads) {}
+void ksmc_resumeEnvironment(__unused thread_act_array_t *threads_inOut,
+                            __unused mach_msg_type_number_t *numThreads_inOut)
+{
+}
 #endif
 
 int ksmc_getThreadCount(const KSMachineContext *const context) { return context->threadCount; }

--- a/Sources/KSCrashRecordingCore/include/KSCrashExceptionHandlingPolicy.h
+++ b/Sources/KSCrashRecordingCore/include/KSCrashExceptionHandlingPolicy.h
@@ -1,0 +1,109 @@
+//
+//  KSCrashExceptionHandlingPolicy.h
+//
+//  Created by Karl Stenerud on 2025-08-11.
+//
+//  Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef HDR_KSCrashExceptionHandlingPolicy_h
+#define HDR_KSCrashExceptionHandlingPolicy_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Policy and state information that affects how a crash will be handled.
+ *
+ * This policy is used in both exception handlers and crash callbacks to give
+ * insight into what's going on, while also ensuring the proper functioning of
+ * this library.
+ *
+ * Heed my warnings, o traveler, or thou shalt have thyself a badde tyme!
+ */
+typedef struct {
+    /**
+     * Something has gone very, VERY wrong, and as a result the library
+     * cannot handle the exception.
+     *
+     * This is a very rare occurrence, but can happen if too many things cause
+     * fatal exceptions simultaneously.
+     *
+     * Do nothing. Touch nothing. Exit the exception handler immediately.
+     */
+    unsigned shouldExitImmediately : 1;
+
+    /**
+     * The process will terminate once exception handling completes.
+     */
+    unsigned isFatal : 1;
+
+    /**
+     * Only async-safe (aka signal-safe) functions may be called.
+     *
+     * This means that you cannot call anything that acquires locks or allocates
+     * memory, which includes:
+     * - Most of the C runtime library
+     * - Most Swift and Objective-C code
+     * - Any interpreted language frameworks such as React-Native
+     * - Any transpiled code such as Kotlin or Unity
+     * - Many C++ features, especially smart pointers
+     *
+     * Doing so risks causing a deadlock (which the user will experience as a
+     * frozen app).
+     *
+     * @see https://www.man7.org/linux/man-pages/man7/signal-safety.7.html
+     *
+     * Implementation detail: This is implemented as a semaphore to allow
+     * multiple internal places to require async safety for their own reasons
+     * (currently there are two). Externally, this field should be read like a
+     * boolean flag (0 = false, nonzero = true).
+     */
+    unsigned requiresAsyncSafety : 2;
+
+    /**
+     * This crash happened as a result of handling another exception, so be
+     * VERY conservative in what you do. Record just enough information to
+     * diagnose a problem within the library or callback itself, and nothing more.
+     *
+     * Most commonly, callbacks should do NOTHING when this flag is set.
+     *
+     * The rerport writer will produce only a minimal report (without threads,
+     * so this will also set `shouldRecordThreads` to false). The original
+     * report and "recrash" reports will then be merged.
+     */
+    unsigned crashedDuringExceptionHandling : 1;
+
+    /**
+     * The handler will try to record all threads if possible.
+     *
+     * This will require stopping all threads, and so `requiresAsyncSafety`
+     * will also be automatically incremented.
+     */
+    unsigned shouldRecordThreads : 1;
+} KSCrash_ExceptionHandlingPolicy;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // HDR_KSCrashExceptionHandlingPolicy_h

--- a/Sources/KSCrashRecordingCore/include/KSCrashExceptionHandlingPolicy.h
+++ b/Sources/KSCrashRecordingCore/include/KSCrashExceptionHandlingPolicy.h
@@ -87,7 +87,7 @@ typedef struct {
      *
      * Most commonly, callbacks should do NOTHING when this flag is set.
      *
-     * The rerport writer will produce only a minimal report (without threads,
+     * The report writer will produce only a minimal report (without threads,
      * so this will also set `shouldRecordThreads` to false). The original
      * report and "recrash" reports will then be merged.
      */

--- a/Sources/KSCrashRecordingCore/include/KSCrashMonitorContext.h
+++ b/Sources/KSCrashRecordingCore/include/KSCrashMonitorContext.h
@@ -30,6 +30,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "KSCrashExceptionHandlingPolicy.h"
 #include "KSCrashMonitorFlag.h"
 #include "KSCrashNamespace.h"
 #include "KSMachineContext.h"
@@ -37,29 +38,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * Policy and state information that affects how a crash will be handled.
- */
-typedef struct {
-    /** Do nothing. Touch nothing. Exit the exception handler immediately. */
-    unsigned shouldExitImmediately : 1;
-
-    /** The process will terminate once exception handling is finished. */
-    unsigned isFatal : 1;
-
-    /** Only async-safe functions may be called. */
-    unsigned requiresAsyncSafety : 1;
-
-    /**
-     * This crash happened while handling a crash, so we'll be producing only a minimal report.
-     * Note: This will override shouldRecordThreads.
-     */
-    unsigned crashedDuringExceptionHandling : 1;
-
-    /** The handle() method will try to record all threads if possible. */
-    unsigned shouldRecordThreads : 1;
-} KSCrash_ExceptionHandlingPolicy;
 
 /**
  * The monitor context is a clearing house for all information that might be recorded into a crash report.

--- a/Sources/KSCrashRecordingCore/include/KSMachineContext.h
+++ b/Sources/KSCrashRecordingCore/include/KSMachineContext.h
@@ -38,13 +38,28 @@
 extern "C" {
 #endif
 
-/** Suspend the runtime environment.
+/**
+ * Suspend the runtime environment.
+ *
+ * This function is idempotent.
+ *
+ * @param threadsToSuspend Pointer to where the threads list pointer will be stored. The pointed-to value MUST be NULL
+ * or else this function will no-op!
+ * @param threadsToSuspendCount Pointer to where the count of suspended threads will be stored.
  */
-void ksmc_suspendEnvironment(thread_act_array_t *suspendedThreads, mach_msg_type_number_t *numSuspendedThreads);
+void ksmc_suspendEnvironment(thread_act_array_t *threadsToSuspend, mach_msg_type_number_t *threadsToSuspendCount);
 
-/** Resume the runtime environment.
+/**
+ * Resume the runtime environment.
+ *
+ * This function is idempotent.
+ *
+ * @param suspendedThreads Pointer to where the threads list pointer is stored. The threads list pointer will be set to
+ * NULL on completion.
+ * @param suspendedThreadsCount Pointer to where the count of suspended threads is stored. The count will be set to
+ * 0 on completion.
  */
-void ksmc_resumeEnvironment(thread_act_array_t threads, mach_msg_type_number_t numThreads);
+void ksmc_resumeEnvironment(thread_act_array_t *suspendedThreads, mach_msg_type_number_t *suspendedThreadsCount);
 
 /** Get the internal size of a machine context.
  */

--- a/Tests/KSCrashRecordingCoreTests/KSCrashMonitor_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSCrashMonitor_Tests.m
@@ -257,7 +257,7 @@ extern void kscm_testcode_resetState(void);
     KSCrash_MonitorContext *ctx = NULL;
     ctx = dummyExceptionHandlerCallbacks.notify((thread_t)ksthread_self(), (KSCrash_ExceptionHandlingPolicy) {
                                                                                .isFatal = false,
-                                                                               .requiresAsyncSafety = true,
+                                                                               .requiresAsyncSafety = 1,
                                                                            });
     XCTAssertFalse(ctx->currentPolicy.isFatal);
     XCTAssertTrue(ctx->currentPolicy.requiresAsyncSafety);
@@ -275,7 +275,7 @@ extern void kscm_testcode_resetState(void);
     KSCrash_MonitorContext *ctx = NULL;
     ctx = dummyExceptionHandlerCallbacks.notify((thread_t)ksthread_self(), (KSCrash_ExceptionHandlingPolicy) {
                                                                                .isFatal = false,
-                                                                               .requiresAsyncSafety = false,
+                                                                               .requiresAsyncSafety = 0,
                                                                            });
     XCTAssertFalse(ctx->currentPolicy.isFatal);
     XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafety);
@@ -602,7 +602,7 @@ static int g_counter = 0;
     XCTAssertTrue(g_dummyMonitor.isEnabled(), @"The monitor should be enabled after activation.");
     KSCrash_MonitorContext *ctx = NULL;
     ctx = dummyExceptionHandlerCallbacks.notify((thread_t)ksthread_self(), (KSCrash_ExceptionHandlingPolicy) {
-                                                                               .requiresAsyncSafety = false,
+                                                                               .requiresAsyncSafety = 0,
                                                                                .isFatal = true,
                                                                            });
     XCTAssertTrue(g_dummyMonitor.isEnabled(),

--- a/Tests/KSCrashRecordingCoreTests/KSMachineContext_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSMachineContext_Tests.m
@@ -43,8 +43,18 @@
     mach_msg_type_number_t numThreads2 = 0;
     ksmc_suspendEnvironment(&threads2, &numThreads2);
 
-    ksmc_resumeEnvironment(threads2, numThreads2);
-    ksmc_resumeEnvironment(threads1, numThreads1);
+    ksmc_resumeEnvironment(&threads2, &numThreads2);
+    ksmc_resumeEnvironment(&threads1, &numThreads1);
+    XCTAssertEqual(threads1, NULL);
+    XCTAssertEqual(threads2, NULL);
+
+    // These should be idempotent
+    ksmc_resumeEnvironment(&threads2, &numThreads2);
+    ksmc_resumeEnvironment(&threads1, &numThreads1);
+    ksmc_resumeEnvironment(&threads2, &numThreads2);
+    ksmc_resumeEnvironment(&threads1, &numThreads1);
+    ksmc_resumeEnvironment(&threads2, &numThreads2);
+    ksmc_resumeEnvironment(&threads1, &numThreads1);
 }
 
 - (void)startTheBackgroundJob

--- a/namespacer/namespacer.py
+++ b/namespacer/namespacer.py
@@ -229,6 +229,8 @@ def generate_header_contents(symbols):
 
 #ifdef {namespace_define}
 
+#define {namespace_define}_STRING #{namespace_define}
+
 #define {namespace_macro}2(NAMESPACE, SYMBOL) SYMBOL##NAMESPACE
 #define {namespace_macro}1(NAMESPACE, SYMBOL) {namespace_macro}2(NAMESPACE, SYMBOL)
 #define {namespace_macro}(SYMBOL) {namespace_macro}1({namespace_define}, SYMBOL)
@@ -240,6 +242,10 @@ def generate_header_contents(symbols):
             line = f"#define {symbol} \\\n    {namespace_macro}({symbol})"
         contents += f"{line}\n"
     contents += f"""
+#else
+
+#define {namespace_define}_STRING ""
+
 #endif
 
 #endif /* {header_define} */


### PR DESCRIPTION
Note: This is a BREAKING API CHANGE.

See KSCrashExceptionHandlingPolicy.h for an explanation of the policy fields.

This commit also reverts the Objective-C block based callbacks and restores the C function pointer approach for the following reasons:

- ISO C doesn't natively support blocks, and while getting the IMP from a block technically returns a function pointer, the actual function is an Objective-C object's dynamic dispatch method implementation, which takes as its first two parameters an id (self) and a SEL. Trying to call and receive with different types is undefined behavior.
- Although you can technically compile C with block support by adding `-fblocks` and linking with libdispatch (which compilers on Mac do automatically), you're still left with the issue that blocks are Objective-C objects. This breaks the C ABI for other languages that are trying to interoperate (such as Rust FFI).
- Attempting to change or clear a reference to a callback block can invoke memory management on the heap, which is not async-safe - BUT the magic makes it hard to tell that any memory management even happened. There are few likely pathways for it to occur in this case, but we need to keep implicit heap and lock code out of the C layer as much as possible as a matter of principle - every instance is a landmine waiting to go off in a future change that looks perfectly safe to the human eye due to the magic.
- Swift 3.1+ supports C function pointers natively. For example, `int32_t (*)(void)` (pointer to function taking no params and returning 32-bit int) is represented in Swift as the closure `@convention(c) () -> Int32`. See https://developer.apple.com/documentation/swift/using-imported-c-functions-in-swift

See InstallBridge.swift:81 for an example of setting a Swift callback.
