### PR TITLE
Return report id from user reports

### DIFF
--- a/Sources/KSCrashRecording/KSCrash.m
+++ b/Sources/KSCrashRecording/KSCrash.m
@@ -274,13 +274,13 @@ static void onNSExceptionHandlingEnabled(NSUncaughtExceptionHandler *uncaughtExc
     return YES;
 }
 
-- (void)reportUserException:(NSString *)name
-                     reason:(NSString *)reason
-                   language:(NSString *)language
-                 lineOfCode:(NSString *)lineOfCode
-                 stackTrace:(NSArray *)stackTrace
-              logAllThreads:(BOOL)logAllThreads
-           terminateProgram:(BOOL)terminateProgram KS_KEEP_FUNCTION_IN_STACKTRACE
+- (int64_t)reportUserException:(NSString *)name
+                        reason:(NSString *)reason
+                      language:(NSString *)language
+                    lineOfCode:(NSString *)lineOfCode
+                    stackTrace:(NSArray *)stackTrace
+                 logAllThreads:(BOOL)logAllThreads
+              terminateProgram:(BOOL)terminateProgram KS_KEEP_FUNCTION_IN_STACKTRACE
 {
     const char *cName = [name cStringUsingEncoding:NSUTF8StringEncoding];
     const char *cReason = [reason cStringUsingEncoding:NSUTF8StringEncoding];
@@ -299,8 +299,10 @@ static void onNSExceptionHandlingEnabled(NSUncaughtExceptionHandler *uncaughtExc
         cStackTrace = [jsonString cStringUsingEncoding:NSUTF8StringEncoding];
     }
 
-    kscrash_reportUserException(cName, cReason, cLanguage, cLineOfCode, cStackTrace, logAllThreads, terminateProgram);
+    int64_t reportId = kscrash_reportUserException(cName, cReason, cLanguage, cLineOfCode, cStackTrace, logAllThreads,
+                                                   terminateProgram);
     KS_THWART_TAIL_CALL_OPTIMISATION
+    return reportId;
 }
 
 - (void)reportNSException:(NSException *)exception logAllThreads:(BOOL)logAllThreads KS_KEEP_FUNCTION_IN_STACKTRACE

--- a/Sources/KSCrashRecording/KSCrashC.c
+++ b/Sources/KSCrashRecording/KSCrashC.c
@@ -374,15 +374,17 @@ void kscrash_setUserInfoJSON(const char *const userInfoJSON) { kscrashreport_set
 
 const char *kscrash_getUserInfoJSON(void) { return kscrashreport_getUserInfoJSON(); }
 
-void kscrash_reportUserException(const char *name, const char *reason, const char *language, const char *lineOfCode,
-                                 const char *stackTrace, bool logAllThreads,
-                                 bool terminateProgram) KS_KEEP_FUNCTION_IN_STACKTRACE
+int64_t kscrash_reportUserException(const char *name, const char *reason, const char *language, const char *lineOfCode,
+                                    const char *stackTrace, bool logAllThreads,
+                                    bool terminateProgram) KS_KEEP_FUNCTION_IN_STACKTRACE
 {
-    kscm_reportUserException(name, reason, language, lineOfCode, stackTrace, logAllThreads, terminateProgram);
+    int64_t reportId =
+        kscm_reportUserException(name, reason, language, lineOfCode, stackTrace, logAllThreads, terminateProgram);
     if (g_shouldAddConsoleLogToReport) {
         kslog_clearLogFile();
     }
     KS_THWART_TAIL_CALL_OPTIMISATION
+    return reportId;
 }
 
 void kscrash_notifyObjCLoad(void) { kscrashstate_notifyObjCLoad(); }

--- a/Sources/KSCrashRecording/KSCrashReportStoreC+Private.h
+++ b/Sources/KSCrashRecording/KSCrashReportStoreC+Private.h
@@ -44,6 +44,12 @@ extern "C" {
 int64_t kscrs_getNextCrashReport(char *crashReportPathBuffer,
                                  const KSCrashReportStoreCConfiguration *const configuration);
 
+/** Get the next crash report id.
+ *
+ * @return The report ID of the next report.
+ */
+int64_t kscrs_getNextCrashReportId(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Sources/KSCrashRecording/KSCrashReportStoreC.c
+++ b/Sources/KSCrashRecording/KSCrashReportStoreC.c
@@ -58,6 +58,8 @@ static int compareInt64(const void *a, const void *b)
 
 static inline int64_t getNextUniqueID(void) { return g_nextUniqueIDHigh + g_nextUniqueIDLow++; }
 
+static inline int64_t getNextUniqueIDWithoutIncrementing(void) { return g_nextUniqueIDHigh + g_nextUniqueIDLow; }
+
 static void getCrashReportPathByID(int64_t id, char *pathBuffer, const KSCrashReportStoreCConfiguration *const config)
 {
     snprintf(pathBuffer, KSCRS_MAX_PATH_LENGTH, "%s/%s-report-%016llx.json", config->reportsPath, config->appName,
@@ -179,6 +181,8 @@ KSCrashInstallErrorCode kscrs_initialize(const KSCrashReportStoreCConfiguration 
     pthread_mutex_unlock(&g_mutex);
     return result;
 }
+
+int64_t kscrs_getNextCrashReportId(void) { return getNextUniqueIDWithoutIncrementing(); }
 
 int64_t kscrs_getNextCrashReport(char *crashReportPathBuffer,
                                  const KSCrashReportStoreCConfiguration *const configuration)

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_User.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_User.c
@@ -50,7 +50,7 @@ int64_t kscm_reportUserException(const char *name, const char *reason, const cha
 {
     if (!g_isEnabled) {
         KSLOG_WARN("User-reported exception monitor is not installed. Exception has not been recorded.");
-        return 0;
+        return -1;
     }
 
     // get the next report id without incrementing it
@@ -63,7 +63,6 @@ int64_t kscm_reportUserException(const char *name, const char *reason, const cha
                                                               .shouldRecordAllThreads = logAllThreads,
                                                               .shouldWriteReport = true });
     if (ctx->requirements.shouldExitImmediately) {
-        nextReportId = 0;
         goto exit_immediately;
     }
 

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_User.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_User.h
@@ -53,9 +53,11 @@ extern "C" {
  *                      performance penalty, so it's best to use only on fatal errors.
  *
  * @param terminateProgram If true, do not return from this function call. Terminate the program instead.
+ *
+ * @return the new report's ID.
  */
-void kscm_reportUserException(const char *name, const char *reason, const char *language, const char *lineOfCode,
-                              const char *stackTrace, bool logAllThreads, bool terminateProgram);
+int64_t kscm_reportUserException(const char *name, const char *reason, const char *language, const char *lineOfCode,
+                                 const char *stackTrace, bool logAllThreads, bool terminateProgram);
 
 /** Access the Monitor API.
  */

--- a/Sources/KSCrashRecording/include/KSCrash.h
+++ b/Sources/KSCrashRecording/include/KSCrash.h
@@ -149,14 +149,16 @@ NS_ASSUME_NONNULL_BEGIN
  *                      performance penalty, so it's best to use only on fatal errors.
  *
  * @param terminateProgram If true, do not return from this function call. Terminate the program instead.
+ *
+ * @return The new report ID.
  */
-- (void)reportUserException:(NSString *)name
-                     reason:(nullable NSString *)reason
-                   language:(nullable NSString *)language
-                 lineOfCode:(nullable NSString *)lineOfCode
-                 stackTrace:(nullable NSArray *)stackTrace
-              logAllThreads:(BOOL)logAllThreads
-           terminateProgram:(BOOL)terminateProgram;
+- (int64_t)reportUserException:(NSString *)name
+                        reason:(nullable NSString *)reason
+                      language:(nullable NSString *)language
+                    lineOfCode:(nullable NSString *)lineOfCode
+                    stackTrace:(nullable NSArray *)stackTrace
+                 logAllThreads:(BOOL)logAllThreads
+              terminateProgram:(BOOL)terminateProgram;
 
 /** Report an NSException as if it's caught by the NSException monitor.
  *

--- a/Sources/KSCrashRecording/include/KSCrashC.h
+++ b/Sources/KSCrashRecording/include/KSCrashC.h
@@ -122,9 +122,11 @@ const char *kscrash_getUserInfoJSON(void);
  *                      performance penalty, so it's best to use only on fatal errors.
  *
  * @param terminateProgram If true, do not return from this function call. Terminate the program instead.
+ *
+ * @return the new report's ID.
  */
-void kscrash_reportUserException(const char *name, const char *reason, const char *language, const char *lineOfCode,
-                                 const char *stackTrace, bool logAllThreads, bool terminateProgram);
+int64_t kscrash_reportUserException(const char *name, const char *reason, const char *language, const char *lineOfCode,
+                                    const char *stackTrace, bool logAllThreads, bool terminateProgram);
 
 #pragma mark-- Notifications --
 


### PR DESCRIPTION
## Summary
  This PR enhances the user report functionality by returning the report ID when creating user reports, allowing
  callers to track and reference specific reports.

  ## Changes Made

  ### API Updates
  - **C API**: Modified `kscrash_reportUserException()` to return `int64_t` report ID instead of `void`
  - **Objective-C API**: Updated
  `reportUserException:reason:language:lineOfCode:stackTrace:logAllThreads:terminateProgram:` to return `int64_t`
  report ID
  - **Internal APIs**: Updated `kscm_reportUserException()` in the user monitor to return report ID

  ### Implementation Details
  - Added `kscrs_getNextCrashReportId()` function to get the next report ID without incrementing the counter
  - Modified report generation flow to capture and return the report ID before writing the report
  - Returns `0` if the user monitor is not installed or if immediate exit is required
  
  ## Possibly Breaking Changes
  This is a **breaking change** for existing callers of the user exception reporting APIs, as the return type has
  changed from `void` to `int64_t`.