### PR TITLE
Expose an intermediate struct to the user rather than our internal struct

### DIFF
--- a/Samples/Common/Sources/CrashCallback/CrashCallback.m
+++ b/Samples/Common/Sources/CrashCallback/CrashCallback.m
@@ -9,15 +9,15 @@
 #import <stdio.h>
 #import "KSCrashC.h"
 
-static void (^g_integrationTestCrashCallback)(KSCrash_ExceptionHandlingPolicy policy, const struct KSCrashReportWriter * _Nonnull writer) =
-^void (KSCrash_ExceptionHandlingPolicy policy, const struct KSCrashReportWriter * _Nonnull writer) {
+static void (^g_integrationTestReportWritingCallback)(const KSCrash_ExceptionHandlingPlan *const plan, const struct KSCrashReportWriter * _Nonnull writer) =
+^void (const KSCrash_ExceptionHandlingPlan *const plan, const struct KSCrashReportWriter * _Nonnull writer) {
     // Do nothing by default
 };
 
-void integrationTestCrashNotifyCallback(KSCrash_ExceptionHandlingPolicy policy, const struct KSCrashReportWriter * _Nonnull writer) {
-    g_integrationTestCrashCallback(policy, writer);
+void integrationTestReportWritingCallback(const KSCrash_ExceptionHandlingPlan *const plan, const struct KSCrashReportWriter * _Nonnull writer) {
+    g_integrationTestReportWritingCallback(plan, writer);
 }
 
-void setIntegrationTestCrashNotifyImplementation(void (^implementation)(KSCrash_ExceptionHandlingPolicy policy, const struct KSCrashReportWriter * _Nonnull writer)) {
-    g_integrationTestCrashCallback = implementation;
+void setIntegrationTestReportWritingImplementation(void (^implementation)(const KSCrash_ExceptionHandlingPlan *const plan, const struct KSCrashReportWriter * _Nonnull writer)) {
+    g_integrationTestReportWritingCallback = implementation;
 }

--- a/Samples/Common/Sources/CrashCallback/include/CrashCallback.h
+++ b/Samples/Common/Sources/CrashCallback/include/CrashCallback.h
@@ -7,16 +7,16 @@
 
 #pragma once
 
-#include "KSCrashExceptionHandlingPolicy.h"
+#include "KSCrashExceptionHandlingPlan.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 struct KSCrashReportWriter;
-void integrationTestCrashNotifyCallback(KSCrash_ExceptionHandlingPolicy policy, const struct KSCrashReportWriter * _Nonnull writer);
+void integrationTestReportWritingCallback(const KSCrash_ExceptionHandlingPlan *const _Nonnull plan, const struct KSCrashReportWriter * _Nonnull writer);
 
-void setIntegrationTestCrashNotifyImplementation(void (^ _Nonnull implementation)(KSCrash_ExceptionHandlingPolicy policy, const struct KSCrashReportWriter * _Nonnull writer));
+void setIntegrationTestReportWritingImplementation(void (^ _Nonnull implementation)(const KSCrash_ExceptionHandlingPlan *const _Nonnull plan, const struct KSCrashReportWriter * _Nonnull writer));
 
 #ifdef __cplusplus
 }

--- a/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
+++ b/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
@@ -186,13 +186,13 @@ NSString *const KSCrashNSExceptionStacktraceFuncName = @"exceptionWithStacktrace
     [self trigger_other_stackOverflow];
 }
 
-#define TRIGGER_MULTIPLE(TYPE_A, TYPE_B)                                                      \
-    setIntegrationTestCrashNotifyImplementation(                                              \
-        ^(KSCrash_ExceptionHandlingPolicy policy, const struct KSCrashReportWriter *writer) { \
-            if (!policy.crashedDuringExceptionHandling) {                                     \
-                trigger_##TYPE_B();                                                           \
-            }                                                                                 \
-        });                                                                                   \
+#define TRIGGER_MULTIPLE(TYPE_A, TYPE_B)                                                               \
+    setIntegrationTestReportWritingImplementation(                                                     \
+        ^(const KSCrash_ExceptionHandlingPlan *const plan, const struct KSCrashReportWriter *writer) { \
+            if (!plan->crashedDuringExceptionHandling) {                                               \
+                trigger_##TYPE_B();                                                                    \
+            }                                                                                          \
+        });                                                                                            \
     trigger_##TYPE_A()
 
 + (void)trigger_multiple_mach_mach

--- a/Samples/Common/Sources/LibraryBridge/InstallBridge.swift
+++ b/Samples/Common/Sources/LibraryBridge/InstallBridge.swift
@@ -86,7 +86,8 @@ public class InstallBridge: ObservableObject {
             writer.pointee.beginObject(writer, "policy")
             writer.pointee.addBooleanElement(writer, "shouldExitImmediately", policy.shouldExitImmediately != 0)
             writer.pointee.addBooleanElement(writer, "isFatal", policy.isFatal != 0)
-            writer.pointee.addBooleanElement(writer, "requiresAsyncSafety", policy.requiresAsyncSafety != 0)
+            writer.pointee.addBooleanElement(writer, "requiresAsyncSafetyAlways", policy.requiresAsyncSafetyAlways != 0)
+            writer.pointee.addBooleanElement(writer, "requiresAsyncSafetyToRecordThreads", policy.requiresAsyncSafetyToRecordThreads != 0)
             writer.pointee.addBooleanElement(
                 writer, "crashedDuringExceptionHandling", policy.crashedDuringExceptionHandling != 0)
             writer.pointee.addBooleanElement(writer, "shouldRecordThreads", policy.shouldRecordThreads != 0)

--- a/Samples/Common/Sources/LibraryBridge/InstallBridge.swift
+++ b/Samples/Common/Sources/LibraryBridge/InstallBridge.swift
@@ -81,21 +81,19 @@ public class InstallBridge: ObservableObject {
         // Example of setting a crash notify callback from Swift.
         // To see this in action, comment out the line: "config.crashNotifyCallbackWithPolicy = integrationTestCrashNotifyCallback"
         // Then tap "Install", "Report", "Log Raw to Console" in the sample app to see a crash report via the logs.
-        let cb: @convention(c) (ExceptionHandlingPolicy, UnsafePointer<ReportWriter>) -> Void = {
-            policy, writer in
-            writer.pointee.beginObject(writer, "policy")
-            writer.pointee.addBooleanElement(writer, "shouldExitImmediately", policy.shouldExitImmediately != 0)
-            writer.pointee.addBooleanElement(writer, "isFatal", policy.isFatal != 0)
-            writer.pointee.addBooleanElement(writer, "requiresAsyncSafetyAlways", policy.requiresAsyncSafetyAlways != 0)
-            writer.pointee.addBooleanElement(writer, "requiresAsyncSafetyToRecordThreads", policy.requiresAsyncSafetyToRecordThreads != 0)
+        let cb: @convention(c) (UnsafePointer<ExceptionHandlingPlan>, UnsafePointer<ReportWriter>) -> Void = {
+            plan, writer in
+            writer.pointee.beginObject(writer, "plan")
+            writer.pointee.addBooleanElement(writer, "isFatal", plan.pointee.isFatal)
+            writer.pointee.addBooleanElement(writer, "requiresAsyncSafety", plan.pointee.requiresAsyncSafety)
             writer.pointee.addBooleanElement(
-                writer, "crashedDuringExceptionHandling", policy.crashedDuringExceptionHandling != 0)
-            writer.pointee.addBooleanElement(writer, "shouldRecordThreads", policy.shouldRecordThreads != 0)
+                writer, "crashedDuringExceptionHandling", plan.pointee.crashedDuringExceptionHandling)
+            writer.pointee.addBooleanElement(writer, "shouldRecordThreads", plan.pointee.shouldRecordThreads)
             writer.pointee.endContainer(writer)
         }
-        config.crashNotifyCallbackWithPolicy = cb
+        config.crashNotifyCallbackWithPlan = cb
 
-        config.crashNotifyCallbackWithPolicy = integrationTestCrashNotifyCallback
+        config.crashNotifyCallbackWithPlan = integrationTestReportWritingCallback
 
         $basePath
             .removeDuplicates()

--- a/Sources/KSCrashInstallations/KSCrashInstallation.m
+++ b/Sources/KSCrashInstallations/KSCrashInstallation.m
@@ -52,7 +52,7 @@ typedef struct {
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     KSReportWriteCallback userCrashCallback;
 #pragma clang diagnostic pop
-    KSReportWriteCallbackWithPolicy userCrashCallbackWithPolicy;
+    KSReportWriteCallbackWithPlan userCrashCallbackWithPlan;
     int reportFieldsCount;
     ReportField *reportFields[0];
 } CrashHandlerData;
@@ -241,21 +241,21 @@ static CrashHandlerData *g_crashHandlerData;
 }
 #pragma clang diagnostic pop
 
-- (KSReportWriteCallbackWithPolicy)onCrashWithPolicy
+- (KSReportWriteCallbackWithPlan)onCrashWithPlan
 {
     @synchronized(self) {
-        return self.crashHandlerData->userCrashCallbackWithPolicy;
+        return self.crashHandlerData->userCrashCallbackWithPlan;
     }
 }
 
-- (void)setOnCrashWithPolicy:(KSReportWriteCallbackWithPolicy)onCrash
+- (void)setOnCrashWithPlan:(KSReportWriteCallbackWithPlan)onCrash
 {
     @synchronized(self) {
-        self.crashHandlerData->userCrashCallbackWithPolicy = onCrash;
+        self.crashHandlerData->userCrashCallbackWithPlan = onCrash;
     }
 }
 
-static void onCrash(const KSCrash_ExceptionHandlingPolicy policy, const struct KSCrashReportWriter *_Nonnull writer)
+static void onCrash(const KSCrash_ExceptionHandlingPlan *plan, const struct KSCrashReportWriter *_Nonnull writer)
 {
     CrashHandlerData *crashHandlerData = g_crashHandlerData;
     if (crashHandlerData == NULL) {
@@ -268,8 +268,8 @@ static void onCrash(const KSCrash_ExceptionHandlingPolicy policy, const struct K
         }
     }
 
-    if (crashHandlerData->userCrashCallbackWithPolicy != NULL) {
-        crashHandlerData->userCrashCallbackWithPolicy(policy, writer);
+    if (crashHandlerData->userCrashCallbackWithPlan != NULL) {
+        crashHandlerData->userCrashCallbackWithPlan(plan, writer);
     } else if (crashHandlerData->userCrashCallback != NULL) {
         // TODO: Remove in 3.0 - Deprecated callback invocation for backward compatibility
         crashHandlerData->userCrashCallback(writer);
@@ -282,7 +282,7 @@ static void onCrash(const KSCrash_ExceptionHandlingPolicy policy, const struct K
     @synchronized(handler) {
         g_crashHandlerData = self.crashHandlerData;
 
-        configuration.crashNotifyCallbackWithPolicy = onCrash;
+        configuration.crashNotifyCallbackWithPlan = onCrash;
 
         NSError *installError = nil;
         BOOL success = [handler installWithConfiguration:configuration error:&installError];

--- a/Sources/KSCrashInstallations/include/KSCrashInstallation.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallation.h
@@ -47,28 +47,28 @@ NS_SWIFT_NAME(CrashInstallation)
 /** C Function to call during a crash report to give the callee an opportunity to
  * add to the report. NULL = ignore (DEPRECATED).
  *
- * @deprecated Use `onCrashWithPolicy` for async-safety awareness (since v2.4.0).
- * This callback does not receive policy information and may not handle crash
+ * @deprecated Use `onCrashWithPlan` for async-safety awareness (since v2.4.0).
+ * This callback does not receive plan information and may not handle crash
  * scenarios safely.
  *
  * WARNING: Only call async-safe functions from this function! DO NOT call
  * Swift/Objective-C methods!!!
  */
 @property(atomic, readwrite, assign, nullable) KSReportWriteCallback onCrash
-    __attribute__((deprecated("Use `onCrashWithPolicy` for async-safety awareness (since v2.4.0).")));
+    __attribute__((deprecated("Use `onCrashWithPlan` for async-safety awareness (since v2.4.0).")));
 
 /** C Function to call during a crash report to give the callee an opportunity to
  * add to the report. NULL = ignore.
  *
- * The policy parameter provides crucial information about the crash context and
+ * The plan parameter provides crucial information about the crash context and
  * safety constraints that must be observed within the callback.
  *
- * @see KSCrash_ExceptionHandlingPolicy
+ * @see KSCrash_ExceptionHandlingPlan
  *
- * WARNING: Only call async-safe functions from this function when `kscexc_requiresAsyncSafety(policy)` is true!
- * DO NOT call Swift/Objective-C methods unless policy allows it!!!
+ * WARNING: Only call async-safe functions from this function when `requiresAsyncSafety` is true!
+ * DO NOT call Swift/Objective-C methods unless the plan allows it!!!
  */
-@property(atomic, readwrite, assign, nullable) KSReportWriteCallbackWithPolicy onCrashWithPolicy;
+@property(atomic, readwrite, assign, nullable) KSReportWriteCallbackWithPlan onCrashWithPlan;
 
 /** Flag for disabling built-in demangling pre-filter.
  * If enabled an additional `KSCrashReportFilterDemangle` filter will be applied first.

--- a/Sources/KSCrashInstallations/include/KSCrashInstallation.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallation.h
@@ -65,7 +65,7 @@ NS_SWIFT_NAME(CrashInstallation)
  *
  * @see KSCrash_ExceptionHandlingPolicy
  *
- * WARNING: Only call async-safe functions from this function when policy.requiresAsyncSafety is true!
+ * WARNING: Only call async-safe functions from this function when `kscexc_requiresAsyncSafety(policy)` is true!
  * DO NOT call Swift/Objective-C methods unless policy allows it!!!
  */
 @property(atomic, readwrite, assign, nullable) KSReportWriteCallbackWithPolicy onCrashWithPolicy;

--- a/Sources/KSCrashRecording/KSCrashConfiguration.m
+++ b/Sources/KSCrashRecording/KSCrashConfiguration.m
@@ -105,8 +105,8 @@
         config.reportWrittenCallback = (KSReportWrittenCallback)imp_implementationWithBlock(self.reportWrittenCallback);
     }
 #pragma clang diagnostic pop
-    config.crashNotifyCallbackWithPolicy = self.crashNotifyCallbackWithPolicy;
-    config.reportWrittenCallbackWithPolicy = self.reportWrittenCallbackWithPolicy;
+    config.crashNotifyCallbackWithPlan = self.crashNotifyCallbackWithPlan;
+    config.reportWrittenCallbackWithPlan = self.reportWrittenCallbackWithPlan;
     config.addConsoleLogToReport = self.addConsoleLogToReport;
     config.printPreviousLogOnStartup = self.printPreviousLogOnStartup;
     config.enableSwapCxaThrow = self.enableSwapCxaThrow;
@@ -164,8 +164,8 @@
     copy.crashNotifyCallback = self.crashNotifyCallback;
     copy.reportWrittenCallback = self.reportWrittenCallback;
 #pragma clang diagnostic pop
-    copy.crashNotifyCallbackWithPolicy = self.crashNotifyCallbackWithPolicy;
-    copy.reportWrittenCallbackWithPolicy = self.reportWrittenCallbackWithPolicy;
+    copy.crashNotifyCallbackWithPlan = self.crashNotifyCallbackWithPlan;
+    copy.reportWrittenCallbackWithPlan = self.reportWrittenCallbackWithPlan;
     copy.eventNotifyCallback = self.eventNotifyCallback;
     copy.addConsoleLogToReport = self.addConsoleLogToReport;
     copy.printPreviousLogOnStartup = self.printPreviousLogOnStartup;

--- a/Sources/KSCrashRecording/KSCrashReportC.c
+++ b/Sources/KSCrashRecording/KSCrashReportC.c
@@ -1625,11 +1625,10 @@ void kscrashreport_writeStandardReport(KSCrash_MonitorContext *const monitorCont
                 writeAllThreads(writer, KSCrashField_Threads, monitorContext, g_introspectionRules.enabled);
                 ksfu_flushBufferedWriter(&bufferedWriter);
                 if (monitorContext->suspendedThreadsCount > 0) {
-                    // Special case: If we only needed to suspend the environment to record the threads
-                    // (requiresAsyncSafety == 1), then we can safely resume now. This gives any remaining callbacks
-                    // more freedom.
-                    monitorContext->currentPolicy.requiresAsyncSafety--;
-                    if (monitorContext->currentPolicy.requiresAsyncSafety == 0) {
+                    // Special case: If we only needed to suspend the environment to record the threads, then we can
+                    // safely resume now. This gives any remaining callbacks more freedom.
+                    monitorContext->currentPolicy.requiresAsyncSafetyToRecordThreads = false;
+                    if (!kscexc_requiresAsyncSafety(monitorContext->currentPolicy)) {
                         ksmc_resumeEnvironment(&monitorContext->suspendedThreads,
                                                &monitorContext->suspendedThreadsCount);
                     }

--- a/Sources/KSCrashRecording/KSCrashReportC.c
+++ b/Sources/KSCrashRecording/KSCrashReportC.c
@@ -28,6 +28,7 @@
 
 #include "KSBinaryImageCache.h"
 #include "KSCPU.h"
+#include "KSCrashExceptionHandlingPlan+Private.h"
 #include "KSCrashMonitorHelper.h"
 #include "KSCrashMonitor_AppState.h"
 #include "KSCrashMonitor_CPPException.h"

--- a/Sources/KSCrashRecording/KSCrashReportC.h
+++ b/Sources/KSCrashRecording/KSCrashReportC.h
@@ -79,7 +79,7 @@ void kscrashreport_setDoNotIntrospectClasses(const char **doNotIntrospectClasses
  *
  * @param userSectionWriteCallback The user section write callback.
  */
-void kscrashreport_setUserSectionWriteCallback(const KSReportWriteCallbackWithPolicy userSectionWriteCallback);
+void kscrashreport_setUserSectionWriteCallback(const KSReportWriteCallbackWithPlan userSectionWriteCallback);
 
 // ============================================================================
 #pragma mark - Main API -

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
@@ -125,12 +125,11 @@ static void CPPExceptionTerminate(void)
     if (name == NULL || strcmp(name, "NSException") != 0) {
         thread_t thisThread = (thread_t)ksthread_self();
         // This requires async-safety because the environment is suspended.
-        KSCrash_MonitorContext *crashContext =
-            g_callbacks.notify(thisThread, (KSCrash_ExceptionHandlingPolicy) { .requiresAsyncSafetyAlways = true,
-                                                                               .isFatal = true,
-                                                                               .shouldRecordThreads = true,
-                                                                               .shouldWriteReport = true });
-        if (crashContext->currentPolicy.shouldExitImmediately) {
+        KSCrash_MonitorContext *crashContext = g_callbacks.notify(
+            thisThread,
+            (KSCrash_ExceptionHandlingRequirements) {
+                .asyncSafety = true, .isFatal = true, .shouldRecordThreads = true, .shouldWriteReport = true });
+        if (crashContext->requirements.shouldExitImmediately) {
             goto exit_immediately;
         }
 

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
@@ -125,10 +125,11 @@ static void CPPExceptionTerminate(void)
     if (name == NULL || strcmp(name, "NSException") != 0) {
         thread_t thisThread = (thread_t)ksthread_self();
         // This requires async-safety because the environment is suspended.
-        KSCrash_MonitorContext *crashContext = g_callbacks.notify(
-            thisThread,
-            (KSCrash_ExceptionHandlingPolicy) {
-                .requiresAsyncSafety = 1, .isFatal = true, .shouldRecordThreads = true, .shouldWriteReport = true });
+        KSCrash_MonitorContext *crashContext =
+            g_callbacks.notify(thisThread, (KSCrash_ExceptionHandlingPolicy) { .requiresAsyncSafetyAlways = true,
+                                                                               .isFatal = true,
+                                                                               .shouldRecordThreads = true,
+                                                                               .shouldWriteReport = true });
         if (crashContext->currentPolicy.shouldExitImmediately) {
             goto exit_immediately;
         }

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Deadlock.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Deadlock.m
@@ -105,12 +105,10 @@ static KSCrash_ExceptionHandlerCallbacks g_callbacks;
 {
     thread_t thisThread = (thread_t)ksthread_self();
     // This requires async-safety because the environment is suspended.
-    KSCrash_MonitorContext *crashContext =
-        g_callbacks.notify(thisThread, (KSCrash_ExceptionHandlingPolicy) { .requiresAsyncSafetyAlways = true,
-                                                                           .isFatal = true,
-                                                                           .shouldRecordThreads = true,
-                                                                           .shouldWriteReport = true });
-    if (crashContext->currentPolicy.shouldExitImmediately) {
+    KSCrash_MonitorContext *crashContext = g_callbacks.notify(
+        thisThread, (KSCrash_ExceptionHandlingRequirements) {
+                        .asyncSafety = true, .isFatal = true, .shouldRecordThreads = true, .shouldWriteReport = true });
+    if (crashContext->requirements.shouldExitImmediately) {
         goto exit_immediately;
     }
 

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Deadlock.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Deadlock.m
@@ -105,10 +105,11 @@ static KSCrash_ExceptionHandlerCallbacks g_callbacks;
 {
     thread_t thisThread = (thread_t)ksthread_self();
     // This requires async-safety because the environment is suspended.
-    KSCrash_MonitorContext *crashContext = g_callbacks.notify(
-        thisThread,
-        (KSCrash_ExceptionHandlingPolicy) {
-            .requiresAsyncSafety = 1, .isFatal = true, .shouldRecordThreads = true, .shouldWriteReport = true });
+    KSCrash_MonitorContext *crashContext =
+        g_callbacks.notify(thisThread, (KSCrash_ExceptionHandlingPolicy) { .requiresAsyncSafetyAlways = true,
+                                                                           .isFatal = true,
+                                                                           .shouldRecordThreads = true,
+                                                                           .shouldWriteReport = true });
     if (crashContext->currentPolicy.shouldExitImmediately) {
         goto exit_immediately;
     }

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_MachException.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_MachException.c
@@ -410,11 +410,10 @@ static void sendExceptionReply(ExceptionContext *ctx, bool exceptionPortsCanHand
 static void handleException(ExceptionContext *exceptionCtx)
 {
     KSCrash_MonitorContext *monitorCtx = g_state.callbacks.notify(
-        exceptionCtx->request->thread.name, (KSCrash_ExceptionHandlingPolicy) { .requiresAsyncSafetyAlways = true,
-                                                                                .isFatal = true,
-                                                                                .shouldRecordThreads = true,
-                                                                                .shouldWriteReport = true });
-    if (monitorCtx->currentPolicy.shouldExitImmediately) {
+        exceptionCtx->request->thread.name,
+        (KSCrash_ExceptionHandlingRequirements) {
+            .asyncSafety = true, .isFatal = true, .shouldRecordThreads = true, .shouldWriteReport = true });
+    if (monitorCtx->requirements.shouldExitImmediately) {
         KSLOG_DEBUG("Thread %s: Should exit immediately, so returning", exceptionCtx->threadName);
         return;
     }

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_MachException.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_MachException.c
@@ -410,9 +410,10 @@ static void sendExceptionReply(ExceptionContext *ctx, bool exceptionPortsCanHand
 static void handleException(ExceptionContext *exceptionCtx)
 {
     KSCrash_MonitorContext *monitorCtx = g_state.callbacks.notify(
-        exceptionCtx->request->thread.name,
-        (KSCrash_ExceptionHandlingPolicy) {
-            .requiresAsyncSafety = 1, .isFatal = true, .shouldRecordThreads = true, .shouldWriteReport = true });
+        exceptionCtx->request->thread.name, (KSCrash_ExceptionHandlingPolicy) { .requiresAsyncSafetyAlways = true,
+                                                                                .isFatal = true,
+                                                                                .shouldRecordThreads = true,
+                                                                                .shouldWriteReport = true });
     if (monitorCtx->currentPolicy.shouldExitImmediately) {
         KSLOG_DEBUG("Thread %s: Should exit immediately, so returning", exceptionCtx->threadName);
         return;

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
@@ -283,7 +283,7 @@ static NSURL *kscm_memory_oom_breadcrumb_URL(void)
 
 static void addContextualInfoToEvent(KSCrash_MonitorContext *eventContext)
 {
-    bool asyncSafeOnly = eventContext->currentPolicy.requiresAsyncSafety;
+    bool asyncSafeOnly = kscexc_requiresAsyncSafety(eventContext->currentPolicy);
 
     // we'll use this when reading this back on the next run
     // to know if an OOM is even possible.
@@ -535,10 +535,11 @@ static void ksmemory_write_possible_oom(void)
     const char *reportPath = reportURL.path.UTF8String;
 
     thread_t thisThread = (thread_t)ksthread_self();
-    KSCrash_MonitorContext *ctx = g_callbacks.notify(
-        thisThread,
-        (KSCrash_ExceptionHandlingPolicy) {
-            .requiresAsyncSafety = false, .isFatal = false, .shouldRecordThreads = false, .shouldWriteReport = true });
+    KSCrash_MonitorContext *ctx =
+        g_callbacks.notify(thisThread, (KSCrash_ExceptionHandlingPolicy) { .requiresAsyncSafetyAlways = false,
+                                                                           .isFatal = false,
+                                                                           .shouldRecordThreads = false,
+                                                                           .shouldWriteReport = true });
     if (ctx->currentPolicy.shouldExitImmediately) {
         return;
     }

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
@@ -283,7 +283,7 @@ static NSURL *kscm_memory_oom_breadcrumb_URL(void)
 
 static void addContextualInfoToEvent(KSCrash_MonitorContext *eventContext)
 {
-    bool asyncSafeOnly = kscexc_requiresAsyncSafety(eventContext->currentPolicy);
+    bool asyncSafeOnly = kscexc_requiresAsyncSafety(eventContext->requirements);
 
     // we'll use this when reading this back on the next run
     // to know if an OOM is even possible.
@@ -291,10 +291,10 @@ static void addContextualInfoToEvent(KSCrash_MonitorContext *eventContext)
         // since we're in a singal or something that can only
         // use async safe functions, we can't lock.
         // It's "ok" though, since no other threads should be running.
-        g_memory->fatal = eventContext->currentPolicy.isFatal;
+        g_memory->fatal = eventContext->requirements.isFatal;
     } else {
         _ks_memory_update(^(KSCrash_Memory *mem) {
-            mem->fatal = eventContext->currentPolicy.isFatal;
+            mem->fatal = eventContext->requirements.isFatal;
         });
     }
 
@@ -535,12 +535,11 @@ static void ksmemory_write_possible_oom(void)
     const char *reportPath = reportURL.path.UTF8String;
 
     thread_t thisThread = (thread_t)ksthread_self();
-    KSCrash_MonitorContext *ctx =
-        g_callbacks.notify(thisThread, (KSCrash_ExceptionHandlingPolicy) { .requiresAsyncSafetyAlways = false,
-                                                                           .isFatal = false,
-                                                                           .shouldRecordThreads = false,
-                                                                           .shouldWriteReport = true });
-    if (ctx->currentPolicy.shouldExitImmediately) {
+    KSCrash_MonitorContext *ctx = g_callbacks.notify(
+        thisThread,
+        (KSCrash_ExceptionHandlingRequirements) {
+            .asyncSafety = false, .isFatal = false, .shouldRecordThreads = false, .shouldWriteReport = true });
+    if (ctx->requirements.shouldExitImmediately) {
         return;
     }
 

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException.m
@@ -118,7 +118,7 @@ static KS_NOINLINE void handleException(NSException *exception, BOOL isUserRepor
 
         // Now start exception handling
         KSCrash_MonitorContext *crashContext = g_callbacks.notify(
-            thisThread, (KSCrash_ExceptionHandlingPolicy) { .requiresAsyncSafety = 0,
+            thisThread, (KSCrash_ExceptionHandlingPolicy) { .requiresAsyncSafetyAlways = false,
                                                             // User-reported exceptions are not considered fatal.
                                                             .isFatal = !isUserReported,
                                                             .shouldRecordThreads = logAllThreads != NO,

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException.m
@@ -118,12 +118,12 @@ static KS_NOINLINE void handleException(NSException *exception, BOOL isUserRepor
 
         // Now start exception handling
         KSCrash_MonitorContext *crashContext = g_callbacks.notify(
-            thisThread, (KSCrash_ExceptionHandlingPolicy) { .requiresAsyncSafetyAlways = false,
-                                                            // User-reported exceptions are not considered fatal.
-                                                            .isFatal = !isUserReported,
-                                                            .shouldRecordThreads = logAllThreads != NO,
-                                                            .shouldWriteReport = true });
-        if (crashContext->currentPolicy.shouldExitImmediately) {
+            thisThread, (KSCrash_ExceptionHandlingRequirements) { .asyncSafety = false,
+                                                                  // User-reported exceptions are not considered fatal.
+                                                                  .isFatal = !isUserReported,
+                                                                  .shouldRecordThreads = logAllThreads != NO,
+                                                                  .shouldWriteReport = true });
+        if (crashContext->requirements.shouldExitImmediately) {
             goto exit_immediately;
         }
 

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.c
@@ -93,10 +93,11 @@ static void handleSignal(int sigNum, siginfo_t *signalInfo, void *userContext)
     KSLOG_DEBUG("Trapped signal %d", sigNum);
     if (g_isEnabled && shouldHandleSignal(sigNum)) {
         thread_t thisThread = (thread_t)ksthread_self();
-        KSCrash_MonitorContext *crashContext = g_callbacks.notify(
-            thisThread,
-            (KSCrash_ExceptionHandlingPolicy) {
-                .requiresAsyncSafety = 1, .isFatal = true, .shouldRecordThreads = true, .shouldWriteReport = true });
+        KSCrash_MonitorContext *crashContext =
+            g_callbacks.notify(thisThread, (KSCrash_ExceptionHandlingPolicy) { .requiresAsyncSafetyAlways = true,
+                                                                               .isFatal = true,
+                                                                               .shouldRecordThreads = true,
+                                                                               .shouldWriteReport = true });
         if (crashContext->currentPolicy.shouldExitImmediately) {
             goto exit_immediately;
         }

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.c
@@ -93,12 +93,11 @@ static void handleSignal(int sigNum, siginfo_t *signalInfo, void *userContext)
     KSLOG_DEBUG("Trapped signal %d", sigNum);
     if (g_isEnabled && shouldHandleSignal(sigNum)) {
         thread_t thisThread = (thread_t)ksthread_self();
-        KSCrash_MonitorContext *crashContext =
-            g_callbacks.notify(thisThread, (KSCrash_ExceptionHandlingPolicy) { .requiresAsyncSafetyAlways = true,
-                                                                               .isFatal = true,
-                                                                               .shouldRecordThreads = true,
-                                                                               .shouldWriteReport = true });
-        if (crashContext->currentPolicy.shouldExitImmediately) {
+        KSCrash_MonitorContext *crashContext = g_callbacks.notify(
+            thisThread,
+            (KSCrash_ExceptionHandlingRequirements) {
+                .asyncSafety = true, .isFatal = true, .shouldRecordThreads = true, .shouldWriteReport = true });
+        if (crashContext->requirements.shouldExitImmediately) {
             goto exit_immediately;
         }
 

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_User.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_User.c
@@ -51,12 +51,12 @@ void kscm_reportUserException(const char *name, const char *reason, const char *
         KSLOG_WARN("User-reported exception monitor is not installed. Exception has not been recorded.");
     } else {
         thread_t thisThread = (thread_t)ksthread_self();
-        KSCrash_MonitorContext *ctx =
-            g_callbacks.notify(thisThread, (KSCrash_ExceptionHandlingPolicy) { .requiresAsyncSafetyAlways = false,
-                                                                               .isFatal = terminateProgram,
-                                                                               .shouldRecordThreads = logAllThreads,
-                                                                               .shouldWriteReport = true });
-        if (ctx->currentPolicy.shouldExitImmediately) {
+        KSCrash_MonitorContext *ctx = g_callbacks.notify(
+            thisThread, (KSCrash_ExceptionHandlingRequirements) { .asyncSafety = false,
+                                                                  .isFatal = terminateProgram,
+                                                                  .shouldRecordThreads = logAllThreads,
+                                                                  .shouldWriteReport = true });
+        if (ctx->requirements.shouldExitImmediately) {
             goto exit_immediately;
         }
 

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_User.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_User.c
@@ -52,7 +52,7 @@ void kscm_reportUserException(const char *name, const char *reason, const char *
     } else {
         thread_t thisThread = (thread_t)ksthread_self();
         KSCrash_MonitorContext *ctx =
-            g_callbacks.notify(thisThread, (KSCrash_ExceptionHandlingPolicy) { .requiresAsyncSafety = 0,
+            g_callbacks.notify(thisThread, (KSCrash_ExceptionHandlingPolicy) { .requiresAsyncSafetyAlways = false,
                                                                                .isFatal = terminateProgram,
                                                                                .shouldRecordThreads = logAllThreads,
                                                                                .shouldWriteReport = true });

--- a/Sources/KSCrashRecording/include/KSCrashCConfiguration.h
+++ b/Sources/KSCrashRecording/include/KSCrashCConfiguration.h
@@ -30,7 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "KSCrashExceptionHandlingPolicy.h"
+#include "KSCrashExceptionHandlingPlan.h"
 #include "KSCrashMonitorContext.h"
 #include "KSCrashMonitorType.h"
 #include "KSCrashNamespace.h"
@@ -164,8 +164,8 @@ typedef struct {
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     /** Callback to invoke upon a crash (DEPRECATED).
      *
-     * @deprecated Use `crashNotifyCallbackWithPolicy` for async-safety awareness (since v2.4.0).
-     * This callback does not receive policy information and may not handle crash
+     * @deprecated Use `crashNotifyCallbackWithPlan` for async-safety awareness (since v2.4.0).
+     * This callback does not receive plan information and may not handle crash
      * scenarios safely.
      *
      * This function is called during the crash reporting process, providing an opportunity
@@ -175,15 +175,15 @@ typedef struct {
      * **Default**: NULL
      */
     KSReportWriteCallback crashNotifyCallback
-        __attribute__((deprecated("Use `crashNotifyCallbackWithPolicy` for async-safety awareness (since v2.4.0).")));
+        __attribute__((deprecated("Use `crashNotifyCallbackWithPlan` for async-safety awareness (since v2.4.0).")));
 #pragma clang diagnostic pop
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     /** Callback to invoke upon finishing writing a crash report (DEPRECATED).
      *
-     * @deprecated Use `reportWrittenCallbackWithPolicy` for async-safety awareness (since v2.4.0).
-     * This callback does not receive policy information and may not handle crash
+     * @deprecated Use `reportWrittenCallbackWithPlan` for async-safety awareness (since v2.4.0).
+     * This callback does not receive plan information and may not handle crash
      * scenarios safely.
      *
      * This function is called after a crash report has been written. It allows the caller
@@ -193,38 +193,41 @@ typedef struct {
      * **Default**: NULL
      */
     KSReportWrittenCallback reportWrittenCallback
-        __attribute__((deprecated("Use `reportWrittenCallbackWithPolicy` for async-safety awareness (since v2.4.0).")));
+        __attribute__((deprecated("Use `reportWrittenCallbackWithPlan` for async-safety awareness (since v2.4.0).")));
 #pragma clang diagnostic pop
 
     /** Callback to invoke upon a crash.
      *
      * This function is called during the crash reporting process, providing an opportunity
-     * to add additional information to the crash report. The `policy` parameter determines
-     * what can be safely done within the callback.
+     * to add additional information to the crash report.
      *
-     * @see KSCrash_ExceptionHandlingPolicy
+     * The `plan` parameter determines what can be safely done within the callback.
+     *
+     * @see KSCrash_ExceptionHandlingPlan
      *
      * **Default**: NULL
      */
-    KSReportWriteCallbackWithPolicy crashNotifyCallbackWithPolicy;
+    KSReportWriteCallbackWithPlan crashNotifyCallbackWithPlan;
 
     /** Callback to invoke upon finishing writing a crash report.
      *
      * This function is called after a crash report has been written. It allows the caller
-     * to react to the completion of the report. The `policy` parameter determines
-     * what can be safely done within the callback.
+     * to react to the completion of the report.
      *
-     * @see KSCrash_ExceptionHandlingPolicy
+     * The `plan` parameter determines what can be safely done within the callback.
+     *
+     * @see KSCrash_ExceptionHandlingPlan
      *
      * **Default**: NULL
      */
-    KSReportWrittenCallbackWithPolicy reportWrittenCallbackWithPolicy;
+    KSReportWrittenCallbackWithPlan reportWrittenCallbackWithPlan;
 
     /** Callback to invoke upon a crash before begining to process/write it.
      *
+     * The `plan` parameter can be modified.
+     *
      * This function is called during the crash reporting process, providing an opportunity
-     * to add additional information to the crash report, and stop the process from writting
-     * the report.
+     * to modify the plan for handling the crash.
      *
      * **Default**: NULL
      */
@@ -287,8 +290,8 @@ static inline KSCrashCConfiguration KSCrashCConfiguration_Default(void)
         .eventNotifyCallback = NULL,
         .reportWrittenCallback = NULL,
 #pragma clang diagnostic pop
-        .crashNotifyCallbackWithPolicy = NULL,
-        .reportWrittenCallbackWithPolicy = NULL,
+        .crashNotifyCallbackWithPlan = NULL,
+        .reportWrittenCallbackWithPlan = NULL,
         .addConsoleLogToReport = false,
         .printPreviousLogOnStartup = false,
         .enableSwapCxaThrow = true,

--- a/Sources/KSCrashRecording/include/KSCrashConfiguration.h
+++ b/Sources/KSCrashRecording/include/KSCrashConfiguration.h
@@ -26,7 +26,7 @@
 
 #import <Foundation/Foundation.h>
 #import "KSCrashCConfiguration.h"
-#import "KSCrashExceptionHandlingPolicy.h"
+#import "KSCrashExceptionHandlingPlan.h"
 #import "KSCrashMonitorType.h"
 #include "KSCrashNamespace.h"
 #import "KSCrashReportStore.h"
@@ -113,8 +113,8 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 /** Callback to invoke upon a crash (DEPRECATED).
  *
- * @deprecated Use `crashNotifyCallbackWithPolicy` for async-safety awareness (since v2.4.0).
- * This callback does not receive policy information and may not handle crash
+ * @deprecated Use `crashNotifyCallbackWithPlan` for async-safety awareness (since v2.4.0).
+ * This callback does not receive plan information and may not handle crash
  * scenarios safely (e.g., calling non-async-safe functions during signal handling).
  *
  * This function is called during the crash reporting process, providing an opportunity
@@ -123,15 +123,15 @@ NS_ASSUME_NONNULL_BEGIN
  * **Default**: NULL
  */
 @property(nonatomic, copy, nullable) void (^crashNotifyCallback)(const struct KSCrashReportWriter *writer)
-    __attribute__((deprecated("Use `crashNotifyCallbackWithPolicy` for async-safety awareness (since v2.4.0).")));
+    __attribute__((deprecated("Use `crashNotifyCallbackWithPlan` for async-safety awareness (since v2.4.0).")));
 #pragma clang diagnostic pop
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 /** Callback to invoke upon finishing writing a crash report (DEPRECATED).
  *
- * @deprecated Use `reportWrittenCallbackWithPolicy` for async-safety awareness (since v2.4.0).
- * This callback does not receive policy information and may not handle crash
+ * @deprecated Use `reportWrittenCallbackWithPlan` for async-safety awareness (since v2.4.0).
+ * This callback does not receive plan information and may not handle crash
  * scenarios safely.
  *
  * This function is called after a crash report has been written. It allows the caller
@@ -140,32 +140,32 @@ NS_ASSUME_NONNULL_BEGIN
  * **Default**: NULL
  */
 @property(nonatomic, copy, nullable) void (^reportWrittenCallback)(int64_t reportID)
-    __attribute__((deprecated("Use `reportWrittenCallbackWithPolicy` for async-safety awareness (since v2.4.0).")));
+    __attribute__((deprecated("Use `reportWrittenCallbackWithPlan` for async-safety awareness (since v2.4.0).")));
 #pragma clang diagnostic pop
 
 /** Callback to invoke upon a crash.
  *
  * This function is called during the crash reporting process, providing an opportunity
- * to add additional information to the crash report. The `policy` parameter determines
+ * to add additional information to the crash report. The `plan` parameter determines
  * what can be safely done within the callback.
  *
- * @see KSCrash_ExceptionHandlingPolicy
+ * @see KSCrash_ExceptionHandlingPlan
  *
  * **Default**: NULL
  */
-@property(nonatomic, nullable) KSReportWriteCallbackWithPolicy crashNotifyCallbackWithPolicy;
+@property(nonatomic, nullable) KSReportWriteCallbackWithPlan crashNotifyCallbackWithPlan;
 
 /** Callback to invoke upon finishing writing a crash report.
  *
  * This function is called after a crash report has been written. It allows the caller
- * to react to the completion of the report. The `policy` parameter determines
+ * to react to the completion of the report. The `plan` parameter determines
  * what can be safely done within the callback.
  *
- * @see KSCrash_ExceptionHandlingPolicy
+ * @see KSCrash_ExceptionHandlingPlan
  *
  * **Default**: NULL
  */
-@property(nonatomic, nullable) KSReportWrittenCallbackWithPolicy reportWrittenCallbackWithPolicy;
+@property(nonatomic, nullable) KSReportWrittenCallbackWithPlan reportWrittenCallbackWithPlan;
 
 /** Callback to invoke before writing a crash report.
  *

--- a/Sources/KSCrashRecording/include/KSCrashReportWriter.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportWriter.h
@@ -34,7 +34,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "KSCrashExceptionHandlingPolicy.h"
+#include "KSCrashExceptionHandlingPlan.h"
 #include "KSCrashMonitorContext.h"
 #include "KSCrashNamespace.h"
 
@@ -231,26 +231,26 @@ typedef struct KSCrashReportWriter {
 
 /** Callback type for when a crash report is being written (DEPRECATED).
  *
- * @deprecated Use `KSReportWriteCallbackWithPolicy` for async-safety awareness (since v2.4.0).
- * This callback does not receive policy information and may not handle crash
+ * @deprecated Use `KSReportWriteCallbackWithPlan` for async-safety awareness (since v2.4.0).
+ * This callback does not receive plan information and may not handle crash
  * scenarios safely.
  *
  * @param writer The report writer.
  */
 typedef void (*KSReportWriteCallback)(const KSCrashReportWriter *writer)
-    __attribute__((deprecated("Use `KSReportWriteCallbackWithPolicy` for async-safety awareness (since v2.4.0).")))
+    __attribute__((deprecated("Use `KSReportWriteCallbackWithPlan` for async-safety awareness (since v2.4.0).")))
     NS_SWIFT_UNAVAILABLE("Use Swift closures instead!");
 
 /** Callback type for when a crash report is finished writing (DEPRECATED).
  *
- * @deprecated Use `KSReportWrittenCallbackWithPolicy` for async-safety awareness (since v2.4.0).
- * This callback does not receive policy information and may not handle crash
+ * @deprecated Use `KSReportWrittenCallbackWithPlan` for async-safety awareness (since v2.4.0).
+ * This callback does not receive plan information and may not handle crash
  * scenarios safely.
  *
  * @param reportID The ID of the report that was written.
  */
 typedef void (*KSReportWrittenCallback)(int64_t reportID)
-    __attribute__((deprecated("Use `KSReportWrittenCallbackWithPolicy` for async-safety awareness (since v2.4.0).")))
+    __attribute__((deprecated("Use `KSReportWrittenCallbackWithPlan` for async-safety awareness (since v2.4.0).")))
     NS_SWIFT_UNAVAILABLE("Use Swift closures instead!");
 
 #ifdef __cplusplus

--- a/Sources/KSCrashRecording/include/KSCrashReportWriterCallbacks.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportWriterCallbacks.h
@@ -27,6 +27,7 @@
 #ifndef HDR_KSCrashReportWriterCallbacks_h
 #define HDR_KSCrashReportWriterCallbacks_h
 
+#include "KSCrashExceptionHandlingPlan.h"
 #include "KSCrashNamespace.h"
 
 #ifndef NS_SWIFT_UNAVAILABLE
@@ -40,42 +41,41 @@ extern "C" {
 // Various callbacks that will be called while handling a crash.
 // The calling order is:
 // * KSCrashEventNotifyCallback
-// * KSReportWriteCallbackWithPolicy
-// * KSReportWrittenCallbackWithPolicy
+// * KSReportWriteCallbackWithPlan
+// * KSReportWrittenCallbackWithPlan
 
 /** Callback type for when a crash has been detected, and we are deciding what to do about it.
  *
- * Normally a callback will just return `policy` as-is, but the user could return a modified policy to change how
+ * Normally a callback will just return `plan` as-is, but the user could return a modified plan to change how
  * this exception is handled.
  *
- * @see KSCrash_ExceptionHandlingPolicy for a list of which policies can be modified.
+ * @see KSCrash_ExceptionHandlingPlan for a list of which policies can be modified.
  *
- * @param policy The current policy for handling this exception
+ * @param plan The current plan for handling this exception, which can be modified by the receiver.
  * @param context The monitor context of the report. Note: This is an INTERNAL structure, subject to change without
  * notice!
- * @return The recommended policy for handling this exception
  */
-typedef KSCrash_ExceptionHandlingPolicy (*KSCrashEventNotifyCallback)(
-    KSCrash_ExceptionHandlingPolicy policy, const struct KSCrash_MonitorContext *_Nonnull context)
+typedef void (*KSCrashEventNotifyCallback)(KSCrash_ExceptionHandlingPlan *_Nonnull const plan,
+                                           const struct KSCrash_MonitorContext *_Nonnull context)
     NS_SWIFT_UNAVAILABLE("Use Swift closures instead!");
 
 /** Callback type for when a crash report is being written, giving the user an opportunity to add custom data to the
  * user section of the report..
  *
- * @param policy The policy under which the report was written.
+ * @param plan The plan under which the report was written.
  * @param writer The report writer.
  */
-typedef void (*KSReportWriteCallbackWithPolicy)(struct KSCrash_ExceptionHandlingPolicy policy,
-                                                const KSCrashReportWriter *_Nonnull writer)
+typedef void (*KSReportWriteCallbackWithPlan)(const KSCrash_ExceptionHandlingPlan *_Nonnull const plan,
+                                              const KSCrashReportWriter *_Nonnull writer)
     NS_SWIFT_UNAVAILABLE("Use Swift closures instead!");
 
 /** Callback type for when a crash report is finished writing.
  *
- * @param policy The policy under which the report was written.
+ * @param plan The plan under which the report was written.
  * @param reportID The ID of the report that was written.
  */
-typedef void (*KSReportWrittenCallbackWithPolicy)(struct KSCrash_ExceptionHandlingPolicy policy, int64_t reportID)
-    NS_SWIFT_UNAVAILABLE("Use Swift closures instead!");
+typedef void (*KSReportWrittenCallbackWithPlan)(const KSCrash_ExceptionHandlingPlan *_Nonnull const plan,
+                                                int64_t reportID) NS_SWIFT_UNAVAILABLE("Use Swift closures instead!");
 
 #ifdef __cplusplus
 }

--- a/Sources/KSCrashRecordingCore/include/KSCrashExceptionHandlingPlan+Private.h
+++ b/Sources/KSCrashRecordingCore/include/KSCrashExceptionHandlingPlan+Private.h
@@ -1,0 +1,52 @@
+//
+//  KSCrashExceptionHandlingPlan+Private.h
+//
+//  Created by Karl Stenerud on 2025-08-24.
+//
+//  Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef HDR_KSCrashExceptionHandlingPlanPrivate_h
+#define HDR_KSCrashExceptionHandlingPlanPrivate_h
+
+#include "KSCrashExceptionHandlingPlan.h"
+#include "KSCrashMonitorContext.h"
+
+static inline KSCrash_ExceptionHandlingPlan ksexc_monitorContextToPlan(const KSCrash_MonitorContext *const context)
+{
+    return (KSCrash_ExceptionHandlingPlan) {
+        .shouldRecordThreads = context->requirements.shouldRecordThreads,
+        .shouldWriteReport = context->requirements.shouldWriteReport,
+        .isFatal = context->requirements.isFatal,
+        .requiresAsyncSafety = kscexc_requiresAsyncSafety(context->requirements),
+        .crashedDuringExceptionHandling = context->requirements.crashedDuringExceptionHandling,
+        .shouldExitImmediately = context->requirements.shouldExitImmediately,
+    };
+}
+
+static inline void ksexc_modifyMonitorContextUsingPlan(KSCrash_MonitorContext *const context,
+                                                       KSCrash_ExceptionHandlingPlan *plan)
+{
+    context->requirements.shouldRecordThreads = plan->shouldRecordThreads;
+    context->requirements.shouldWriteReport = plan->shouldWriteReport;
+}
+
+#endif  // HDR_KSCrashExceptionHandlingPlanPrivate_h

--- a/Sources/KSCrashRecordingCore/include/KSCrashExceptionHandlingPlan.h
+++ b/Sources/KSCrashRecordingCore/include/KSCrashExceptionHandlingPlan.h
@@ -1,0 +1,105 @@
+//
+//  KSCrashExceptionHandlingPlan.h
+//
+//  Created by Karl Stenerud on 2025-08-24.
+//
+//  Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef HDR_KSCrashExceptionHandlingPlan_h
+#define HDR_KSCrashExceptionHandlingPlan_h
+
+#include <CoreFoundation/CoreFoundation.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Plan information that affects how a crash will be handled.
+ *
+ * Some fields can be modified by the user, while others are const (informational only).
+ */
+typedef struct {
+    /**
+     * The handler will try to record all threads if possible.
+     *
+     * Note: Recording all threads will require stopping them, which will trigger `requiresAsyncSafety`
+     */
+    bool shouldRecordThreads;
+
+    /** If true, the handler will write a report about this event. */
+    bool shouldWriteReport;
+
+    /**
+     * The process will terminate once exception handling completes.
+     */
+    const bool isFatal;
+
+    /**
+     * Only async-safe (aka signal-safe) functions may be called.
+     *
+     * This means that you cannot call anything that acquires locks or allocates
+     * memory, which includes:
+     * - Most of the C runtime library
+     * - Most Swift and Objective-C code
+     * - Any interpreted language frameworks such as React-Native
+     * - Any transpiled code such as Kotlin or Unity
+     * - Many C++ features, especially smart pointers
+     *
+     * Doing so risks causing a deadlock (which the user will experience as a
+     * frozen app).
+     *
+     * @see https://www.man7.org/linux/man-pages/man7/signal-safety.7.html
+     */
+    const bool requiresAsyncSafety;
+
+    /**
+     * This crash happened as a result of handling another exception, so be
+     * VERY conservative in what you do. Record just enough information to
+     * diagnose a problem within the library or callback itself, and nothing more.
+     *
+     * Most commonly, callbacks should do NOTHING when this flag is set.
+     *
+     * The report writer will produce only a minimal report (without threads,
+     * so this will also set `shouldRecordThreads` to false). The original
+     * report and "recrash" reports will then be merged.
+     */
+    const bool crashedDuringExceptionHandling;
+
+    /**
+     * Something has gone very, VERY wrong, and as a result the library
+     * cannot handle the exception.
+     *
+     * This is a very rare occurrence, but can happen if too many things cause
+     * fatal exceptions simultaneously.
+     *
+     * Do nothing. Touch nothing. Exit the exception handler immediately.
+     */
+    const bool shouldExitImmediately;
+
+} CF_SWIFT_NAME(ExceptionHandlingPlan) KSCrash_ExceptionHandlingPlan;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // HDR_KSCrashExceptionHandlingPlan_h

--- a/Sources/KSCrashRecordingCore/include/KSCrashMonitorContext.h
+++ b/Sources/KSCrashRecordingCore/include/KSCrashMonitorContext.h
@@ -30,7 +30,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "KSCrashExceptionHandlingPolicy.h"
+#include "KSCrashExceptionHandlingRequirements.h"
 #include "KSCrashMonitorFlag.h"
 #include "KSCrashNamespace.h"
 #include "KSMachineContext.h"
@@ -50,8 +50,8 @@ typedef struct KSCrash_MonitorContext {
     /** Which thread in the thread handler list is handling this exception. */
     int threadHandlerIndex;
 
-    /** The current policy for handling this exception. */
-    KSCrash_ExceptionHandlingPolicy currentPolicy;
+    /** The current requirements for handling this exception. */
+    KSCrash_ExceptionHandlingRequirements requirements;
 
     /** Unique identifier for this event. */
     char eventID[40];
@@ -279,7 +279,7 @@ typedef struct KSCrash_MonitorContext {
 typedef struct {
     /**
      * Notify that an exception has occurred. This function will prepare the system for handling the exception, and make
-     * some policy decisions based on your recommendations and the current system state.
+     * some decisions based on your recommendations and the current system state.
      *
      * This should be called as early as possible in the exception handling process because it will stop all other
      * threads if you've requested to record threads - and stopping threads early minimizes the chances of a context
@@ -292,10 +292,10 @@ typedef struct {
      * handle().
      *
      * @param offendingThread The thread that caused the exception.
-     * @param recommendations Recommendations about the current environment, and how this exception should be handled.
+     * @param requirements Requirements and information about how this exception should be handled.
      * @return a monitor context to be filled out and passed to `handle()`.
      */
-    KSCrash_MonitorContext *(*notify)(thread_t offendingThread, KSCrash_ExceptionHandlingPolicy recommendations);
+    KSCrash_MonitorContext *(*notify)(thread_t offendingThread, KSCrash_ExceptionHandlingRequirements requirements);
 
     /**
      * Handle the exception. This function will collect any pertinent information into the context and then pass the

--- a/Tests/KSCrashRecordingCoreTests/KSCrashMonitor_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSCrashMonitor_Tests.m
@@ -218,7 +218,7 @@ extern void kscm_testcode_resetState(void);
     ctx = dummyExceptionHandlerCallbacks.notify(
         (thread_t)ksthread_self(), (KSCrash_ExceptionHandlingPolicy) { .isFatal = true, .shouldWriteReport = true });
     XCTAssertTrue(ctx->currentPolicy.isFatal);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafety);
+    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
     XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
     XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
     XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
@@ -237,7 +237,7 @@ extern void kscm_testcode_resetState(void);
     ctx = dummyExceptionHandlerCallbacks.notify(
         (thread_t)ksthread_self(), (KSCrash_ExceptionHandlingPolicy) { .isFatal = false, .shouldWriteReport = true });
     XCTAssertFalse(ctx->currentPolicy.isFatal);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafety);
+    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
     XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
     XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
     XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
@@ -253,11 +253,12 @@ extern void kscm_testcode_resetState(void);
     kscm_activateMonitors();
     kscm_setEventCallback(myEventCallback);
     KSCrash_MonitorContext *ctx = NULL;
-    ctx = dummyExceptionHandlerCallbacks.notify(
-        (thread_t)ksthread_self(),
-        (KSCrash_ExceptionHandlingPolicy) { .isFatal = false, .requiresAsyncSafety = 1, .shouldWriteReport = true });
+    ctx = dummyExceptionHandlerCallbacks.notify((thread_t)ksthread_self(),
+                                                (KSCrash_ExceptionHandlingPolicy) { .isFatal = false,
+                                                                                    .requiresAsyncSafetyAlways = true,
+                                                                                    .shouldWriteReport = true });
     XCTAssertFalse(ctx->currentPolicy.isFatal);
-    XCTAssertTrue(ctx->currentPolicy.requiresAsyncSafety);
+    XCTAssertTrue(ctx->currentPolicy.requiresAsyncSafetyAlways);
     XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
     XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
     XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
@@ -270,11 +271,12 @@ extern void kscm_testcode_resetState(void);
     kscm_addMonitor(&g_dummyMonitor);
     kscm_activateMonitors();
     KSCrash_MonitorContext *ctx = NULL;
-    ctx = dummyExceptionHandlerCallbacks.notify(
-        (thread_t)ksthread_self(),
-        (KSCrash_ExceptionHandlingPolicy) { .isFatal = false, .requiresAsyncSafety = 0, .shouldWriteReport = true });
+    ctx = dummyExceptionHandlerCallbacks.notify((thread_t)ksthread_self(),
+                                                (KSCrash_ExceptionHandlingPolicy) { .isFatal = false,
+                                                                                    .requiresAsyncSafetyAlways = false,
+                                                                                    .shouldWriteReport = true });
     XCTAssertFalse(ctx->currentPolicy.isFatal);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafety);
+    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
     XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
     XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
     XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
@@ -310,8 +312,8 @@ static int g_counter = 0;
         (thread_t)ksthread_self(),
         (KSCrash_ExceptionHandlingPolicy) { .shouldRecordThreads = true, .shouldWriteReport = true });
     XCTAssertFalse(ctx->currentPolicy.isFatal);
-    XCTAssertTrue(ctx->currentPolicy.requiresAsyncSafety,
-                  @"requiresAsyncSafety should be set when shouldRecordThreads is true");
+    XCTAssertTrue(ctx->currentPolicy.requiresAsyncSafetyToRecordThreads,
+                  @"requiresAsyncSafetyToRecordThreads should be set when shouldRecordThreads is true");
     XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
     XCTAssertTrue(ctx->currentPolicy.shouldRecordThreads);
     XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
@@ -341,7 +343,7 @@ static int g_counter = 0;
     XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling,
                    @"The first exception shouldn't be detected as a recrash.");
     XCTAssertTrue(ctx->currentPolicy.isFatal);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafety);
+    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
     XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
     XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
 
@@ -351,7 +353,7 @@ static int g_counter = 0;
     XCTAssertTrue(ctx->currentPolicy.crashedDuringExceptionHandling,
                   @"The second exception should be detected as a recrash.");
     XCTAssertTrue(ctx->currentPolicy.isFatal, @"A recrash should set isFatal");
-    XCTAssertTrue(ctx->currentPolicy.requiresAsyncSafety, @"A recrash should set requiresAsyncSafety");
+    XCTAssertTrue(ctx->currentPolicy.requiresAsyncSafetyAlways, @"A recrash should set requiresAsyncSafety");
     XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
     XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads, @"A recrash should clear shouldRecordThreads");
 }
@@ -373,7 +375,7 @@ static int g_counter = 0;
     XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling,
                    @"The first exception shouldn't be detected as a recrash.");
     XCTAssertTrue(ctx->currentPolicy.isFatal);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafety);
+    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
     XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
     XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
 
@@ -383,7 +385,7 @@ static int g_counter = 0;
     XCTAssertTrue(ctx->currentPolicy.crashedDuringExceptionHandling,
                   @"The second exception should be detected as a recrash.");
     XCTAssertTrue(ctx->currentPolicy.isFatal, @"A recrash should set isFatal");
-    XCTAssertTrue(ctx->currentPolicy.requiresAsyncSafety, @"A recrash should set requiresAsyncSafety");
+    XCTAssertTrue(ctx->currentPolicy.requiresAsyncSafetyAlways, @"A recrash should set requiresAsyncSafety");
     XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
     XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads, @"A recrash should clear shouldRecordThreads");
 }
@@ -400,7 +402,7 @@ static int g_counter = 0;
         (thread_t)ksthread_self(), (KSCrash_ExceptionHandlingPolicy) { .isFatal = false, .shouldWriteReport = true });
     XCTAssertFalse(ctx->currentPolicy.isFatal);
     XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafety);
+    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
     XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
     XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
 
@@ -417,7 +419,7 @@ static int g_counter = 0;
     [self cancelThreads:threads];
     XCTAssertFalse(ctx->currentPolicy.isFatal);
     XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafety);
+    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
     XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
     XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
 
@@ -432,7 +434,7 @@ static int g_counter = 0;
     [self cancelThreads:threads];
     XCTAssertTrue(ctx->currentPolicy.isFatal);
     XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafety);
+    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
     XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
     XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
 }
@@ -449,7 +451,7 @@ static int g_counter = 0;
         (thread_t)ksthread_self(), (KSCrash_ExceptionHandlingPolicy) { .isFatal = true, .shouldWriteReport = true });
     XCTAssertTrue(ctx->currentPolicy.isFatal);
     XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafety);
+    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
     XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
     XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
 
@@ -528,7 +530,7 @@ static int g_counter = 0;
         (thread_t)ksthread_self(), (KSCrash_ExceptionHandlingPolicy) { .isFatal = true, .shouldWriteReport = true });
     XCTAssertTrue(ctx->currentPolicy.isFatal);
     XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafety);
+    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
     XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
     XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
 
@@ -583,9 +585,10 @@ static int g_counter = 0;
     kscm_activateMonitors();
     XCTAssertTrue(g_dummyMonitor.isEnabled(), @"The monitor should be enabled after activation.");
     KSCrash_MonitorContext *ctx = NULL;
-    ctx = dummyExceptionHandlerCallbacks.notify(
-        (thread_t)ksthread_self(),
-        (KSCrash_ExceptionHandlingPolicy) { .requiresAsyncSafety = 0, .isFatal = true, .shouldWriteReport = true });
+    ctx = dummyExceptionHandlerCallbacks.notify((thread_t)ksthread_self(),
+                                                (KSCrash_ExceptionHandlingPolicy) { .requiresAsyncSafetyAlways = false,
+                                                                                    .isFatal = true,
+                                                                                    .shouldWriteReport = true });
     XCTAssertTrue(g_dummyMonitor.isEnabled(),
                   @"The monitor should still be enabled before fatal exception handling logic.");
     dummyExceptionHandlerCallbacks.handle(ctx);

--- a/Tests/KSCrashRecordingCoreTests/KSCrashMonitor_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSCrashMonitor_Tests.m
@@ -216,12 +216,13 @@ extern void kscm_testcode_resetState(void);
     kscm_setEventCallback(myEventCallback);
     KSCrash_MonitorContext *ctx = NULL;
     ctx = dummyExceptionHandlerCallbacks.notify(
-        (thread_t)ksthread_self(), (KSCrash_ExceptionHandlingPolicy) { .isFatal = true, .shouldWriteReport = true });
-    XCTAssertTrue(ctx->currentPolicy.isFatal);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
-    XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
-    XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
-    XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
+        (thread_t)ksthread_self(),
+        (KSCrash_ExceptionHandlingRequirements) { .isFatal = true, .shouldWriteReport = true });
+    XCTAssertTrue(ctx->requirements.isFatal);
+    XCTAssertFalse(ctx->requirements.asyncSafety);
+    XCTAssertFalse(ctx->requirements.shouldExitImmediately);
+    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
+    XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
 
     dummyExceptionHandlerCallbacks.handle(ctx);  // Handle the exception
     XCTAssertTrue(g_exceptionHandled, @"The exception should have been handled by the event callback.");
@@ -235,12 +236,13 @@ extern void kscm_testcode_resetState(void);
     kscm_setEventCallback(myEventCallback);
     KSCrash_MonitorContext *ctx = NULL;
     ctx = dummyExceptionHandlerCallbacks.notify(
-        (thread_t)ksthread_self(), (KSCrash_ExceptionHandlingPolicy) { .isFatal = false, .shouldWriteReport = true });
-    XCTAssertFalse(ctx->currentPolicy.isFatal);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
-    XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
-    XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
-    XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
+        (thread_t)ksthread_self(),
+        (KSCrash_ExceptionHandlingRequirements) { .isFatal = false, .shouldWriteReport = true });
+    XCTAssertFalse(ctx->requirements.isFatal);
+    XCTAssertFalse(ctx->requirements.asyncSafety);
+    XCTAssertFalse(ctx->requirements.shouldExitImmediately);
+    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
+    XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
 
     dummyExceptionHandlerCallbacks.handle(ctx);  // Handle the exception
     XCTAssertTrue(g_exceptionHandled, @"The exception should have been handled by the event callback.");
@@ -253,15 +255,14 @@ extern void kscm_testcode_resetState(void);
     kscm_activateMonitors();
     kscm_setEventCallback(myEventCallback);
     KSCrash_MonitorContext *ctx = NULL;
-    ctx = dummyExceptionHandlerCallbacks.notify((thread_t)ksthread_self(),
-                                                (KSCrash_ExceptionHandlingPolicy) { .isFatal = false,
-                                                                                    .requiresAsyncSafetyAlways = true,
-                                                                                    .shouldWriteReport = true });
-    XCTAssertFalse(ctx->currentPolicy.isFatal);
-    XCTAssertTrue(ctx->currentPolicy.requiresAsyncSafetyAlways);
-    XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
-    XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
-    XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
+    ctx = dummyExceptionHandlerCallbacks.notify(
+        (thread_t)ksthread_self(),
+        (KSCrash_ExceptionHandlingRequirements) { .isFatal = false, .asyncSafety = true, .shouldWriteReport = true });
+    XCTAssertFalse(ctx->requirements.isFatal);
+    XCTAssertTrue(ctx->requirements.asyncSafety);
+    XCTAssertFalse(ctx->requirements.shouldExitImmediately);
+    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
+    XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
     XCTAssertFalse(ctx->isHeapAllocated,
                    @"When async safety is required, the context should not be allocated on the heap");
 }
@@ -271,15 +272,14 @@ extern void kscm_testcode_resetState(void);
     kscm_addMonitor(&g_dummyMonitor);
     kscm_activateMonitors();
     KSCrash_MonitorContext *ctx = NULL;
-    ctx = dummyExceptionHandlerCallbacks.notify((thread_t)ksthread_self(),
-                                                (KSCrash_ExceptionHandlingPolicy) { .isFatal = false,
-                                                                                    .requiresAsyncSafetyAlways = false,
-                                                                                    .shouldWriteReport = true });
-    XCTAssertFalse(ctx->currentPolicy.isFatal);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
-    XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
-    XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
-    XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
+    ctx = dummyExceptionHandlerCallbacks.notify(
+        (thread_t)ksthread_self(),
+        (KSCrash_ExceptionHandlingRequirements) { .isFatal = false, .asyncSafety = false, .shouldWriteReport = true });
+    XCTAssertFalse(ctx->requirements.isFatal);
+    XCTAssertFalse(ctx->requirements.asyncSafety);
+    XCTAssertFalse(ctx->requirements.shouldExitImmediately);
+    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
+    XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
     XCTAssertTrue(ctx->isHeapAllocated,
                   @"When async safety is not required, the context should be allocated on the heap");
 }
@@ -310,13 +310,13 @@ static int g_counter = 0;
     usleep(1);
     ctx = dummyExceptionHandlerCallbacks.notify(
         (thread_t)ksthread_self(),
-        (KSCrash_ExceptionHandlingPolicy) { .shouldRecordThreads = true, .shouldWriteReport = true });
-    XCTAssertFalse(ctx->currentPolicy.isFatal);
-    XCTAssertTrue(ctx->currentPolicy.requiresAsyncSafetyToRecordThreads,
-                  @"requiresAsyncSafetyToRecordThreads should be set when shouldRecordThreads is true");
-    XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
-    XCTAssertTrue(ctx->currentPolicy.shouldRecordThreads);
-    XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
+        (KSCrash_ExceptionHandlingRequirements) { .shouldRecordThreads = true, .shouldWriteReport = true });
+    XCTAssertFalse(ctx->requirements.isFatal);
+    XCTAssertTrue(ctx->requirements.asyncSafetyBecauseThreadsSuspended,
+                  @"asyncSafetyBecauseThreadsSuspended should be set when shouldRecordThreads is true");
+    XCTAssertFalse(ctx->requirements.shouldExitImmediately);
+    XCTAssertTrue(ctx->requirements.shouldRecordThreads);
+    XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
 
     XCTAssertFalse([self isCounterThreadRunning]);
     dummyExceptionHandlerCallbacks.handle(ctx);
@@ -339,23 +339,24 @@ static int g_counter = 0;
     KSCrash_MonitorContext *ctx = NULL;
 
     ctx = dummyExceptionHandlerCallbacks.notify(
-        (thread_t)ksthread_self(), (KSCrash_ExceptionHandlingPolicy) { .isFatal = true, .shouldWriteReport = true });
-    XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling,
+        (thread_t)ksthread_self(),
+        (KSCrash_ExceptionHandlingRequirements) { .isFatal = true, .shouldWriteReport = true });
+    XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling,
                    @"The first exception shouldn't be detected as a recrash.");
-    XCTAssertTrue(ctx->currentPolicy.isFatal);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
-    XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
-    XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
+    XCTAssertTrue(ctx->requirements.isFatal);
+    XCTAssertFalse(ctx->requirements.asyncSafety);
+    XCTAssertFalse(ctx->requirements.shouldExitImmediately);
+    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
 
     ctx = dummyExceptionHandlerCallbacks.notify(
-        (thread_t)ksthread_self(),
-        (KSCrash_ExceptionHandlingPolicy) { .isFatal = true, .shouldRecordThreads = true, .shouldWriteReport = true });
-    XCTAssertTrue(ctx->currentPolicy.crashedDuringExceptionHandling,
+        (thread_t)ksthread_self(), (KSCrash_ExceptionHandlingRequirements) {
+                                       .isFatal = true, .shouldRecordThreads = true, .shouldWriteReport = true });
+    XCTAssertTrue(ctx->requirements.crashedDuringExceptionHandling,
                   @"The second exception should be detected as a recrash.");
-    XCTAssertTrue(ctx->currentPolicy.isFatal, @"A recrash should set isFatal");
-    XCTAssertTrue(ctx->currentPolicy.requiresAsyncSafetyAlways, @"A recrash should set requiresAsyncSafety");
-    XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
-    XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads, @"A recrash should clear shouldRecordThreads");
+    XCTAssertTrue(ctx->requirements.isFatal, @"A recrash should set isFatal");
+    XCTAssertTrue(ctx->requirements.asyncSafety, @"A recrash should set requiresAsyncSafety");
+    XCTAssertFalse(ctx->requirements.shouldExitImmediately);
+    XCTAssertFalse(ctx->requirements.shouldRecordThreads, @"A recrash should clear shouldRecordThreads");
 }
 
 - (void)testCrashDuringExceptionHandlingNonFatal
@@ -371,23 +372,24 @@ static int g_counter = 0;
     KSCrash_MonitorContext *ctx = NULL;
 
     ctx = dummyExceptionHandlerCallbacks.notify(
-        (thread_t)ksthread_self(), (KSCrash_ExceptionHandlingPolicy) { .isFatal = true, .shouldWriteReport = true });
-    XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling,
+        (thread_t)ksthread_self(),
+        (KSCrash_ExceptionHandlingRequirements) { .isFatal = true, .shouldWriteReport = true });
+    XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling,
                    @"The first exception shouldn't be detected as a recrash.");
-    XCTAssertTrue(ctx->currentPolicy.isFatal);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
-    XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
-    XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
+    XCTAssertTrue(ctx->requirements.isFatal);
+    XCTAssertFalse(ctx->requirements.asyncSafety);
+    XCTAssertFalse(ctx->requirements.shouldExitImmediately);
+    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
 
     ctx = dummyExceptionHandlerCallbacks.notify(
-        (thread_t)ksthread_self(),
-        (KSCrash_ExceptionHandlingPolicy) { .isFatal = false, .shouldRecordThreads = true, .shouldWriteReport = true });
-    XCTAssertTrue(ctx->currentPolicy.crashedDuringExceptionHandling,
+        (thread_t)ksthread_self(), (KSCrash_ExceptionHandlingRequirements) {
+                                       .isFatal = false, .shouldRecordThreads = true, .shouldWriteReport = true });
+    XCTAssertTrue(ctx->requirements.crashedDuringExceptionHandling,
                   @"The second exception should be detected as a recrash.");
-    XCTAssertTrue(ctx->currentPolicy.isFatal, @"A recrash should set isFatal");
-    XCTAssertTrue(ctx->currentPolicy.requiresAsyncSafetyAlways, @"A recrash should set requiresAsyncSafety");
-    XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
-    XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads, @"A recrash should clear shouldRecordThreads");
+    XCTAssertTrue(ctx->requirements.isFatal, @"A recrash should set isFatal");
+    XCTAssertTrue(ctx->requirements.asyncSafety, @"A recrash should set requiresAsyncSafety");
+    XCTAssertFalse(ctx->requirements.shouldExitImmediately);
+    XCTAssertFalse(ctx->requirements.shouldRecordThreads, @"A recrash should clear shouldRecordThreads");
 }
 
 - (void)testSimultaneousUnrelatedExceptionsNonFatalFirst
@@ -399,12 +401,13 @@ static int g_counter = 0;
     __block KSCrash_MonitorContext *ctx = NULL;
 
     ctx = dummyExceptionHandlerCallbacks.notify(
-        (thread_t)ksthread_self(), (KSCrash_ExceptionHandlingPolicy) { .isFatal = false, .shouldWriteReport = true });
-    XCTAssertFalse(ctx->currentPolicy.isFatal);
-    XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
-    XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
-    XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
+        (thread_t)ksthread_self(),
+        (KSCrash_ExceptionHandlingRequirements) { .isFatal = false, .shouldWriteReport = true });
+    XCTAssertFalse(ctx->requirements.isFatal);
+    XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
+    XCTAssertFalse(ctx->requirements.asyncSafety);
+    XCTAssertFalse(ctx->requirements.shouldExitImmediately);
+    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
 
     NSMutableArray *threads = [NSMutableArray new];
 
@@ -412,31 +415,31 @@ static int g_counter = 0;
     [threads addObject:[self startThreadWithBlock:^{
                  ctx = dummyExceptionHandlerCallbacks.notify(
                      (thread_t)ksthread_self(),
-                     (KSCrash_ExceptionHandlingPolicy) { .isFatal = false, .shouldWriteReport = true });
+                     (KSCrash_ExceptionHandlingRequirements) { .isFatal = false, .shouldWriteReport = true });
              }]];
     XCTAssertLessThan([self waitForThreads:threads maxTime:0.5], 0.1,
                       "Unrelated exceptions following a non-fatal exception should not be delayed");
     [self cancelThreads:threads];
-    XCTAssertFalse(ctx->currentPolicy.isFatal);
-    XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
-    XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
-    XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
+    XCTAssertFalse(ctx->requirements.isFatal);
+    XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
+    XCTAssertFalse(ctx->requirements.asyncSafety);
+    XCTAssertFalse(ctx->requirements.shouldExitImmediately);
+    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
 
     [threads removeAllObjects];
     [threads addObject:[self startThreadWithBlock:^{
                  ctx = dummyExceptionHandlerCallbacks.notify(
                      (thread_t)ksthread_self(),
-                     (KSCrash_ExceptionHandlingPolicy) { .isFatal = true, .shouldWriteReport = true });
+                     (KSCrash_ExceptionHandlingRequirements) { .isFatal = true, .shouldWriteReport = true });
              }]];
     XCTAssertLessThan([self waitForThreads:threads maxTime:0.5], 0.1,
                       "Unrelated exceptions following a non-fatal exception should not be delayed");
     [self cancelThreads:threads];
-    XCTAssertTrue(ctx->currentPolicy.isFatal);
-    XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
-    XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
-    XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
+    XCTAssertTrue(ctx->requirements.isFatal);
+    XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
+    XCTAssertFalse(ctx->requirements.asyncSafety);
+    XCTAssertFalse(ctx->requirements.shouldExitImmediately);
+    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
 }
 
 - (void)testSimultaneousUnrelatedExceptionsFatalFirst
@@ -448,12 +451,13 @@ static int g_counter = 0;
     __block KSCrash_MonitorContext *ctx = NULL;
 
     ctx = dummyExceptionHandlerCallbacks.notify(
-        (thread_t)ksthread_self(), (KSCrash_ExceptionHandlingPolicy) { .isFatal = true, .shouldWriteReport = true });
-    XCTAssertTrue(ctx->currentPolicy.isFatal);
-    XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
-    XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
-    XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
+        (thread_t)ksthread_self(),
+        (KSCrash_ExceptionHandlingRequirements) { .isFatal = true, .shouldWriteReport = true });
+    XCTAssertTrue(ctx->requirements.isFatal);
+    XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
+    XCTAssertFalse(ctx->requirements.asyncSafety);
+    XCTAssertFalse(ctx->requirements.shouldExitImmediately);
+    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
 
     NSMutableArray *threads = [NSMutableArray new];
 
@@ -461,7 +465,7 @@ static int g_counter = 0;
     [threads addObject:[self startThreadWithBlock:^{
                  ctx = dummyExceptionHandlerCallbacks.notify(
                      (thread_t)ksthread_self(),
-                     (KSCrash_ExceptionHandlingPolicy) { .isFatal = false, .shouldWriteReport = true });
+                     (KSCrash_ExceptionHandlingRequirements) { .isFatal = false, .shouldWriteReport = true });
              }]];
     XCTAssertGreaterThan([self waitForThreads:threads maxTime:0.5], 0.49,
                          "Unrelated exceptions following a fatal exception should be delayed");
@@ -472,7 +476,7 @@ static int g_counter = 0;
     [threads addObject:[self startThreadWithBlock:^{
                  ctx = dummyExceptionHandlerCallbacks.notify(
                      (thread_t)ksthread_self(),
-                     (KSCrash_ExceptionHandlingPolicy) { .isFatal = true, .shouldWriteReport = true });
+                     (KSCrash_ExceptionHandlingRequirements) { .isFatal = true, .shouldWriteReport = true });
              }]];
     XCTAssertGreaterThan([self waitForThreads:threads maxTime:0.5], 0.49,
                          "Unrelated exceptions following a fatal exception should be delayed");
@@ -493,11 +497,11 @@ static int g_counter = 0;
 //    ctx = dummyExceptionHandlerCallbacks.notify((thread_t)ksthread_self(), (KSCrash_ExceptionHandlingPolicy) {
 //                                                                               .isFatal = false,
 //                                                                           });
-//    XCTAssertFalse(ctx->currentPolicy.isFatal);
-//    XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
-//    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafety);
-//    XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
-//    XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
+//    XCTAssertFalse(ctx->requirements.isFatal);
+//    XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
+//    XCTAssertFalse(ctx->requirements.requiresAsyncSafety);
+//    XCTAssertFalse(ctx->requirements.shouldExitImmediately);
+//    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
 //
 //    NSMutableArray *threads = [NSMutableArray new];
 //
@@ -514,7 +518,7 @@ static int g_counter = 0;
 //    [self waitForThreads:threads maxTime:0.5];
 //    [self cancelThreads:threads];
 //    XCTAssertFalse(g_dummyEnabledState);
-//    XCTAssertTrue(ctx->currentPolicy.shouldExitImmediately);
+//    XCTAssertTrue(ctx->requirements.shouldExitImmediately);
 //}
 
 - (void)testOverloadThreadHandlerFatal
@@ -527,12 +531,13 @@ static int g_counter = 0;
     __block KSCrash_MonitorContext *ctx = NULL;
 
     ctx = dummyExceptionHandlerCallbacks.notify(
-        (thread_t)ksthread_self(), (KSCrash_ExceptionHandlingPolicy) { .isFatal = true, .shouldWriteReport = true });
-    XCTAssertTrue(ctx->currentPolicy.isFatal);
-    XCTAssertFalse(ctx->currentPolicy.crashedDuringExceptionHandling);
-    XCTAssertFalse(ctx->currentPolicy.requiresAsyncSafetyAlways);
-    XCTAssertFalse(ctx->currentPolicy.shouldExitImmediately);
-    XCTAssertFalse(ctx->currentPolicy.shouldRecordThreads);
+        (thread_t)ksthread_self(),
+        (KSCrash_ExceptionHandlingRequirements) { .isFatal = true, .shouldWriteReport = true });
+    XCTAssertTrue(ctx->requirements.isFatal);
+    XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
+    XCTAssertFalse(ctx->requirements.asyncSafety);
+    XCTAssertFalse(ctx->requirements.shouldExitImmediately);
+    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
 
     NSMutableArray *threads = [NSMutableArray new];
 
@@ -540,13 +545,13 @@ static int g_counter = 0;
         [threads addObject:[self startThreadWithBlock:^{
                      ctx = dummyExceptionHandlerCallbacks.notify(
                          (thread_t)ksthread_self(),
-                         (KSCrash_ExceptionHandlingPolicy) { .isFatal = false, .shouldWriteReport = true });
+                         (KSCrash_ExceptionHandlingRequirements) { .isFatal = false, .shouldWriteReport = true });
                  }]];
     }
     [self waitForThreads:threads maxTime:0.5];
     [self cancelThreads:threads];
     XCTAssertFalse(g_dummyEnabledState);
-    XCTAssertTrue(ctx->currentPolicy.shouldExitImmediately);
+    XCTAssertTrue(ctx->requirements.shouldExitImmediately);
 }
 
 - (void)testHandleExceptionAddsContextualInfoFatal
@@ -557,7 +562,8 @@ static int g_counter = 0;
     KSCrash_MonitorContext *ctx = NULL;
 
     ctx = dummyExceptionHandlerCallbacks.notify(
-        (thread_t)ksthread_self(), (KSCrash_ExceptionHandlingPolicy) { .isFatal = true, .shouldWriteReport = true });
+        (thread_t)ksthread_self(),
+        (KSCrash_ExceptionHandlingRequirements) { .isFatal = true, .shouldWriteReport = true });
     XCTAssertFalse([self cstringIsEqual:ctx->eventID to:g_eventID]);
     dummyExceptionHandlerCallbacks.handle(ctx);  // Handle the exception
     XCTAssertTrue([self cstringIsEqual:g_copiedEventID to:g_eventID],
@@ -572,7 +578,8 @@ static int g_counter = 0;
     KSCrash_MonitorContext *ctx = NULL;
 
     ctx = dummyExceptionHandlerCallbacks.notify(
-        (thread_t)ksthread_self(), (KSCrash_ExceptionHandlingPolicy) { .isFatal = false, .shouldWriteReport = true });
+        (thread_t)ksthread_self(),
+        (KSCrash_ExceptionHandlingRequirements) { .isFatal = false, .shouldWriteReport = true });
     XCTAssertFalse([self cstringIsEqual:ctx->eventID to:g_eventID]);
     dummyExceptionHandlerCallbacks.handle(ctx);  // Handle the exception
     XCTAssertTrue([self cstringIsEqual:g_copiedEventID to:g_eventID],
@@ -585,10 +592,9 @@ static int g_counter = 0;
     kscm_activateMonitors();
     XCTAssertTrue(g_dummyMonitor.isEnabled(), @"The monitor should be enabled after activation.");
     KSCrash_MonitorContext *ctx = NULL;
-    ctx = dummyExceptionHandlerCallbacks.notify((thread_t)ksthread_self(),
-                                                (KSCrash_ExceptionHandlingPolicy) { .requiresAsyncSafetyAlways = false,
-                                                                                    .isFatal = true,
-                                                                                    .shouldWriteReport = true });
+    ctx = dummyExceptionHandlerCallbacks.notify(
+        (thread_t)ksthread_self(),
+        (KSCrash_ExceptionHandlingRequirements) { .asyncSafety = false, .isFatal = true, .shouldWriteReport = true });
     XCTAssertTrue(g_dummyMonitor.isEnabled(),
                   @"The monitor should still be enabled before fatal exception handling logic.");
     dummyExceptionHandlerCallbacks.handle(ctx);


### PR DESCRIPTION
"Policy" has now been renamed "Requirements", and is used internally for the monitors to decide what requirements are in play when handling a crash.

For the user-facing portion, we introduce a "plan" struct that contains some informational content (marked const), and other controlling fields that the user can modify in order to change the requirements.

This shields our internal structs and prevents situations where the user can modify things they're not supposed to.
