### PR TITLE
Remove direct dependency between the signal and memory monitors

### DIFF
--- a/Sources/KSCrashCore/include/KSCrashNamespace.h
+++ b/Sources/KSCrashCore/include/KSCrashNamespace.h
@@ -332,7 +332,6 @@
 #define ksmemory_get_fatal_reports_enabled KSCRASH_NS(ksmemory_get_fatal_reports_enabled)
 #define ksmemory_get_nonfatal_report_level KSCRASH_NS(ksmemory_get_nonfatal_report_level)
 #define ksmemory_initialize KSCRASH_NS(ksmemory_initialize)
-#define ksmemory_notifyUnhandledFatalSignal KSCRASH_NS(ksmemory_notifyUnhandledFatalSignal)
 #define ksmemory_previous_session_was_terminated_due_to_memory \
     KSCRASH_NS(ksmemory_previous_session_was_terminated_due_to_memory)
 #define ksmemory_set_fatal_reports_enabled KSCRASH_NS(ksmemory_set_fatal_reports_enabled)

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.h
@@ -122,12 +122,6 @@ void ksmemory_set_fatal_reports_enabled(bool enabled);
  */
 bool ksmemory_get_fatal_reports_enabled(void);
 
-/** Notifies memory monitoring logic that there was an unhandled fatal signal.
- *  E.g. SIGTERM is not considered as a crash by-default but ignoring this signal
- *  causes false-positive OOM reports.
- */
-void ksmemory_notifyUnhandledFatalSignal(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.m
@@ -288,7 +288,7 @@ static void addContextualInfoToEvent(KSCrash_MonitorContext *eventContext)
     // we'll use this when reading this back on the next run
     // to know if an OOM is even possible.
     if (asyncSafeOnly) {
-        // since we're in a singal or something that can only
+        // since we're in a signal or something that can only
         // use async safe functions, we can't lock.
         // It's "ok" though, since no other threads should be running.
         g_memory->fatal = eventContext->requirements.isFatal;
@@ -599,11 +599,3 @@ uint8_t ksmemory_get_nonfatal_report_level(void) { return g_MinimumNonFatalRepor
 void ksmemory_set_fatal_reports_enabled(bool enabled) { g_FatalReportsEnabled = enabled; }
 
 bool ksmemory_get_fatal_reports_enabled(void) { return g_FatalReportsEnabled; }
-
-void ksmemory_notifyUnhandledFatalSignal(void)
-{
-    // this is only called from a signal so we cannot lock.
-    if (g_memory) {
-        g_memory->fatal = true;
-    }
-}

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_Memory_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_Memory_Tests.m
@@ -315,9 +315,4 @@ static KSCrashAppMemory *Memory(uint64_t footprint)
     XCTAssertEqual(ksmemory_get_nonfatal_report_level(), KSCrashAppMemoryStateUrgent);
 }
 
-- (void)testNotifyUnhandledFatalSignal
-{
-    XCTAssertNoThrow(ksmemory_notifyUnhandledFatalSignal(), @"NULL safety for g_memory");
-}
-
 @end


### PR DESCRIPTION
`ksmemory_notifyUnhandledFatalSignal` existed to help avoid triggering false-positive OOM reports when SIGTERM is being captured (because SIGTERM is a normal part of the process shutdown). This also created a direct dependency between the signal and memory monitors.

`ksmemory_notifyUnhandledFatalSignal` is no longer needed since we can get the same effect (the memory monitor gets informed, but no report gets written) by disabling `shouldWriteReport` in the signal handler for such cases.
