### PR TITLE
Modify KSCrashEventNotifyCallback to return a user-supplied policy

### DIFF
--- a/Sources/KSCrashRecording/KSCrashC.c
+++ b/Sources/KSCrashRecording/KSCrashC.c
@@ -186,12 +186,15 @@ static void notifyOfBeforeInstallationState(void)
  */
 static void onCrash(struct KSCrash_MonitorContext *monitorContext)
 {
-    // Check if the user wants to modify or deny this crash.
+    // Check if the user wants to modify the policy for this crash.
     if (g_eventNotifyCallback) {
-        g_eventNotifyCallback(monitorContext);
+        KSCrash_ExceptionHandlingPolicy changedPolicy =
+            g_eventNotifyCallback(monitorContext->currentPolicy, monitorContext);
+        monitorContext->currentPolicy.shouldRecordThreads = changedPolicy.shouldRecordThreads;
+        monitorContext->currentPolicy.shouldWriteReport = changedPolicy.shouldWriteReport;
     }
 
-    // Check if we should cancel out the writting of the report.
+    // If we shouldn't write a report, then there's nothing left to do here.
     if (monitorContext->currentPolicy.shouldWriteReport == 0) {
         return;
     }

--- a/Sources/KSCrashRecording/KSCrashC.c
+++ b/Sources/KSCrashRecording/KSCrashC.c
@@ -190,8 +190,9 @@ static void onCrash(struct KSCrash_MonitorContext *monitorContext)
     if (g_eventNotifyCallback) {
         KSCrash_ExceptionHandlingPolicy changedPolicy =
             g_eventNotifyCallback(monitorContext->currentPolicy, monitorContext);
-        monitorContext->currentPolicy.shouldRecordThreads = changedPolicy.shouldRecordThreads;
-        monitorContext->currentPolicy.shouldWriteReport = changedPolicy.shouldWriteReport;
+#define OVERRIDE_POLICY(POLICY) monitorContext->currentPolicy.POLICY = changedPolicy.POLICY
+        OVERRIDE_POLICY(shouldRecordThreads);
+        OVERRIDE_POLICY(shouldWriteReport);
     }
 
     // If we shouldn't write a report, then there's nothing left to do here.

--- a/Sources/KSCrashRecording/include/KSCrashReportWriterCallbacks.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportWriterCallbacks.h
@@ -37,20 +37,35 @@
 extern "C" {
 #endif
 
-/** Callback type for when a crash report is being written.
+// Various callbacks that will be called while handling a crash.
+// The calling order is:
+// * KSCrashEventNotifyCallback
+// * KSReportWriteCallbackWithPolicy
+// * KSReportWrittenCallbackWithPolicy
+
+/** Callback type for when a crash has been detected, and we are deciding what to do about it.
+ *
+ * Normally a callback will just return `policy` as-is, but the user could return a modified policy to change how
+ * this exception is handled.
+ *
+ * @see KSCrash_ExceptionHandlingPolicy for a list of which policies can be modified.
+ *
+ * @param policy The current policy for handling this exception
+ * @param context The monitor context of the report. Note: This is an INTERNAL structure, subject to change without
+ * notice!
+ * @return The recommended policy for handling this exception
+ */
+typedef KSCrash_ExceptionHandlingPolicy (*KSCrashEventNotifyCallback)(
+    KSCrash_ExceptionHandlingPolicy policy, const struct KSCrash_MonitorContext *_Nonnull context)
+    NS_SWIFT_UNAVAILABLE("Use Swift closures instead!");
+
+/** Callback type for when a crash report is being written, giving the user an opportunity to add custom data to the user section of the report..
  *
  * @param policy The policy under which the report was written.
  * @param writer The report writer.
  */
 typedef void (*KSReportWriteCallbackWithPolicy)(struct KSCrash_ExceptionHandlingPolicy policy,
                                                 const KSCrashReportWriter *_Nonnull writer)
-    NS_SWIFT_UNAVAILABLE("Use Swift closures instead!");
-
-/** Callback type for when a crash report should be written.
- *
- * @param context The monitor context of the report.
- */
-typedef void (*KSCrashEventNotifyCallback)(struct KSCrash_MonitorContext *_Nonnull context)
     NS_SWIFT_UNAVAILABLE("Use Swift closures instead!");
 
 /** Callback type for when a crash report is finished writing.

--- a/Sources/KSCrashRecording/include/KSCrashReportWriterCallbacks.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportWriterCallbacks.h
@@ -59,7 +59,8 @@ typedef KSCrash_ExceptionHandlingPolicy (*KSCrashEventNotifyCallback)(
     KSCrash_ExceptionHandlingPolicy policy, const struct KSCrash_MonitorContext *_Nonnull context)
     NS_SWIFT_UNAVAILABLE("Use Swift closures instead!");
 
-/** Callback type for when a crash report is being written, giving the user an opportunity to add custom data to the user section of the report..
+/** Callback type for when a crash report is being written, giving the user an opportunity to add custom data to the
+ * user section of the report..
  *
  * @param policy The policy under which the report was written.
  * @param writer The report writer.

--- a/Sources/KSCrashRecordingCore/include/KSCrashExceptionHandlingPolicy.h
+++ b/Sources/KSCrashRecordingCore/include/KSCrashExceptionHandlingPolicy.h
@@ -43,16 +43,26 @@ extern "C" {
  * Heed my warnings, o traveler, or thou shalt have thyself a badde tyme!
  */
 typedef struct KSCrash_ExceptionHandlingPolicy {
+    // ---------------------------------------------------------------
+    // User-Modifiable Policies
+    // In a return from a user callback, these fields will be honored.
+    // ---------------------------------------------------------------
+
     /**
-     * Something has gone very, VERY wrong, and as a result the library
-     * cannot handle the exception.
+     * The handler will try to record all threads if possible.
      *
-     * This is a very rare occurrence, but can happen if too many things cause
-     * fatal exceptions simultaneously.
-     *
-     * Do nothing. Touch nothing. Exit the exception handler immediately.
+     * This will require stopping all threads, and so `requiresAsyncSafety`
+     * will also be automatically incremented.
      */
-    unsigned shouldExitImmediately : 1;
+    unsigned shouldRecordThreads : 1;
+
+    /** If true, the handler will write a report about this event. */
+    unsigned shouldWriteReport : 1;
+
+    // ---------------------------------------------------------------
+    // User-Immutable Policies
+    // In a return from a user callback, these fields will be ignored.
+    // ---------------------------------------------------------------
 
     /**
      * The process will terminate once exception handling completes.
@@ -96,15 +106,16 @@ typedef struct KSCrash_ExceptionHandlingPolicy {
     unsigned crashedDuringExceptionHandling : 1;
 
     /**
-     * The handler will try to record all threads if possible.
+     * Something has gone very, VERY wrong, and as a result the library
+     * cannot handle the exception.
      *
-     * This will require stopping all threads, and so `requiresAsyncSafety`
-     * will also be automatically incremented.
+     * This is a very rare occurrence, but can happen if too many things cause
+     * fatal exceptions simultaneously.
+     *
+     * Do nothing. Touch nothing. Exit the exception handler immediately.
      */
-    unsigned shouldRecordThreads : 1;
+    unsigned shouldExitImmediately : 1;
 
-    /** If true, the handler will write a report about this event. */
-    unsigned shouldWriteReport : 1;
 } CF_SWIFT_NAME(ExceptionHandlingPolicy) KSCrash_ExceptionHandlingPolicy;
 
 #ifdef __cplusplus


### PR DESCRIPTION
`KSCrashEventNotifyCallback` now accepts and returns a `KSCrash_ExceptionHandlingPolicy`, and `context` is const.

This protects the internals, while also providing a future-expandable list of things the user can control from this function.

Example:

```c
static KSCrash_ExceptionHandlingPolicy myEventNotifyCallback(KSCrash_ExceptionHandlingPolicy policy,
                                                             const struct KSCrash_MonitorContext *_Nonnull context) {
    if (context->signal.signum == SIGTERM) {
        policy.shouldWriteReport = 0;
    }
    if (context->currentSnapshotUserReported) {
        policy.shouldRecordThreads = 0;
    }

    return policy;
}
```
