### PR TITLE
Fix error pointer checks

### DIFF
--- a/Sources/KSCrashRecording/KSCrash.m
+++ b/Sources/KSCrashRecording/KSCrash.m
@@ -155,7 +155,7 @@ static void onNSExceptionHandlingEnabled(NSUncaughtExceptionHandler *uncaughtExc
         NSDictionary *userInfoDict = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
         free((void *)userInfoJSON);  // Free the allocated memory
 
-        if (error != nil) {
+        if (userInfoDict == nil) {
             KSLOG_ERROR(@"Error parsing JSON: %@", error.localizedDescription);
             return nil;
         }
@@ -172,7 +172,7 @@ static void onNSExceptionHandlingEnabled(NSUncaughtExceptionHandler *uncaughtExc
     if (userInfo != nil) {
         userInfoJSON = [NSJSONSerialization dataWithJSONObject:userInfo options:NSJSONWritingSortedKeys error:&error];
 
-        if (error != nil) {
+        if (userInfoJSON == nil) {
             KSLOG_ERROR(@"Could not serialize user info: %@", error.localizedDescription);
             return;
         }
@@ -291,7 +291,7 @@ static void onNSExceptionHandlingEnabled(NSUncaughtExceptionHandler *uncaughtExc
     if (stackTrace != nil) {
         NSError *error = nil;
         NSData *jsonData = [KSJSONCodec encode:stackTrace options:0 error:&error];
-        if (jsonData == nil || error != nil) {
+        if (jsonData == nil) {
             KSLOG_ERROR(@"Error encoding stack trace to JSON: %@", error);
             // Don't return, since we can still record other useful information.
         }


### PR DESCRIPTION
I saw a few stray error pointer checks that should be checking the returned value from the API being called instead.

There was one more that I didn't address since it looks harmless (but still seems incorrect):

<img width="841" height="195" alt="Screenshot 2025-09-02 at 10 26 42 AM" src="https://github.com/user-attachments/assets/3dfc50e9-61b9-48b3-98a9-9d73889c089a" />
