### PR TITLE
Allow Cancelling Processing/Writting a Crash

### DIFF
--- a/Sources/KSCrashRecording/KSCrashConfiguration.m
+++ b/Sources/KSCrashRecording/KSCrashConfiguration.m
@@ -61,7 +61,8 @@
         _printPreviousLogOnStartup = cConfig.printPreviousLogOnStartup ? YES : NO;
         _enableSwapCxaThrow = cConfig.enableSwapCxaThrow ? YES : NO;
         _enableSigTermMonitoring = cConfig.enableSigTermMonitoring ? YES : NO;
-
+        _willWriteCallback = cConfig.willWriteCallback;
+        
         _reportStoreConfiguration = [KSCrashReportStoreConfiguration new];
         _reportStoreConfiguration.appName = nil;
         _reportStoreConfiguration.maxReportCount = cConfig.reportStoreConfiguration.maxReportCount;
@@ -104,7 +105,8 @@
     config.printPreviousLogOnStartup = self.printPreviousLogOnStartup;
     config.enableSwapCxaThrow = self.enableSwapCxaThrow;
     config.enableSigTermMonitoring = self.enableSigTermMonitoring;
-
+    config.willWriteCallback = self.willWriteCallback;
+    
     return config;
 }
 
@@ -152,6 +154,7 @@
                                                                           copyItems:YES]
                                       : nil;
     copy.crashNotifyCallback = [self.crashNotifyCallback copy];
+    copy.willWriteCallback = self.willWriteCallback;
     copy.reportWrittenCallback = [self.reportWrittenCallback copy];
     copy.addConsoleLogToReport = self.addConsoleLogToReport;
     copy.printPreviousLogOnStartup = self.printPreviousLogOnStartup;

--- a/Sources/KSCrashRecording/KSCrashConfiguration.m
+++ b/Sources/KSCrashRecording/KSCrashConfiguration.m
@@ -61,8 +61,8 @@
         _printPreviousLogOnStartup = cConfig.printPreviousLogOnStartup ? YES : NO;
         _enableSwapCxaThrow = cConfig.enableSwapCxaThrow ? YES : NO;
         _enableSigTermMonitoring = cConfig.enableSigTermMonitoring ? YES : NO;
-        _willWriteCallback = cConfig.willWriteCallback;
-        
+        _shouldWriteReportCallback = cConfig.shouldWriteReportCallback;
+
         _reportStoreConfiguration = [KSCrashReportStoreConfiguration new];
         _reportStoreConfiguration.appName = nil;
         _reportStoreConfiguration.maxReportCount = cConfig.reportStoreConfiguration.maxReportCount;
@@ -105,8 +105,8 @@
     config.printPreviousLogOnStartup = self.printPreviousLogOnStartup;
     config.enableSwapCxaThrow = self.enableSwapCxaThrow;
     config.enableSigTermMonitoring = self.enableSigTermMonitoring;
-    config.willWriteCallback = self.willWriteCallback;
-    
+    config.shouldWriteReportCallback = self.shouldWriteReportCallback;
+
     return config;
 }
 
@@ -154,7 +154,7 @@
                                                                           copyItems:YES]
                                       : nil;
     copy.crashNotifyCallback = [self.crashNotifyCallback copy];
-    copy.willWriteCallback = self.willWriteCallback;
+    copy.shouldWriteReportCallback = self.shouldWriteReportCallback;
     copy.reportWrittenCallback = [self.reportWrittenCallback copy];
     copy.addConsoleLogToReport = self.addConsoleLogToReport;
     copy.printPreviousLogOnStartup = self.printPreviousLogOnStartup;

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
@@ -531,12 +531,10 @@ static void ksmemory_write_possible_oom(void)
     const char *reportPath = reportURL.path.UTF8String;
 
     thread_t thisThread = (thread_t)ksthread_self();
-    KSCrash_MonitorContext *ctx = g_callbacks.notify(thisThread, (KSCrash_ExceptionHandlingPolicy) {
-                                                                     .requiresAsyncSafety = false,
-                                                                     .isFatal = false,
-                                                                     .shouldRecordThreads = false,
-                                                                     .forFutureReference = true
-                                                                 });
+    KSCrash_MonitorContext *ctx = g_callbacks.notify(
+        thisThread,
+        (KSCrash_ExceptionHandlingPolicy) {
+            .requiresAsyncSafety = false, .isFatal = false, .shouldRecordThreads = false, .forFutureReference = true });
     if (ctx->currentPolicy.shouldExitImmediately) {
         return;
     }

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
@@ -535,6 +535,7 @@ static void ksmemory_write_possible_oom(void)
                                                                      .requiresAsyncSafety = false,
                                                                      .isFatal = false,
                                                                      .shouldRecordThreads = false,
+                                                                     .forFutureReference = true
                                                                  });
     if (ctx->currentPolicy.shouldExitImmediately) {
         return;

--- a/Sources/KSCrashRecording/include/KSCrashCConfiguration.h
+++ b/Sources/KSCrashRecording/include/KSCrashCConfiguration.h
@@ -33,6 +33,7 @@
 #include "KSCrashMonitorType.h"
 #include "KSCrashNamespace.h"
 #include "KSCrashReportWriter.h"
+#include "KSCrashMonitorContext.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,6 +44,7 @@ extern "C" {
  * @param reportID The ID of the report that was written.
  */
 typedef void (*KSReportWrittenCallback)(int64_t reportID);
+typedef bool (*KSReportWillWriteCallback)(const struct KSCrash_MonitorContext *context);
 
 /** Configuration for managing crash reports through the report store API.
  */
@@ -172,7 +174,8 @@ typedef struct {
      * **Default**: NULL
      */
     KSReportWriteCallback crashNotifyCallback;
-
+    KSReportWillWriteCallback willWriteCallback;
+    
     /** Callback to invoke upon finishing writing a crash report.
      *
      * This function is called after a crash report has been written. It allows the caller
@@ -234,6 +237,7 @@ static inline KSCrashCConfiguration KSCrashCConfiguration_Default(void)
         .enableMemoryIntrospection = false,
         .doNotIntrospectClasses = { .strings = NULL, .length = 0 },
         .crashNotifyCallback = NULL,
+        .willWriteCallback = NULL,
         .reportWrittenCallback = NULL,
         .addConsoleLogToReport = false,
         .printPreviousLogOnStartup = false,

--- a/Sources/KSCrashRecording/include/KSCrashConfiguration.h
+++ b/Sources/KSCrashRecording/include/KSCrashConfiguration.h
@@ -29,6 +29,7 @@
 #include "KSCrashNamespace.h"
 #import "KSCrashReportStore.h"
 #import "KSCrashReportWriter.h"
+#import "KSCrashCConfiguration.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -125,6 +126,7 @@ NS_ASSUME_NONNULL_BEGIN
  * **Default**: NULL
  */
 @property(nonatomic, copy, nullable) void (^reportWrittenCallback)(int64_t reportID);
+@property(nonatomic, assign, nullable) KSReportWillWriteCallback willWriteCallback;
 
 /** If true, append KSLOG console messages to the crash report.
  *

--- a/Sources/KSCrashRecording/include/KSCrashConfiguration.h
+++ b/Sources/KSCrashRecording/include/KSCrashConfiguration.h
@@ -25,11 +25,11 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "KSCrashCConfiguration.h"
 #import "KSCrashMonitorType.h"
 #include "KSCrashNamespace.h"
 #import "KSCrashReportStore.h"
 #import "KSCrashReportWriter.h"
-#import "KSCrashCConfiguration.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -126,7 +126,15 @@ NS_ASSUME_NONNULL_BEGIN
  * **Default**: NULL
  */
 @property(nonatomic, copy, nullable) void (^reportWrittenCallback)(int64_t reportID);
-@property(nonatomic, assign, nullable) KSReportWillWriteCallback willWriteCallback;
+
+/** Callback to invoke before writing a crash report.
+ *
+ * This function is called before a crash report has been written. It allows the caller
+ * to cancel writting the report, or modify the report being written.
+ *
+ * **Default**: NULL
+ */
+@property(nonatomic, assign, nullable) KSReportShouldWriteReportCallback shouldWriteReportCallback;
 
 /** If true, append KSLOG console messages to the crash report.
  *

--- a/Sources/KSCrashRecordingCore/include/KSCrashMonitorContext.h
+++ b/Sources/KSCrashRecordingCore/include/KSCrashMonitorContext.h
@@ -47,18 +47,21 @@ typedef struct {
 
     /** The process will terminate once exception handling is finished. */
     unsigned isFatal : 1;
-
+    
     /** Only async-safe functions may be called. */
     unsigned requiresAsyncSafety : 1;
-
+    
     /**
      * This crash happened while handling a crash, so we'll be producing only a minimal report.
      * Note: This will override shouldRecordThreads.
      */
     unsigned crashedDuringExceptionHandling : 1;
-
+    
     /** The handle() method will try to record all threads if possible. */
     unsigned shouldRecordThreads : 1;
+    
+    /** Some report writes might be prepared for future use, such as preparing an OOM reprot for the next session. */
+    unsigned forFutureReference: 1;
 } KSCrash_ExceptionHandlingPolicy;
 
 /**

--- a/Sources/KSCrashRecordingCore/include/KSCrashMonitorContext.h
+++ b/Sources/KSCrashRecordingCore/include/KSCrashMonitorContext.h
@@ -47,21 +47,21 @@ typedef struct {
 
     /** The process will terminate once exception handling is finished. */
     unsigned isFatal : 1;
-    
+
     /** Only async-safe functions may be called. */
     unsigned requiresAsyncSafety : 1;
-    
+
     /**
      * This crash happened while handling a crash, so we'll be producing only a minimal report.
      * Note: This will override shouldRecordThreads.
      */
     unsigned crashedDuringExceptionHandling : 1;
-    
+
     /** The handle() method will try to record all threads if possible. */
     unsigned shouldRecordThreads : 1;
-    
-    /** Some report writes might be prepared for future use, such as preparing an OOM reprot for the next session. */
-    unsigned forFutureReference: 1;
+
+    /** Some report writes might be prepared for future use, such as preparing an OOM report for the next session. */
+    unsigned forFutureReference : 1;
 } KSCrash_ExceptionHandlingPolicy;
 
 /**


### PR DESCRIPTION
This PR adds a new callback that allows a user to look at a crash after all monitors have been processed and decide to continue on and write it or simply cancel out. This in turn adds a way to users to write the context out themselves to some other format, and cancel the rest of the processing (or continue). In essence, it allows someone to use KSCrash as a shell that gives knowledge of crashes without actually doing anything else about them (At Embrace we have a use case for this). 

As a secondary item other than this PR, we add a `.forFutureReference` policy. This policy allows reports to be written but not reported or cancelled by users. This is useful in cases like OOMs where a report is written out at startup and reused on the next run if an OOM was found.