### PR TITLE
Fix arm64e build

### DIFF
--- a/.github/workflows/build-devices.yml
+++ b/.github/workflows/build-devices.yml
@@ -25,15 +25,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: iOS
-            archs: "arm64 arm64e"
-          - platform: watchOS
-            archs: "arm64_32"
-          - platform: tvOS
-            archs: "arm64"
-          - platform: macOS
-            archs: "arm64 x86_64"
+        platform:
+          - iOS
+          - watchOS
+          - tvOS
+          - macOS
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -43,17 +39,12 @@ jobs:
         with:
           xcode-version: latest-stable
 
-      - name: Download Platform SDK
-        if: matrix.platform != 'macOS'
-        continue-on-error: true
-        run: |
-          xcodebuild -downloadPlatform ${{ matrix.platform }} -architectureVariant universal
-
       - name: Build for Device Platform
-        run: |
-          xcodebuild build \
-            -workspace ".swiftpm/xcode/package.xcworkspace" \
-            -scheme "KSCrash-Package" \
-            -destination "generic/platform=${{ matrix.platform }}" \
-            -configuration Release \
-            ARCHS="${{ matrix.archs }}"
+        uses: mxcl/xcodebuild@v3
+        timeout-minutes: 10
+        with:
+          action: build
+          workspace: ".swiftpm/xcode/package.xcworkspace"
+          scheme: "KSCrash-Package"
+          destination: generic/platform=${{ matrix.platform }}
+          configuration: Release


### PR DESCRIPTION
## Problem

Building for arm64e architecture was failing with compilation errors about missing struct members.

**Error:**
```
error: no member named '__fp' in 'struct __darwin_arm_thread_state64'
error: no member named '__lr' in 'struct __darwin_arm_thread_state64'
error: no member named '__sp' in 'struct __darwin_arm_thread_state64'
error: no member named '__pc' in 'struct __darwin_arm_thread_state64'
```

When `__DARWIN_OPAQUE_ARM_THREAD_STATE64` is defined (for arm64e), the thread state struct members change from `__fp`, `__lr`, `__sp`, `__pc` to `__opaque_fp`, `__opaque_lr`, `__opaque_sp`, `__opaque_pc`.

**Context:**
arm64e has been available in hardware since the A12 chip, but Apple kept changing the ABI to fix security weaknesses, making it unusable for 3rd-party. ref: [Xcode 10.1 Release Notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-10_1-release-notes)
It seems that the arm64e ABI was finally stabilized in **iOS/macOS 26**, making it safe for 3rd-party apps. ref: [this Stack Overflow discussion](https://stackoverflow.com/questions/66163619/arm64e-architecture-for-ios-framework) has historical weaknesses.
I don't see official announcement but this is critical to support.

**To reproduce:**
```bash
xcodebuild build -workspace ".swiftpm/xcode/package.xcworkspace" -scheme "KSCrash-Package" -destination "generic/platform=iOS" -configuration Release ARCHS="arm64 arm64e"
```

## Solution

**Fix arm64e support**

~~Added conditional macros to handle both regular arm64 and arm64e thread state structures in `KSCPU_arm64.c`: Created `THREAD_STATE_FP`, `THREAD_STATE_LR`, `THREAD_STATE_SP`, `THREAD_STATE_PC` macros that select correct member names based on `__DARWIN_OPAQUE_ARM_THREAD_STATE64`~~

Use built-in `arm_thread_state64_get_` macros.

**Add arm64e build validation**
Reverting the checks as Github Runners need to download platforms with universal architecture variant. It represent ~10GB for iOS and ~5GB for watchOS to download for each build.

~~Enhanced CI to explicitly test arm64e and other device architectures:~~
~~- `build-devices.yml`: Changed from platform-only matrix to include explicit architecture testing:~~
  ~~- iOS: arm64, arm64e~~
  ~~- watchOS: arm64_32~~
  ~~- tvOS: arm64~~
  ~~- macOS: arm64, x86_64~~