### PR TITLE
Clean up pragma and example app warnings

### DIFF
--- a/Samples/Tests/IntegrationTests.swift
+++ b/Samples/Tests/IntegrationTests.swift
@@ -130,12 +130,12 @@ final class CppTests: IntegrationTestBase {
             })
             XCTAssertNotNil(expectedFrame)
 
-            var threadStates = [
+            let threadStates = [
                 "TH_STATE_RUNNING", "TH_STATE_STOPPED", "TH_STATE_WAITING",
                 "TH_STATE_UNINTERRUPTIBLE", "TH_STATE_HALTED",
             ]
             for thread in rawReport.crash?.threads ?? [] {
-                var threadState = thread.state ?? ""
+                let threadState = thread.state ?? ""
                 XCTAssertTrue(threadStates.contains(threadState))
             }
 

--- a/Sources/KSCrashDemangleFilter/swift/Basic/Demangler.h
+++ b/Sources/KSCrashDemangleFilter/swift/Basic/Demangler.h
@@ -118,6 +118,7 @@ namespace swift {
                     << ", End = " << (void *)End << "\n";
 #endif
                 }
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-align"
                 T *AllocatedObj = (T *)CurPtr;
 #pragma clang diagnostic pop

--- a/Sources/KSCrashDemangleFilter/swift/Basic/NodePrinter.cpp
+++ b/Sources/KSCrashDemangleFilter/swift/Basic/NodePrinter.cpp
@@ -1933,6 +1933,7 @@ return nullptr;
         case Node::Kind::ImplErrorResult:
             Printer << "@error ";
 //            LLVM_FALLTHROUGH;
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wimplicit-fallthrough"
         case Node::Kind::ImplParameter:
 #pragma clang diagnostic pop

--- a/Sources/KSCrashRecording/KSCrashAppMemoryTracker.m
+++ b/Sources/KSCrashRecording/KSCrashAppMemoryTracker.m
@@ -209,7 +209,7 @@ static KSCrashAppMemory *_Nullable _ProvideCrashAppMemory(KSCrashAppMemoryState 
     }
 
 #pragma clang diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self.delegate appMemoryTracker:self memory:memory changed:changes];
 #pragma clang diagnostic pop
 }

--- a/Sources/KSCrashRecordingCore/KSDynamicLinker.c
+++ b/Sources/KSCrashRecordingCore/KSDynamicLinker.c
@@ -312,6 +312,7 @@ static bool isValidCrashInfoMessage(const char *str)
 static void getCrashInfo(const struct mach_header *header, KSBinaryImage *buffer)
 {
     unsigned long size = 0;
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-align"
     crash_info_t *crashInfo =
         (crash_info_t *)getsectiondata((mach_header_t *)header, SEG_DATA, KSDL_SECT_CRASH_INFO, &size);

--- a/Sources/KSCrashRecordingCore/KSJSONCodec.c
+++ b/Sources/KSCrashRecordingCore/KSJSONCodec.c
@@ -968,6 +968,7 @@ static int decodeElement(const char *const name, KSJSONDecodeContext *context)
                 return KSJSON_ERROR_INVALID_CHARACTER;
             }
             // Fallthrough
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wimplicit-fallthrough"
         case '0':
 #pragma clang diagnostic pop

--- a/Sources/KSCrashRecordingCore/KSJSONCodecObjC.m
+++ b/Sources/KSCrashRecordingCore/KSJSONCodecObjC.m
@@ -304,6 +304,7 @@ static int encodeObject(KSJSONCodec *codec, id object, NSString *name, KSJSONEnc
                     return ksjson_addBooleanElement(context, cName, [object boolValue]);
                 }
                 // Fall through to integer handling if it's not a boolean
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wimplicit-fallthrough"
             case kCFNumberSInt8Type:
 #pragma clang diagnostic pop

--- a/Sources/KSCrashRecordingCore/KSObjCApple.h
+++ b/Sources/KSCrashRecordingCore/KSObjCApple.h
@@ -702,7 +702,7 @@ typedef struct class_t {
     struct class_t *isa;
     struct class_t *superclass;
 #pragma clang diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     Cache cache;
 #pragma clang diagnostic pop
     IMP *vtable;
@@ -971,6 +971,7 @@ CF_INLINE CFIndex __CFArrayGetSizeOfType(CFIndex t) {
 /* Only applies to immutable and mutable-deque-using arrays;
  * Returns the bucket holding the left-most real value in the latter case. */
 CF_INLINE struct __CFArrayBucket *__CFArrayGetBucketsPtr(CFArrayRef array) {
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-align"
     switch (__CFArrayGetType(array)) {
         case __kCFArrayImmutable:

--- a/Sources/KSCrashRecordingCore/KSThread.c
+++ b/Sources/KSCrashRecordingCore/KSThread.c
@@ -108,6 +108,7 @@ bool ksthread_getQueueName(const KSThread thread, char *const buffer, int bufLen
         return false;
     }
 
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-align"
     thread_identifier_info_t idInfo = (thread_identifier_info_t)info;
 #pragma clang diagnostic pop

--- a/Tests/KSCrashFiltersTests/KSCrashReportFilterJSON_Tests.m
+++ b/Tests/KSCrashFiltersTests/KSCrashReportFilterJSON_Tests.m
@@ -64,6 +64,7 @@
 
 - (void)testFilterJSONEncodeInvalid
 {
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-literal-conversion"
     NSArray *decoded = @[
         [KSCrashReportDictionary reportWithValue:@{ @1 : @2 }],  // Not a JSON

--- a/Tests/KSCrashRecordingCoreTests/KSMach-O_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSMach-O_Tests.m
@@ -9,6 +9,7 @@
 #import <mach-o/loader.h>
 #import "KSMach-O.h"
 
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-align"
 
 @interface KSMach_O_Tests : XCTestCase

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_AppState_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_AppState_Tests.m
@@ -28,6 +28,7 @@
 
 #import "KSCrashMonitor_AppState.h"
 
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wfloat-equal"
 
 @interface KSCrashMonitor_AppState_Tests : FileBasedTestCase


### PR DESCRIPTION
For some reason, clang won't issue warnings about having a `#pragma clang diagnostic pop` without a corresponding push, except when using KSCrash as an external dependency?

Either way, this PR balances the pushes and the pops.
