### PR TITLE
RFC: KSCrash 3.0 - Run-Scoped Data Model

### DIFF
--- a/Proposals/KSCrash-3.0-Proposal.md
+++ b/Proposals/KSCrash-3.0-Proposal.md
@@ -3,7 +3,7 @@
 ## Summary
 KSCrash currently cannot produce reports for terminations that lack crash-time callbacks—OOM, SIGKILL, watchdog kills. When iOS terminates an app this way, there's no opportunity to capture context, so these events go unreported.
 
-This proposal introduces a run-scoped data model where each app launch writes all data for that run into a dedicated folder. Crash-time data stays minimal and async-safe, while metadata is continuously updated via mmap-backed structs (example: [`KSCrash_Memory`](Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.h)). Reports are stitched from crash data + latest metadata at send time. For terminations without crash-time callbacks, reports are assembled on next launch using the prior run's metadata.
+This proposal introduces a run-scoped data model where each app launch writes all data for that run into a dedicated folder. Crash-time data stays minimal and async-safe, while metadata is continuously updated via mmap-backed structs (example: [`KSCrash_Memory`](../Sources/KSCrashRecording/Monitors/KSCrashMonitor_Memory.h)). Reports are stitched from crash data + latest metadata at send time. For terminations without crash-time callbacks, reports are assembled on next launch using the prior run's metadata.
 
 ## Goals
 


### PR DESCRIPTION
This [proposal](https://github.com/kstenerud/KSCrash/blob/proposal/kscrash-3.0/Proposals/KSCrash-3.0-Proposal.md) introduces a run-scoped data model for KSCrash to address a key gap: terminations without crash-time callbacks (OOM, SIGKILL, watchdog) currently go unreported.

**Key changes:**
- Each app launch writes to a dedicated `Data/Runs/<run-id>/` folder
- Crash-time data stays minimal and async-signal-safe (`term/*.bin`)
- Metadata is continuously updated via mmap-backed structs (`meta/*.bin`)
- Reports are stitched from crash data + metadata at send time or next launch

## Status
This is an early-stage RFC for discussion. The document covers:
- ✅ Problem statement and goals
- ✅ Proposed architecture and data flow
- ✅ Migration/compatibility approach
- 🔲 Termination heuristics (TBD)
- 🔲 Cleanup policies (TBD)
- 🔲 Implementation details (TBD)

## Feedback Requested
- Does the overall approach make sense?
- Are there additional termination scenarios to consider?
- Concerns about startup latency or disk usage?