### PR TITLE
Fix outdated headerdoc reference in KSCrashInstallation

### DIFF
--- a/Sources/KSCrashInstallations/include/KSCrashInstallation.h
+++ b/Sources/KSCrashInstallations/include/KSCrashInstallation.h
@@ -105,7 +105,7 @@ NS_SWIFT_NAME(CrashInstallation)
 /** Convenience method to call -[KSCrash sendAllReportsWithCompletion:].
  * This method will set the KSCrash sink and then send all outstanding reports.
  *
- * Note: Pay special attention to KSCrash's "deleteBehaviorAfterSendAll" property.
+ * Note: Pay special attention to KSCrashConfiguration's `reportCleanupPolicy` property.
  *
  * @param onCompletion Called when sending is complete (nil = ignore).
  */


### PR DESCRIPTION
One thing I noticed while trying to configure the deletion policy, the headerdoc references a property that no longer exists, might be pre–2.x?