### PR TITLE
fix: watchdog monitor now collects threads

### DIFF
--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Watchdog.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Watchdog.m
@@ -482,12 +482,12 @@ static int TaskRole(void)
                 .asyncSafety = false, .isFatal = false, .shouldRecordAllThreads = true, .shouldWriteReport = true });
 
         KSMachineContext machineContext = { 0 };
-        ksmc_getContextForThread(g_mainQueueThread, &machineContext, false);
+        ksmc_getContextForThread(g_mainQueueThread, &machineContext, true);
         KSStackCursor stackCursor;
         kssc_initWithMachineContext(&stackCursor, KSSC_MAX_STACK_DEPTH, &machineContext);
 
         kscm_fillMonitorContext(crashContext, kscm_watchdog_getAPI());
-        crashContext->registersAreValid = false;
+        crashContext->registersAreValid = true;
         crashContext->offendingMachineContext = &machineContext;
         crashContext->stackCursor = &stackCursor;
 


### PR DESCRIPTION
- Fix watchdog monitor to properly capture thread backtraces in crash reports
- Add integration test to verify threads are present in watchdog timeout reports