### PR TITLE
Always record the offending thread at least

### DIFF
--- a/Samples/Common/Sources/CrashCallback/CrashCallback.m
+++ b/Samples/Common/Sources/CrashCallback/CrashCallback.m
@@ -9,6 +9,19 @@
 #import <stdio.h>
 #import "KSCrashC.h"
 
+static void (^g_integrationTestEventNotifyCallback)(KSCrash_ExceptionHandlingPlan *_Nonnull const plan, const struct KSCrash_MonitorContext *_Nonnull context) =
+^void (KSCrash_ExceptionHandlingPlan *_Nonnull const plan, const struct KSCrash_MonitorContext *_Nonnull context) {
+    // Do nothing by default
+};
+
+void integrationTestEventNotifyCallback(KSCrash_ExceptionHandlingPlan *_Nonnull const plan, const struct KSCrash_MonitorContext *_Nonnull context) {
+    g_integrationTestEventNotifyCallback(plan, context);
+}
+
+void setIntegrationTestEventNotifyImplementation(void (^ _Nonnull implementation)(KSCrash_ExceptionHandlingPlan *_Nonnull const plan, const struct KSCrash_MonitorContext *_Nonnull context)) {
+    g_integrationTestEventNotifyCallback = implementation;
+}
+
 static void (^g_integrationTestReportWritingCallback)(const KSCrash_ExceptionHandlingPlan *const plan, const struct KSCrashReportWriter * _Nonnull writer) =
 ^void (const KSCrash_ExceptionHandlingPlan *const plan, const struct KSCrashReportWriter * _Nonnull writer) {
     // Do nothing by default

--- a/Samples/Common/Sources/CrashCallback/include/CrashCallback.h
+++ b/Samples/Common/Sources/CrashCallback/include/CrashCallback.h
@@ -14,6 +14,12 @@ extern "C" {
 #endif
 
 struct KSCrashReportWriter;
+
+void integrationTestEventNotifyCallback(KSCrash_ExceptionHandlingPlan *_Nonnull const plan, const struct KSCrash_MonitorContext *_Nonnull context);
+
+void setIntegrationTestEventNotifyImplementation(void (^ _Nonnull implementation)(KSCrash_ExceptionHandlingPlan *_Nonnull const plan, const struct KSCrash_MonitorContext *_Nonnull context));
+
+
 void integrationTestReportWritingCallback(const KSCrash_ExceptionHandlingPlan *const _Nonnull plan, const struct KSCrashReportWriter * _Nonnull writer);
 
 void setIntegrationTestReportWritingImplementation(void (^ _Nonnull implementation)(const KSCrash_ExceptionHandlingPlan *const _Nonnull plan, const struct KSCrashReportWriter * _Nonnull writer));

--- a/Samples/Common/Sources/IntegrationTestsHelper/InstallConfig.swift
+++ b/Samples/Common/Sources/IntegrationTestsHelper/InstallConfig.swift
@@ -32,6 +32,7 @@ public struct InstallConfig: Codable {
     public var installPath: String
     public var isCxaThrowEnabled: Bool?
     public var isSigTermMonitoringEnabled: Bool?
+    public var shouldRecordAllThreads: Bool?
 
     public init(installPath: String) {
         self.installPath = installPath
@@ -48,6 +49,14 @@ extension InstallConfig {
         if let isSigTermMonitoringEnabled {
             config.enableSigTermMonitoring = isSigTermMonitoringEnabled
         }
+        setIntegrationTestEventNotifyImplementation({
+            (plan: UnsafeMutablePointer<ExceptionHandlingPlan>, ctx: UnsafePointer<KSCrash_MonitorContext>) in
+            if let shouldRecordAllThreads {
+                plan.pointee.shouldRecordAllThreads = shouldRecordAllThreads
+            }
+        })
+        config.eventNotifyCallback = integrationTestEventNotifyCallback
+
         try KSCrash.shared.install(with: config)
     }
 }

--- a/Samples/Common/Sources/LibraryBridge/InstallBridge.swift
+++ b/Samples/Common/Sources/LibraryBridge/InstallBridge.swift
@@ -88,7 +88,7 @@ public class InstallBridge: ObservableObject {
             writer.pointee.addBooleanElement(writer, "requiresAsyncSafety", plan.pointee.requiresAsyncSafety)
             writer.pointee.addBooleanElement(
                 writer, "crashedDuringExceptionHandling", plan.pointee.crashedDuringExceptionHandling)
-            writer.pointee.addBooleanElement(writer, "shouldRecordThreads", plan.pointee.shouldRecordThreads)
+            writer.pointee.addBooleanElement(writer, "shouldRecordAllThreads", plan.pointee.shouldRecordAllThreads)
             writer.pointee.endContainer(writer)
         }
         config.crashNotifyCallbackWithPlan = cb

--- a/Samples/Tests/Core/IntegrationTestBase.swift
+++ b/Samples/Tests/Core/IntegrationTestBase.swift
@@ -97,6 +97,26 @@ class IntegrationTestBase: XCTestCase {
         try? FileManager.default.removeItem(at: installUrl)
     }
 
+    func logData(name: String, data: Data) {
+        let str = String(data: data, encoding: .utf8) ?? "<no \(name)>"
+        log.info(
+            "\n\nvvvvvvvvvvvvvvvvvvvv \(name) vvvvvvvvvvvvvvvvvvvv\n\(str)\n^^^^^^^^^^^^^^^^^^^^ \(name) ^^^^^^^^^^^^^^^^^^^^"
+        )
+    }
+
+    func logFile(name: String, path: String) {
+        if FileManager.default.fileExists(atPath: path) {
+            do {
+                let str = try String(contentsOfFile: path, encoding: .utf8)
+                log.info(
+                    "\n\nvvvvvvvvvvvvvvvvvvvv \(name) vvvvvvvvvvvvvvvvvvvv\n\(str)\n^^^^^^^^^^^^^^^^^^^^ \(name) ^^^^^^^^^^^^^^^^^^^^"
+                )
+            } catch {
+                log.info("Could not load \(name) from \(path): \(error)")
+            }
+        }
+    }
+
     func launchAppAndRunScript() {
         app.launch()
         _ = app.wait(for: .runningForeground, timeout: appLaunchTimeout)
@@ -109,6 +129,7 @@ class IntegrationTestBase: XCTestCase {
         #else
             XCTAssert(app.wait(for: .notRunning, timeout: actionDelay + appCrashTimeout), "App crash is expected")
         #endif
+        logFile(name: "Data/ConsoleLog.txt", path: installUrl.path.appending("/Data/ConsoleLog.txt"))
     }
 
     private func waitForFile(in dir: URL, timeout: TimeInterval? = nil) throws -> URL {
@@ -178,6 +199,10 @@ class IntegrationTestBase: XCTestCase {
         let reportData = try readRawCrashReportData()
         let report = try JSONDecoder().decode(PartialCrashReport.self, from: reportData)
         return report
+    }
+
+    func decodePartialCrashReport(reportData: Data) throws -> PartialCrashReport {
+        return try JSONDecoder().decode(PartialCrashReport.self, from: reportData)
     }
 
     func hasCrashReport() throws -> Bool {

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
@@ -128,7 +128,7 @@ static void CPPExceptionTerminate(void)
         KSCrash_MonitorContext *crashContext = g_callbacks.notify(
             thisThread,
             (KSCrash_ExceptionHandlingRequirements) {
-                .asyncSafety = true, .isFatal = true, .shouldRecordThreads = true, .shouldWriteReport = true });
+                .asyncSafety = true, .isFatal = true, .shouldRecordAllThreads = true, .shouldWriteReport = true });
         if (crashContext->requirements.shouldExitImmediately) {
             goto exit_immediately;
         }

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Deadlock.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Deadlock.m
@@ -106,8 +106,9 @@ static KSCrash_ExceptionHandlerCallbacks g_callbacks;
     thread_t thisThread = (thread_t)ksthread_self();
     // This requires async-safety because the environment is suspended.
     KSCrash_MonitorContext *crashContext = g_callbacks.notify(
-        thisThread, (KSCrash_ExceptionHandlingRequirements) {
-                        .asyncSafety = true, .isFatal = true, .shouldRecordThreads = true, .shouldWriteReport = true });
+        thisThread,
+        (KSCrash_ExceptionHandlingRequirements) {
+            .asyncSafety = true, .isFatal = true, .shouldRecordAllThreads = true, .shouldWriteReport = true });
     if (crashContext->requirements.shouldExitImmediately) {
         goto exit_immediately;
     }

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_MachException.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_MachException.c
@@ -412,7 +412,7 @@ static void handleException(ExceptionContext *exceptionCtx)
     KSCrash_MonitorContext *monitorCtx = g_state.callbacks.notify(
         exceptionCtx->request->thread.name,
         (KSCrash_ExceptionHandlingRequirements) {
-            .asyncSafety = true, .isFatal = true, .shouldRecordThreads = true, .shouldWriteReport = true });
+            .asyncSafety = true, .isFatal = true, .shouldRecordAllThreads = true, .shouldWriteReport = true });
     if (monitorCtx->requirements.shouldExitImmediately) {
         KSLOG_DEBUG("Thread %s: Should exit immediately, so returning", exceptionCtx->threadName);
         return;

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
@@ -538,7 +538,7 @@ static void ksmemory_write_possible_oom(void)
     KSCrash_MonitorContext *ctx = g_callbacks.notify(
         thisThread,
         (KSCrash_ExceptionHandlingRequirements) {
-            .asyncSafety = false, .isFatal = false, .shouldRecordThreads = false, .shouldWriteReport = true });
+            .asyncSafety = false, .isFatal = false, .shouldRecordAllThreads = false, .shouldWriteReport = true });
     if (ctx->requirements.shouldExitImmediately) {
         return;
     }

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException.m
@@ -121,7 +121,7 @@ static KS_NOINLINE void handleException(NSException *exception, BOOL isUserRepor
             thisThread, (KSCrash_ExceptionHandlingRequirements) { .asyncSafety = false,
                                                                   // User-reported exceptions are not considered fatal.
                                                                   .isFatal = !isUserReported,
-                                                                  .shouldRecordThreads = logAllThreads != NO,
+                                                                  .shouldRecordAllThreads = logAllThreads != NO,
                                                                   .shouldWriteReport = true });
         if (crashContext->requirements.shouldExitImmediately) {
             goto exit_immediately;

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.c
@@ -96,7 +96,7 @@ static void handleSignal(int sigNum, siginfo_t *signalInfo, void *userContext)
         KSCrash_MonitorContext *crashContext = g_callbacks.notify(
             thisThread,
             (KSCrash_ExceptionHandlingRequirements) {
-                .asyncSafety = true, .isFatal = true, .shouldRecordThreads = true, .shouldWriteReport = true });
+                .asyncSafety = true, .isFatal = true, .shouldRecordAllThreads = true, .shouldWriteReport = true });
         if (crashContext->requirements.shouldExitImmediately) {
             goto exit_immediately;
         }

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_User.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_User.c
@@ -54,7 +54,7 @@ void kscm_reportUserException(const char *name, const char *reason, const char *
         KSCrash_MonitorContext *ctx = g_callbacks.notify(
             thisThread, (KSCrash_ExceptionHandlingRequirements) { .asyncSafety = false,
                                                                   .isFatal = terminateProgram,
-                                                                  .shouldRecordThreads = logAllThreads,
+                                                                  .shouldRecordAllThreads = logAllThreads,
                                                                   .shouldWriteReport = true });
         if (ctx->requirements.shouldExitImmediately) {
             goto exit_immediately;

--- a/Sources/KSCrashRecordingCore/KSCxaThrowSwapper.c
+++ b/Sources/KSCrashRecordingCore/KSCxaThrowSwapper.c
@@ -216,9 +216,9 @@ static void rebind_symbols_for_image(const struct mach_header *header, intptr_t 
         KSLOG_WARN("dladdr failed");
         return;
     }
-    KSLOG_DEBUG("Image name: %s", info.dli_fname);
+    KSLOG_TRACE("Image name: %s", info.dli_fname);
     if (slide == 0) {
-        KSLOG_DEBUG("Zero slide, can't do anything with it");
+        KSLOG_TRACE("Zero slide, can't do anything with it");
         return;
     }
 

--- a/Sources/KSCrashRecordingCore/KSMach-O.c
+++ b/Sources/KSCrashRecordingCore/KSMach-O.c
@@ -93,7 +93,7 @@ const segment_command_t *ksmacho_getSegmentByNameFromHeader(const mach_header_t 
     for (commandIndex = 0; commandIndex < header->ncmds; commandIndex++) {
         if (segmentCommand->cmd == LC_SEGMENT_ARCH_DEPENDENT &&
             strncmp(segmentCommand->segname, segmentName, sizeof(segmentCommand->segname)) == 0) {
-            KSLOG_DEBUG("Segment %s found at %p", segmentName, segmentCommand);
+            KSLOG_TRACE("Segment %s found at %p", segmentName, segmentCommand);
             return segmentCommand;
         }
         segmentCommand = (segment_command_t *)((uintptr_t)segmentCommand + segmentCommand->cmdsize);
@@ -122,7 +122,7 @@ const section_t *ksmacho_getSectionByTypeFlagFromSegment(const segment_command_t
         }
     }
 
-    KSLOG_DEBUG("Section with flag %u not found in segment %s", flag, segmentCommand->segname);
+    KSLOG_TRACE("Section with flag %u not found in segment %s", flag, segmentCommand->segname);
     return NULL;
 }
 
@@ -146,7 +146,7 @@ vm_prot_t ksmacho_getSectionProtection(void *sectionStart)
         vm_region(task, &address, &size, VM_REGION_BASIC_INFO, (vm_region_info_t)&info, &count, &object);
 #endif
     if (info_ret == KERN_SUCCESS) {
-        KSLOG_DEBUG("Protection obtained: %d", info.protection);
+        KSLOG_TRACE("Protection obtained: %d", info.protection);
         return info.protection;
     } else {
         KSLOG_ERROR("Failed to get protection for section: %s", mach_error_string(info_ret));

--- a/Sources/KSCrashRecordingCore/include/KSCrashExceptionHandlingPlan+Private.h
+++ b/Sources/KSCrashRecordingCore/include/KSCrashExceptionHandlingPlan+Private.h
@@ -33,7 +33,7 @@
 static inline KSCrash_ExceptionHandlingPlan ksexc_monitorContextToPlan(const KSCrash_MonitorContext *const context)
 {
     return (KSCrash_ExceptionHandlingPlan) {
-        .shouldRecordThreads = context->requirements.shouldRecordThreads,
+        .shouldRecordAllThreads = context->requirements.shouldRecordAllThreads,
         .shouldWriteReport = context->requirements.shouldWriteReport,
         .isFatal = context->requirements.isFatal,
         .requiresAsyncSafety = kscexc_requiresAsyncSafety(context->requirements),
@@ -45,7 +45,7 @@ static inline KSCrash_ExceptionHandlingPlan ksexc_monitorContextToPlan(const KSC
 static inline void ksexc_modifyMonitorContextUsingPlan(KSCrash_MonitorContext *const context,
                                                        KSCrash_ExceptionHandlingPlan *plan)
 {
-    context->requirements.shouldRecordThreads = plan->shouldRecordThreads;
+    context->requirements.shouldRecordAllThreads = plan->shouldRecordAllThreads;
     context->requirements.shouldWriteReport = plan->shouldWriteReport;
 }
 

--- a/Sources/KSCrashRecordingCore/include/KSCrashExceptionHandlingPlan.h
+++ b/Sources/KSCrashRecordingCore/include/KSCrashExceptionHandlingPlan.h
@@ -44,7 +44,7 @@ typedef struct {
      *
      * Note: Recording all threads will require stopping them, which will trigger `requiresAsyncSafety`
      */
-    bool shouldRecordThreads;
+    bool shouldRecordAllThreads;
 
     /** If true, the handler will write a report about this event. */
     bool shouldWriteReport;

--- a/Sources/KSCrashRecordingCore/include/KSCrashExceptionHandlingRequirements.h
+++ b/Sources/KSCrashRecordingCore/include/KSCrashExceptionHandlingRequirements.h
@@ -43,7 +43,7 @@ typedef struct {
      * This will require stopping all threads, and so `asyncSafetyBecauseThreadsSuspended` will be set once the threads
      * are stopped.
      */
-    unsigned shouldRecordThreads : 1;
+    unsigned shouldRecordAllThreads : 1;
 
     /**
      * The handler should try to write a report about this event.

--- a/Tests/KSCrashRecordingCoreTests/KSCrashMonitor_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSCrashMonitor_Tests.m
@@ -221,7 +221,7 @@ extern void kscm_testcode_resetState(void);
     XCTAssertTrue(ctx->requirements.isFatal);
     XCTAssertFalse(ctx->requirements.asyncSafety);
     XCTAssertFalse(ctx->requirements.shouldExitImmediately);
-    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
+    XCTAssertFalse(ctx->requirements.shouldRecordAllThreads);
     XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
 
     dummyExceptionHandlerCallbacks.handle(ctx);  // Handle the exception
@@ -241,7 +241,7 @@ extern void kscm_testcode_resetState(void);
     XCTAssertFalse(ctx->requirements.isFatal);
     XCTAssertFalse(ctx->requirements.asyncSafety);
     XCTAssertFalse(ctx->requirements.shouldExitImmediately);
-    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
+    XCTAssertFalse(ctx->requirements.shouldRecordAllThreads);
     XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
 
     dummyExceptionHandlerCallbacks.handle(ctx);  // Handle the exception
@@ -261,7 +261,7 @@ extern void kscm_testcode_resetState(void);
     XCTAssertFalse(ctx->requirements.isFatal);
     XCTAssertTrue(ctx->requirements.asyncSafety);
     XCTAssertFalse(ctx->requirements.shouldExitImmediately);
-    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
+    XCTAssertFalse(ctx->requirements.shouldRecordAllThreads);
     XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
     XCTAssertFalse(ctx->isHeapAllocated,
                    @"When async safety is required, the context should not be allocated on the heap");
@@ -278,7 +278,7 @@ extern void kscm_testcode_resetState(void);
     XCTAssertFalse(ctx->requirements.isFatal);
     XCTAssertFalse(ctx->requirements.asyncSafety);
     XCTAssertFalse(ctx->requirements.shouldExitImmediately);
-    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
+    XCTAssertFalse(ctx->requirements.shouldRecordAllThreads);
     XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
     XCTAssertTrue(ctx->isHeapAllocated,
                   @"When async safety is not required, the context should be allocated on the heap");
@@ -310,12 +310,12 @@ static int g_counter = 0;
     usleep(1);
     ctx = dummyExceptionHandlerCallbacks.notify(
         (thread_t)ksthread_self(),
-        (KSCrash_ExceptionHandlingRequirements) { .shouldRecordThreads = true, .shouldWriteReport = true });
+        (KSCrash_ExceptionHandlingRequirements) { .shouldRecordAllThreads = true, .shouldWriteReport = true });
     XCTAssertFalse(ctx->requirements.isFatal);
     XCTAssertTrue(ctx->requirements.asyncSafetyBecauseThreadsSuspended,
                   @"asyncSafetyBecauseThreadsSuspended should be set when shouldRecordThreads is true");
     XCTAssertFalse(ctx->requirements.shouldExitImmediately);
-    XCTAssertTrue(ctx->requirements.shouldRecordThreads);
+    XCTAssertTrue(ctx->requirements.shouldRecordAllThreads);
     XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
 
     XCTAssertFalse([self isCounterThreadRunning]);
@@ -346,17 +346,17 @@ static int g_counter = 0;
     XCTAssertTrue(ctx->requirements.isFatal);
     XCTAssertFalse(ctx->requirements.asyncSafety);
     XCTAssertFalse(ctx->requirements.shouldExitImmediately);
-    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
+    XCTAssertFalse(ctx->requirements.shouldRecordAllThreads);
 
     ctx = dummyExceptionHandlerCallbacks.notify(
         (thread_t)ksthread_self(), (KSCrash_ExceptionHandlingRequirements) {
-                                       .isFatal = true, .shouldRecordThreads = true, .shouldWriteReport = true });
+                                       .isFatal = true, .shouldRecordAllThreads = true, .shouldWriteReport = true });
     XCTAssertTrue(ctx->requirements.crashedDuringExceptionHandling,
                   @"The second exception should be detected as a recrash.");
     XCTAssertTrue(ctx->requirements.isFatal, @"A recrash should set isFatal");
     XCTAssertTrue(ctx->requirements.asyncSafety, @"A recrash should set requiresAsyncSafety");
     XCTAssertFalse(ctx->requirements.shouldExitImmediately);
-    XCTAssertFalse(ctx->requirements.shouldRecordThreads, @"A recrash should clear shouldRecordThreads");
+    XCTAssertFalse(ctx->requirements.shouldRecordAllThreads, @"A recrash should clear shouldRecordThreads");
 }
 
 - (void)testCrashDuringExceptionHandlingNonFatal
@@ -379,17 +379,17 @@ static int g_counter = 0;
     XCTAssertTrue(ctx->requirements.isFatal);
     XCTAssertFalse(ctx->requirements.asyncSafety);
     XCTAssertFalse(ctx->requirements.shouldExitImmediately);
-    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
+    XCTAssertFalse(ctx->requirements.shouldRecordAllThreads);
 
     ctx = dummyExceptionHandlerCallbacks.notify(
         (thread_t)ksthread_self(), (KSCrash_ExceptionHandlingRequirements) {
-                                       .isFatal = false, .shouldRecordThreads = true, .shouldWriteReport = true });
+                                       .isFatal = false, .shouldRecordAllThreads = true, .shouldWriteReport = true });
     XCTAssertTrue(ctx->requirements.crashedDuringExceptionHandling,
                   @"The second exception should be detected as a recrash.");
     XCTAssertTrue(ctx->requirements.isFatal, @"A recrash should set isFatal");
     XCTAssertTrue(ctx->requirements.asyncSafety, @"A recrash should set requiresAsyncSafety");
     XCTAssertFalse(ctx->requirements.shouldExitImmediately);
-    XCTAssertFalse(ctx->requirements.shouldRecordThreads, @"A recrash should clear shouldRecordThreads");
+    XCTAssertFalse(ctx->requirements.shouldRecordAllThreads, @"A recrash should clear shouldRecordThreads");
 }
 
 - (void)testSimultaneousUnrelatedExceptionsNonFatalFirst
@@ -407,7 +407,7 @@ static int g_counter = 0;
     XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
     XCTAssertFalse(ctx->requirements.asyncSafety);
     XCTAssertFalse(ctx->requirements.shouldExitImmediately);
-    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
+    XCTAssertFalse(ctx->requirements.shouldRecordAllThreads);
 
     NSMutableArray *threads = [NSMutableArray new];
 
@@ -424,7 +424,7 @@ static int g_counter = 0;
     XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
     XCTAssertFalse(ctx->requirements.asyncSafety);
     XCTAssertFalse(ctx->requirements.shouldExitImmediately);
-    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
+    XCTAssertFalse(ctx->requirements.shouldRecordAllThreads);
 
     [threads removeAllObjects];
     [threads addObject:[self startThreadWithBlock:^{
@@ -439,7 +439,7 @@ static int g_counter = 0;
     XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
     XCTAssertFalse(ctx->requirements.asyncSafety);
     XCTAssertFalse(ctx->requirements.shouldExitImmediately);
-    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
+    XCTAssertFalse(ctx->requirements.shouldRecordAllThreads);
 }
 
 - (void)testSimultaneousUnrelatedExceptionsFatalFirst
@@ -457,7 +457,7 @@ static int g_counter = 0;
     XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
     XCTAssertFalse(ctx->requirements.asyncSafety);
     XCTAssertFalse(ctx->requirements.shouldExitImmediately);
-    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
+    XCTAssertFalse(ctx->requirements.shouldRecordAllThreads);
 
     NSMutableArray *threads = [NSMutableArray new];
 
@@ -501,7 +501,7 @@ static int g_counter = 0;
 //    XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
 //    XCTAssertFalse(ctx->requirements.requiresAsyncSafety);
 //    XCTAssertFalse(ctx->requirements.shouldExitImmediately);
-//    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
+//    XCTAssertFalse(ctx->requirements.shouldRecordAllThreads);
 //
 //    NSMutableArray *threads = [NSMutableArray new];
 //
@@ -537,7 +537,7 @@ static int g_counter = 0;
     XCTAssertFalse(ctx->requirements.crashedDuringExceptionHandling);
     XCTAssertFalse(ctx->requirements.asyncSafety);
     XCTAssertFalse(ctx->requirements.shouldExitImmediately);
-    XCTAssertFalse(ctx->requirements.shouldRecordThreads);
+    XCTAssertFalse(ctx->requirements.shouldRecordAllThreads);
 
     NSMutableArray *threads = [NSMutableArray new];
 

--- a/Tests/KSCrashRecordingTests/KSCrashConfiguration_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashConfiguration_Tests.m
@@ -245,9 +245,10 @@ static void onReportWritten(const KSCrash_ExceptionHandlingPlan *const plan, int
     XCTAssertEqual(g_callbackData.capturedPlan, &testPlan);
     XCTAssertEqual(g_callbackData.capturedWriter, testWriter);
 
-    KSCrash_ExceptionHandlingPlan testPlan2 = (KSCrash_ExceptionHandlingPlan) {
-        .isFatal = false, .crashedDuringExceptionHandling = true, .shouldWriteReport = true, .shouldRecordThreads = true
-    };
+    KSCrash_ExceptionHandlingPlan testPlan2 = (KSCrash_ExceptionHandlingPlan) { .isFatal = false,
+                                                                                .crashedDuringExceptionHandling = true,
+                                                                                .shouldWriteReport = true,
+                                                                                .shouldRecordAllThreads = true };
     int64_t testReportID = 12345;
     cConfig.reportWrittenCallbackWithPlan(&testPlan2, testReportID);
     XCTAssertTrue(g_callbackData.reportWrittenCallbackCalled);


### PR DESCRIPTION
The new `shouldRecordAllThreads` plan field controls whether all threads get recorded or not, but we must at least record the offending thread regardless of this setting.

Also added an integration test for this.
