### PR TITLE
Add GitHub Copilot code review instructions for API breaking changes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,48 +2,232 @@
 
 When performing code reviews on this repository, follow these instructions to identify API breaking changes in the KSCrash crash reporting library.
 
-## Focus Areas
+## Scope of Review
 
 Only review changes to public API surfaces. The public modules are: KSCrashRecording, KSCrashFilters, KSCrashSinks, KSCrashInstallations, KSCrashDiscSpaceMonitor, KSCrashBootTimeMonitor, and KSCrashDemangleFilter. Only examine files in `Sources/[ModuleName]/include/*.h` directories as these contain the public headers.
 
-## Always Flag as Breaking Changes
+## Critical Breaking Changes - Always Flag
 
-Comment on any of these changes as they break existing user code:
+### Method Parameter Changes
+Flag ANY parameter addition, removal, or type changes to existing Objective-C methods. Objective-C has no default parameters, so even adding a nullable parameter breaks all existing call sites.
 
-- Any parameter addition, removal, or type change to existing Objective-C methods. Remember that Objective-C has no default parameters, so adding even a nullable parameter breaks all existing call sites.
+Examples of breaking changes:
+```objc
+// BREAKING: Adding parameter
+- (void)method:(NSString *)existing;                                     // Old
+- (void)method:(NSString *)existing newParam:(nullable NSString *)param; // New - BREAKING
 
-- Any change to callback or function pointer signatures including parameter addition, removal, reordering, or return type changes.
+// BREAKING: Parameter removal  
+- (void)method:(NSString *)param1 param2:(NSString *)param2;    // Old
+- (void)method:(NSString *)param1;                              // New - BREAKING
 
-- Any property type changes, including changing between primitive types, object types, or nullability changes in either direction (nonnull to nullable breaks Swift API by changing String to String?, nullable to nonnull breaks code that passes nil).
+// BREAKING: Parameter type changes
+- (void)method:(NSString *)param;    // Old
+- (void)method:(NSArray *)param;     // New - BREAKING
 
-- Any struct or enum field reordering, removal, or type changes as these break binary compatibility.
+// BREAKING: Parameter reordering
+- (void)method:(NSString *)first second:(NSString *)second;    // Old
+- (void)method:(NSString *)second first:(NSString *)first;     // New - BREAKING
+```
 
-- Any addition, modification, or removal of NS_SWIFT_NAME attributes on existing types or methods as these change the Swift API surface.
+### Callback Signature Changes
+Flag any changes to callback or function pointer signatures including parameter addition, removal, reordering, or return type changes.
 
-- Any changes to protocol methods between required and optional as this breaks conforming classes.
+Examples of breaking changes:
+```c
+// BREAKING: Parameter addition
+typedef void (*SomeCallback)(Writer *writer);                   // Old
+typedef void (*SomeCallback)(Policy policy, Writer *writer);    // New - BREAKING
 
-- Any superclass changes for existing classes as this alters inheritance behavior.
+// BREAKING: Return type changes
+typedef void (*SomeCallback)(Context *ctx);      // Old
+typedef Policy (*SomeCallback)(Context *ctx);    // New - BREAKING
+```
 
-- Any private module types appearing in public headers as this creates unintended API dependencies.
+### Property Changes
+Flag any property type changes or nullability changes in either direction.
 
-## Safe Changes (Don't Flag)
+Examples of breaking changes:
+```objc
+// BREAKING: Property type changes
+@property (nonatomic, strong) NSString *prop;    // Old
+@property (nonatomic, strong) NSArray *prop;     // New - BREAKING
 
-These changes are not breaking and don't require comments:
+// BREAKING: Nullability changes (both directions)
+@property (nullable) NSString *prop;    // Old
+@property (nonnull) NSString *prop;     // New - BREAKING (breaks code passing nil)
 
-- Adding `__attribute__((deprecated))` to existing APIs as deprecation warnings don't break compilation.
+@property (nonnull) NSString *prop;     // Old
+@property (nullable) NSString *prop;    // New - BREAKING (Swift API: String → String?)
 
-- Adding completely new methods, properties, or classes with entirely new names.
+// BREAKING: Property attribute changes
+@property (atomic) id prop;       // Old
+@property (nonatomic) id prop;    // New - BREAKING (ABI change)
+```
 
-- Adding NS_SWIFT_NAME to brand new APIs that didn't have it before.
+### Swift API Changes via NS_SWIFT_NAME
+Flag any addition, modification, or removal of NS_SWIFT_NAME attributes on existing types or methods.
 
-- Adding optional methods to existing protocols.
+Examples of breaking changes:
+```objc
+// BREAKING: Adding NS_SWIFT_NAME to existing type
+@interface ExistingClass : NSObject                              // Old
+@interface ExistingClass : NSObject NS_SWIFT_NAME(SwiftName)     // New - BREAKING
 
-- Internal implementation changes in .m files or private headers not in include directories.
+// BREAKING: Changing existing NS_SWIFT_NAME
+NS_SWIFT_NAME(OldName) @interface MyClass : NSObject     // Old
+NS_SWIFT_NAME(NewName) @interface MyClass : NSObject     // New - BREAKING
 
-- Documentation updates or comments.
+// BREAKING: Removing NS_SWIFT_NAME
+NS_SWIFT_NAME(SwiftName) @interface MyClass : NSObject    // Old
+@interface MyClass : NSObject                             // New - BREAKING
 
-## Review Context
+// BREAKING: Changing Swift parameter names
+- (void)method:(NSString *)param NS_SWIFT_NAME(method(value:));    // Old
+- (void)method:(NSString *)param NS_SWIFT_NAME(method(input:));    // New - BREAKING
+```
 
-When reviewing changes, ask yourself: Would existing user code fail to compile after this change? If yes, it's breaking. The KSCrash library prioritizes API stability, so any breaking change needs strong justification and clear migration guidance.
+### Struct and Enum Changes
+Flag any struct or enum field reordering, removal, or type changes as these break binary compatibility.
+
+Examples of breaking changes:
+```c
+// BREAKING: Field reordering
+typedef struct {    // Old
+    int field1;
+    int field2;
+} PublicStruct;
+
+typedef struct {    // New - BREAKING
+    int field2;     // Reordered!
+    int field1;
+} PublicStruct;
+
+// BREAKING: Field type changes
+typedef struct {
+    int field;      // Old
+} PublicStruct;
+
+typedef struct {
+    float field;    // New - BREAKING
+} PublicStruct;
+
+// BREAKING: Enum value changes
+typedef enum {      // Old
+    Value1 = 0,
+    Value2 = 1,
+} PublicEnum;
+
+typedef enum {      // New - BREAKING
+    Value1 = 1,     // Changed value!
+    Value2 = 0,
+} PublicEnum;
+```
+
+### Protocol Requirement Changes
+Flag changes between required and optional protocol methods.
+
+Examples of breaking changes:
+```objc
+// BREAKING: Adding required methods
+@protocol PublicProtocol         // Old
+- (void)existingMethod;
+@end
+
+@protocol PublicProtocol         // New - BREAKING
+- (void)existingMethod;
+- (void)newRequiredMethod;       // Added required method
+@end
+
+// BREAKING: Making optional methods required
+@protocol PublicProtocol         // Old
+- (void)existingMethod;
+@optional
+- (void)method;
+@end
+
+@protocol PublicProtocol         // New - BREAKING
+- (void)existingMethod;
+- (void)method;                  // Now required!
+@end
+```
+
+### Function Signature Changes
+Flag any C function parameter or return type changes.
+
+Examples of breaking changes:
+```c
+// BREAKING: Parameter changes
+void someFunction(int param);                    // Old
+void someFunction(int param, char *newParam);    // New - BREAKING
+
+// BREAKING: Return type changes
+void someFunction(void);    // Old
+int someFunction(void);     // New - BREAKING
+```
+
+### Class Hierarchy Changes
+Flag any superclass changes for existing classes.
+
+Examples of breaking changes:
+```objc
+// BREAKING: Changing superclass
+@interface MyClass : NSObject    // Old
+@interface MyClass : NSView      // New - BREAKING (changes inheritance)
+```
+
+### Private Module Leaks
+Flag any private module types appearing in public headers.
+
+Examples of breaking changes:
+```objc
+// BREAKING: Private types in public API
+#import "KSCrashRecordingCore/SomePrivateType.h"  // FLAG if used in public headers
+@property (nonatomic) KSCrash_InternalStruct *detail;  // FLAG if Internal type is private
+```
+
+## Safe Changes - Don't Flag
+
+### Deprecation
+Adding deprecation attributes is safe:
+```objc
+// SAFE: Deprecation warnings don't break compilation
+@property (deprecated("Use newProperty instead")) id oldProperty;
+@property id newProperty;
+```
+
+### New APIs with New Names
+Adding completely new methods, properties, or classes is safe:
+```objc
+// SAFE: New methods with different names
+- (void)existingMethod:(NSString *)param;
+- (void)brandNewMethod:(NSString *)param;  // Different selector
+
+// SAFE: New properties and classes
+@property (nonatomic) id brandNewProperty;
+@interface CompletelyNewClass : NSObject
+```
+
+### NS_SWIFT_NAME on New APIs
+Adding NS_SWIFT_NAME to brand new APIs is safe:
+```objc
+// SAFE: NS_SWIFT_NAME on new APIs only
+NS_SWIFT_NAME(NewSwiftAPI) @interface BrandNewClass : NSObject
+```
+
+### Optional Protocol Methods
+Adding optional methods to protocols is safe:
+```objc
+// SAFE: Adding optional methods
+@protocol ExistingProtocol
+- (void)existing;
+@optional
+- (void)newOptionalMethod;
+@end
+```
+
+## Review Process
+
+For each PR, examine modified public headers and flag any of the breaking change patterns above. Ask yourself: Would existing user code fail to compile after this change? If yes, it's breaking. The KSCrash library prioritizes API stability, so breaking changes need strong justification and migration guidance.
 
 Pay special attention to callback API changes as this library has a history of major callback signature evolution for async-safety and policy awareness.


### PR DESCRIPTION
Introduce guidelines for identifying API breaking changes in the KSCrash library during code reviews, emphasizing focus areas, safe changes, and review context to ensure API stability.

I ran into some issues trying to integrate [https://github.com/Adyen/adyen-swift-public-api-diff?tab=readme-ov-file](https://github.com/Adyen/adyen-swift-public-api-diff?tab=readme-ov-file) with our pure Obj-C SPM setup, since Xcode doesn’t generate a `.framework` file with Swift APIs for Obj-C packages. In theory, we could build a full API check using SourceKitten, but that approach is significantly more complex and doesn’t have the kind of ready-to-use tooling that exists for Swift. So this time, let’s see if we can leverage AI to help us out.
