### PR TITLE
We should still attempt to record threads even if we can't suspend them.

### DIFF
--- a/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
+++ b/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
@@ -60,7 +60,7 @@ static void trigger_signal(void)
     abort();  // This will raise a SIGABRT signal
 }
 
-static void trigger_user(void)
+static void trigger_user_nonfatal(void)
 {
     [KSCrash.sharedInstance reportUserException:@"User Exception"
                                          reason:@"My Reason"
@@ -71,7 +71,7 @@ static void trigger_user(void)
                                terminateProgram:NO];
 }
 
-static void trigger_userfatal(void)
+static void trigger_user_fatal(void)
 {
     [KSCrash.sharedInstance reportUserException:@"User Exception"
                                          reason:@"My Reason"
@@ -106,6 +106,14 @@ NSString *const KSCrashNSExceptionStacktraceFuncName = @"exceptionWithStacktrace
     [array objectAtIndex:10];  // This will throw an NSRangeException
 }
 
++ (void)trigger_nsException_user
+{
+    [KSCrash.sharedInstance reportNSException:[NSException exceptionWithName:@"Custom Exception"
+                                                                      reason:@"Custom reason"
+                                                                    userInfo:NULL]
+                                logAllThreads:YES];
+}
+
 + (void)trigger_cpp_runtimeException
 {
     trigger_cpp();
@@ -134,6 +142,16 @@ NSString *const KSCrashNSExceptionStacktraceFuncName = @"exceptionWithStacktrace
 + (void)trigger_signal_abort
 {
     abort();  // This will raise a SIGABRT signal
+}
+
++ (void)trigger_user_nonfatal
+{
+    trigger_user_nonfatal();
+}
+
++ (void)trigger_user_fatal
+{
+    trigger_user_fatal();
 }
 
 + (void)trigger_other_manyThreads
@@ -195,7 +213,7 @@ NSString *const KSCrashNSExceptionStacktraceFuncName = @"exceptionWithStacktrace
 }
 + (void)trigger_multiple_mach_user
 {
-    TRIGGER_MULTIPLE(mach, user);
+    TRIGGER_MULTIPLE(mach, user_nonfatal);
 }
 
 + (void)trigger_multiple_signal_mach
@@ -216,7 +234,7 @@ NSString *const KSCrashNSExceptionStacktraceFuncName = @"exceptionWithStacktrace
 }
 + (void)trigger_multiple_signal_user
 {
-    TRIGGER_MULTIPLE(signal, user);
+    TRIGGER_MULTIPLE(signal, user_nonfatal);
 }
 
 + (void)trigger_multiple_cpp_mach
@@ -237,7 +255,7 @@ NSString *const KSCrashNSExceptionStacktraceFuncName = @"exceptionWithStacktrace
 }
 + (void)trigger_multiple_cpp_user
 {
-    TRIGGER_MULTIPLE(cpp, user);
+    TRIGGER_MULTIPLE(cpp, user_nonfatal);
 }
 
 + (void)trigger_multiple_ns_mach
@@ -258,28 +276,28 @@ NSString *const KSCrashNSExceptionStacktraceFuncName = @"exceptionWithStacktrace
 }
 + (void)trigger_multiple_ns_user
 {
-    TRIGGER_MULTIPLE(ns, user);
+    TRIGGER_MULTIPLE(ns, user_nonfatal);
 }
 
 + (void)trigger_multiple_user_mach
 {
-    TRIGGER_MULTIPLE(userfatal, mach);
+    TRIGGER_MULTIPLE(user_fatal, mach);
 }
 + (void)trigger_multiple_user_signal
 {
-    TRIGGER_MULTIPLE(userfatal, signal);
+    TRIGGER_MULTIPLE(user_fatal, signal);
 }
 + (void)trigger_multiple_user_cpp
 {
-    TRIGGER_MULTIPLE(userfatal, cpp);
+    TRIGGER_MULTIPLE(user_fatal, cpp);
 }
 + (void)trigger_multiple_user_ns
 {
-    TRIGGER_MULTIPLE(userfatal, ns);
+    TRIGGER_MULTIPLE(user_fatal, ns);
 }
 + (void)trigger_multiple_user_user
 {
-    TRIGGER_MULTIPLE(userfatal, user);
+    TRIGGER_MULTIPLE(user_fatal, user_nonfatal);
 }
 
 @end

--- a/Samples/Common/Sources/CrashTriggers/include/KSCrashTriggersList.h
+++ b/Samples/Common/Sources/CrashTriggers/include/KSCrashTriggersList.h
@@ -36,17 +36,21 @@ extern NSString *const KSCrashNSExceptionStacktraceFuncName;
     __PROCESS_GROUP(cpp, @"C++")                 \
     __PROCESS_GROUP(mach, @"Mach")               \
     __PROCESS_GROUP(signal, @"Signal")           \
+    __PROCESS_GROUP(user, @"User")               \
     __PROCESS_GROUP(multiple, @"Multiple")       \
     __PROCESS_GROUP(other, @"Other")
 
 #define __ALL_TRIGGERS                                                           \
     __PROCESS_TRIGGER(nsException, genericNSException, @"Generic NSException")   \
     __PROCESS_TRIGGER(nsException, nsArrayOutOfBounds, @"NSArray out-of-bounds") \
+    __PROCESS_TRIGGER(nsException, user, @"User reported NSException")           \
     __PROCESS_TRIGGER(cpp, runtimeException, @"Runtime Exception")               \
     __PROCESS_TRIGGER(mach, badAccess, @"EXC_BAD_ACCESS (SIGSEGV)")              \
     __PROCESS_TRIGGER(mach, busError, @"EXC_BAD_ACCESS (SIGBUS)")                \
     __PROCESS_TRIGGER(mach, illegalInstruction, @"EXC_BAD_INSTRUCTION")          \
     __PROCESS_TRIGGER(signal, abort, @"Abort")                                   \
+    __PROCESS_TRIGGER(user, nonfatal, @"Nonfatal")                               \
+    __PROCESS_TRIGGER(user, fatal, @"Fatal")                                     \
     __PROCESS_TRIGGER(multiple, mach_mach, @"Mach + Mach")                       \
     __PROCESS_TRIGGER(multiple, mach_signal, @"Mach + Signal")                   \
     __PROCESS_TRIGGER(multiple, mach_cpp, @"Mach + CPP")                         \


### PR DESCRIPTION
This fixes the recent WatchOS test breakage.
