### PR TITLE
Fix some latent warning issues

### DIFF
--- a/Sources/KSCrashRecording/KSCrashConfiguration.m
+++ b/Sources/KSCrashRecording/KSCrashConfiguration.m
@@ -97,11 +97,21 @@
     config.doNotIntrospectClasses.length = (int)[self.doNotIntrospectClasses count];
     // TODO: Remove in 3.0 - Deprecated callback assignments for backward compatibility
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
     if (self.crashNotifyCallback) {
+        // Note: This only works by blind luck (so far).
+        // error: cast from 'IMP _Nonnull' (aka 'id  _Nullable (*)(id  _Nonnull __strong, SEL _Nonnull, ...)') to
+        // 'KSReportWriteCallback' (aka 'void (*)(const struct KSCrashReportWriter *)') converts to incompatible
+        // function type
         config.crashNotifyCallback = (KSReportWriteCallback)imp_implementationWithBlock(self.crashNotifyCallback);
     }
     if (self.reportWrittenCallback) {
+        // Note: This only works by blind luck (so far).
+        // error: cast from 'IMP _Nonnull' (aka 'id  _Nullable (*)(id  _Nonnull __strong, SEL _Nonnull, ...)') to
+        // 'KSReportWrittenCallback' (aka 'void (*)(long long)') converts to incompatible function type
+        // [-Werror,-Wcast-function-type-mismatch]
         config.reportWrittenCallback = (KSReportWrittenCallback)imp_implementationWithBlock(self.reportWrittenCallback);
     }
 #pragma clang diagnostic pop

--- a/Sources/KSCrashRecordingCore/KSCPU_x86_32.c
+++ b/Sources/KSCrashRecordingCore/KSCPU_x86_32.c
@@ -107,10 +107,10 @@ uint64_t kscpu_registerValue(const KSMachineContext *const context, const int re
             return context->machineContext.__ss.__fs;
         case 15:
             return context->machineContext.__ss.__gs;
+        default:
+            KSLOG_ERROR("Invalid register number: %d", regNumber);
+            return 0;
     }
-
-    KSLOG_ERROR("Invalid register number: %d", regNumber);
-    return 0;
 }
 
 int kscpu_numExceptionRegisters(void) { return g_exceptionRegisterNamesCount; }
@@ -133,10 +133,10 @@ uint64_t kscpu_exceptionRegisterValue(const KSMachineContext *const context, con
             return context->machineContext.__es.__err;
         case 2:
             return context->machineContext.__es.__faultvaddr;
+        default:
+            KSLOG_ERROR("Invalid register number: %d", regNumber);
+            return 0;
     }
-
-    KSLOG_ERROR("Invalid register number: %d", regNumber);
-    return 0;
 }
 
 uintptr_t kscpu_faultAddress(const KSMachineContext *const context)

--- a/Sources/KSCrashRecordingCore/KSCPU_x86_64.c
+++ b/Sources/KSCrashRecordingCore/KSCPU_x86_64.c
@@ -116,10 +116,10 @@ uint64_t kscpu_registerValue(const KSMachineContext *const context, const int re
             return context->machineContext.__ss.__fs;
         case 20:
             return context->machineContext.__ss.__gs;
+        default:
+            KSLOG_ERROR("Invalid register number: %d", regNumber);
+            return 0;
     }
-
-    KSLOG_ERROR("Invalid register number: %d", regNumber);
-    return 0;
 }
 
 int kscpu_numExceptionRegisters(void) { return g_exceptionRegisterNamesCount; }
@@ -142,10 +142,10 @@ uint64_t kscpu_exceptionRegisterValue(const KSMachineContext *const context, con
             return context->machineContext.__es.__err;
         case 2:
             return context->machineContext.__es.__faultvaddr;
+        default:
+            KSLOG_ERROR("Invalid register number: %d", regNumber);
+            return 0;
     }
-
-    KSLOG_ERROR("Invalid register number: %d", regNumber);
-    return 0;
 }
 
 uintptr_t kscpu_faultAddress(const KSMachineContext *const context)


### PR DESCRIPTION
The compiler behaves very differently depending on how and where you invoke it (even with the same warning switches), so it's hard to track these all down in one shot.
