### PR TITLE
ci: add Infer static analysis and fix PR comments for fork PRs

### DIFF
--- a/.github/scripts/infer_clean_compile_commands.py
+++ b/.github/scripts/infer_clean_compile_commands.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+#
+#  infer_clean_compile_commands.py
+#
+#  Created by Alexander Cohen on 2025-01-29.
+#
+#  Copyright (c) 2012 Karl Stenerud. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall remain in place
+# in this source code.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+"""
+Post-processes an xcodebuild-generated compile_commands.json for use with Infer.
+
+Performs:
+1. Fixes escaped equals signs (\\= -> =)
+2. Removes unsupported compiler flags
+3. Removes @response-file references
+4. Removes -include references pointing to DerivedData
+5. Filters to C/C++/Objective-C files only (.c, .cpp, .m, .mm)
+"""
+
+import json
+import sys
+import os
+
+
+# Flags that take no argument and should be removed entirely
+REMOVE_FLAGS_NO_ARG = {
+    "-fmodules-validate-once-per-build-session",
+}
+
+# Flags that take the next token as an argument (remove flag + argument)
+REMOVE_FLAGS_WITH_ARG = {
+    "-ivfsstatcache",
+    "-index-store-path",
+    "-index-unit-output-path",
+    "-fbuild-session-file",
+}
+
+# Flags where the argument is joined (e.g., --serialize-diagnostics /path)
+REMOVE_FLAGS_WITH_ARG_ALSO = {
+    "--serialize-diagnostics",
+}
+
+# Extensions to keep
+ALLOWED_EXTENSIONS = {".c", ".cpp", ".m", ".mm"}
+
+
+def clean_command(command: str) -> str:
+    """Clean a single compile command string."""
+    # Fix escaped equals signs
+    command = command.replace("\\=", "=")
+
+    # Split into tokens for flag-level processing
+    tokens = command.split()
+    cleaned = []
+    skip_next = False
+
+    for i, token in enumerate(tokens):
+        if skip_next:
+            skip_next = False
+            continue
+
+        # Remove @response-file references
+        if token.startswith("@") and token.endswith(".resp"):
+            continue
+
+        # Remove flags with no argument
+        if token in REMOVE_FLAGS_NO_ARG:
+            continue
+
+        # Remove flags that consume the next argument
+        if token in REMOVE_FLAGS_WITH_ARG or token in REMOVE_FLAGS_WITH_ARG_ALSO:
+            skip_next = True
+            continue
+
+        # Remove -include pointing to DerivedData
+        if token == "-include" and i + 1 < len(tokens):
+            next_token = tokens[i + 1]
+            if "DerivedData" in next_token:
+                skip_next = True
+                continue
+
+        cleaned.append(token)
+
+    return " ".join(cleaned)
+
+
+def get_source_file(entry: dict) -> str:
+    """Extract the source file path from a compilation database entry."""
+    return entry.get("file") or ""
+
+
+def is_c_or_cpp(filepath: str) -> bool:
+    """Check if the file has a C, C++, or Objective-C extension."""
+    _, ext = os.path.splitext(filepath)
+    return ext.lower() in ALLOWED_EXTENSIONS
+
+
+def clean_compile_commands(input_path: str, output_path: str) -> None:
+    """Clean and filter a compilation database."""
+    with open(input_path, "r") as f:
+        entries = json.load(f)
+
+    cleaned = []
+    for entry in entries:
+        source_file = get_source_file(entry)
+
+        # Filter to C/C++ files only
+        if not is_c_or_cpp(source_file):
+            continue
+
+        new_entry = dict(entry)
+        if "command" in new_entry:
+            new_entry["command"] = clean_command(new_entry["command"])
+        if "arguments" in new_entry:
+            # Re-join arguments, clean as a single command, then re-split
+            joined = " ".join(new_entry["arguments"])
+            cleaned_cmd = clean_command(joined)
+            new_entry["arguments"] = cleaned_cmd.split()
+
+        cleaned.append(new_entry)
+
+    with open(output_path, "w") as f:
+        json.dump(cleaned, f, indent=2)
+
+    print(f"Cleaned {len(entries)} -> {len(cleaned)} entries (C/C++/ObjC only)")
+    print(f"Output written to {output_path}")
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <input.json> <output.json>", file=sys.stderr)
+        sys.exit(1)
+
+    input_path = sys.argv[1]
+    output_path = sys.argv[2]
+
+    if not os.path.exists(input_path):
+        print(f"Error: input file not found: {input_path}", file=sys.stderr)
+        sys.exit(1)
+
+    clean_compile_commands(input_path, output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/infer.yml
+++ b/.github/workflows/infer.yml
@@ -1,0 +1,411 @@
+name: Infer Static Analysis
+
+on:
+  pull_request:
+    paths:
+      - "Sources/**/*.c"
+      - "Sources/**/*.cpp"
+      - "Sources/**/*.h"
+      - "Sources/**/*.m"
+      - "Sources/**/*.mm"
+      - "Tests/**/*.c"
+      - "Tests/**/*.cpp"
+      - "Tests/**/*.h"
+      - "Tests/**/*.m"
+      - "Tests/**/*.mm"
+      - "Package.swift"
+      - ".github/workflows/infer.yml"
+      - ".github/scripts/infer_clean_compile_commands.py"
+
+  push:
+    branches:
+      - master
+
+  schedule:
+    - cron: "0 0 1 * *"
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  INFER_VERSION: "1.2.0"
+  COMMENT_ON_CLEAN: "false"
+  INFER_RUNS: "5"
+
+jobs:
+  infer:
+    runs-on: macos-15
+    timeout-minutes: 60
+    steps:
+      # ── Checkout ──────────────────────────────────────────────
+      - name: Checkout PR Branch
+        uses: actions/checkout@v6
+        with:
+          path: pr-branch
+
+      - name: Checkout Base Branch
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base-branch
+
+      - name: Get Changed Files
+        if: github.event_name == 'pull_request'
+        run: |
+          diff -rq pr-branch base-branch \
+            | grep -E '\.(c|cpp|m|mm|h)( differ|$)' \
+            | sed -E 's|^Files pr-branch/||; s| and .*||; s|^Only in pr-branch/||; s|: |/|' \
+            | sort -u > changed_files.txt
+          echo "Changed files:"
+          cat changed_files.txt
+
+      # ── Tool Setup ────────────────────────────────────────────
+      - name: Use Latest Stable Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Install xcpretty
+        run: gem install xcpretty
+
+      - name: Cache Infer Binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/infer-*
+          key: infer-${{ env.INFER_VERSION }}-${{ runner.arch }}
+
+      - name: Install Infer
+        run: |
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "arm64" ]; then
+            INFER_ARCH="arm64"
+          else
+            INFER_ARCH="x86_64"
+          fi
+
+          CACHE_DIR="${HOME}/.cache/infer-${INFER_VERSION}-${INFER_ARCH}"
+
+          if [ -d "$CACHE_DIR/infer-osx-${INFER_ARCH}-v${INFER_VERSION}" ]; then
+            echo "Using cached Infer installation"
+          else
+            echo "Downloading Infer v${INFER_VERSION} for ${INFER_ARCH}..."
+            mkdir -p "$CACHE_DIR"
+            curl -sSL \
+              "https://github.com/facebook/infer/releases/download/v${INFER_VERSION}/infer-osx-${INFER_ARCH}-v${INFER_VERSION}.tar.xz" \
+              -o /tmp/infer.tar.xz
+            tar -xJf /tmp/infer.tar.xz -C "$CACHE_DIR"
+            rm /tmp/infer.tar.xz
+          fi
+
+          INFER_HOME="$CACHE_DIR/infer-osx-${INFER_ARCH}-v${INFER_VERSION}"
+          echo "${INFER_HOME}/bin" >> $GITHUB_PATH
+          echo "INFER_HOME=${INFER_HOME}" >> $GITHUB_ENV
+
+      - name: Verify Infer Installation
+        run: infer --version
+
+      # ── Build PR Branch ───────────────────────────────────────
+      - name: Build PR Branch
+        working-directory: pr-branch
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -workspace ".swiftpm/xcode/package.xcworkspace" \
+            -scheme "KSCrash-Package" \
+            -destination "platform=macOS" \
+            | tee xcodebuild.log \
+            | xcpretty --report json-compilation-database --output compile_commands.json
+
+      # ── Build Base Branch ─────────────────────────────────────
+      - name: Build Base Branch
+        if: github.event_name == 'pull_request'
+        working-directory: base-branch
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -workspace ".swiftpm/xcode/package.xcworkspace" \
+            -scheme "KSCrash-Package" \
+            -destination "platform=macOS" \
+            | tee xcodebuild.log \
+            | xcpretty --report json-compilation-database --output compile_commands.json
+
+      # ── Clean Compilation Databases ───────────────────────────
+      - name: Clean PR Compilation Database
+        run: |
+          python3 pr-branch/.github/scripts/infer_clean_compile_commands.py \
+            pr-branch/compile_commands.json \
+            pr-branch/compile_commands_c_only.json
+
+      - name: Clean Base Compilation Database
+        if: github.event_name == 'pull_request'
+        run: |
+          python3 pr-branch/.github/scripts/infer_clean_compile_commands.py \
+            base-branch/compile_commands.json \
+            base-branch/compile_commands_c_only.json
+
+      # ── Run Infer ─────────────────────────────────────────────
+      # Run capture once, then analyze multiple times to reduce non-determinism.
+      # Results are merged into a single report per branch.
+      - name: Run Infer on PR Branch
+        run: |
+          infer run \
+            --keep-going \
+            --project-root pr-branch \
+            --results-dir infer-out-pr \
+            --compilation-database pr-branch/compile_commands_c_only.json
+          cp infer-out-pr/report.json infer-out-pr/report-1.json
+
+          for i in $(seq 2 "$INFER_RUNS"); do
+            echo "=== PR analysis run $i/$INFER_RUNS ==="
+            infer analyze \
+              --keep-going \
+              --results-dir infer-out-pr
+            cp infer-out-pr/report.json "infer-out-pr/report-$i.json"
+          done
+
+          python3 -c "
+          import json, glob
+          merged = {}
+          for f in glob.glob('infer-out-pr/report-*.json'):
+              for issue in json.load(open(f)):
+                  key = (issue.get('bug_type',''), issue.get('file',''), issue.get('line',0))
+                  if key not in merged:
+                      merged[key] = issue
+          result = list(merged.values())
+          json.dump(result, open('infer-out-pr/report.json', 'w'), indent=2)
+          print(f'Merged {len(result)} unique issues from $INFER_RUNS runs')
+          "
+
+      - name: Run Infer on Base Branch
+        if: github.event_name == 'pull_request'
+        run: |
+          infer run \
+            --keep-going \
+            --project-root base-branch \
+            --results-dir infer-out-base \
+            --compilation-database base-branch/compile_commands_c_only.json
+          cp infer-out-base/report.json infer-out-base/report-1.json
+
+          for i in $(seq 2 "$INFER_RUNS"); do
+            echo "=== Base analysis run $i/$INFER_RUNS ==="
+            infer analyze \
+              --keep-going \
+              --results-dir infer-out-base
+            cp infer-out-base/report.json "infer-out-base/report-$i.json"
+          done
+
+          python3 -c "
+          import json, glob
+          merged = {}
+          for f in glob.glob('infer-out-base/report-*.json'):
+              for issue in json.load(open(f)):
+                  key = (issue.get('bug_type',''), issue.get('file',''), issue.get('line',0))
+                  if key not in merged:
+                      merged[key] = issue
+          result = list(merged.values())
+          json.dump(result, open('infer-out-base/report.json', 'w'), indent=2)
+          print(f'Merged {len(result)} unique issues from $INFER_RUNS runs')
+          "
+
+      # ── Diff & Report ─────────────────────────────────────────
+      - name: Generate Report
+        id: report
+        run: |
+          python3 << 'PYTHON_SCRIPT'
+          import json
+          import os
+          from datetime import datetime, timezone
+
+          is_pr = os.environ.get("IS_PR", "false") == "true"
+
+          def load_report(path):
+              if not os.path.exists(path):
+                  return []
+              with open(path) as f:
+                  return json.load(f)
+
+          def load_changed_files(path):
+              if not os.path.exists(path):
+                  return set()
+              with open(path) as f:
+                  return set(line.strip() for line in f if line.strip())
+
+          def issue_key(issue):
+              """Create a stable key for comparing issues across runs."""
+              return (
+                  issue.get("bug_type", ""),
+                  issue.get("file", ""),
+                  issue.get("line", 0),
+              )
+
+          repo = os.environ.get("GITHUB_REPO", "")
+          head_sha = os.environ.get("HEAD_SHA", "")
+
+          def file_link(filepath, line):
+              """Create a GitHub link to the file and line."""
+              if repo and head_sha:
+                  url = f"https://github.com/{repo}/blob/{head_sha}/{filepath}#L{line}"
+                  return f"[`{filepath}:{line}`]({url})"
+              return f"`{filepath}:{line}`"
+
+          def format_issues(issues, title):
+              """Format a list of issues as markdown."""
+              if not issues:
+                  return f"**{title}:** None\n"
+              lines = [f"**{title}:** {len(issues)} issue(s)\n"]
+              lines.append("| Severity | Type | File | Description |")
+              lines.append("|----------|------|------|-------------|")
+              for issue in issues:
+                  sev = issue.get("severity", "WARNING")
+                  bug_type = issue.get("bug_type", "unknown")
+                  bug_type_link = f"[`{bug_type}`](https://fbinfer.com/docs/all-issue-types/#{bug_type.lower()})"
+                  filepath = issue.get("file", "unknown")
+                  line = issue.get("line", 0)
+                  qualifier = issue.get("qualifier", "").replace("|", "\\|")
+                  if len(qualifier) > 200:
+                      qualifier = qualifier[:197] + "..."
+                  location = file_link(filepath, line)
+                  lines.append(f"| {sev} | {bug_type_link} | {location} | {qualifier} |")
+              lines.append("")
+              return "\n".join(lines)
+
+          timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+          output = []
+          output.append("## Infer Static Analysis Report\n")
+
+          if is_pr:
+              # Differential mode: compare PR and base, scoped to changed files only
+              changed_files = load_changed_files("changed_files.txt")
+
+              pr_all = load_report("infer-out-pr/report.json")
+              base_all = load_report("infer-out-base/report.json")
+
+              # Filter both reports to only changed files
+              pr_issues = [i for i in pr_all if i.get("file", "") in changed_files]
+              base_issues = [i for i in base_all if i.get("file", "") in changed_files]
+
+              pr_keys = set(issue_key(i) for i in pr_issues)
+              base_keys = set(issue_key(i) for i in base_issues)
+
+              new_keys = pr_keys - base_keys
+              fixed_keys = base_keys - pr_keys
+
+              new_issues = [i for i in pr_issues if issue_key(i) in new_keys]
+              fixed_issues = [i for i in base_issues if issue_key(i) in fixed_keys]
+              preexisting = [i for i in pr_issues if issue_key(i) not in new_keys]
+
+              if not new_issues:
+                  output.append(":white_check_mark: **No new issues introduced by this PR.**\n")
+              else:
+                  output.append(f":warning: **This PR introduces {len(new_issues)} new issue(s).**\n")
+
+              if fixed_issues:
+                  output.append(f":tada: **This PR fixes {len(fixed_issues)} existing issue(s).**\n")
+
+              if new_issues:
+                  output.append("<details open>")
+                  output.append("<summary>New Issues ({} total)</summary>\n".format(len(new_issues)))
+                  output.append(format_issues(new_issues, "New Issues"))
+                  output.append("</details>\n")
+
+              if fixed_issues:
+                  output.append("<details>")
+                  output.append("<summary>Fixed Issues</summary>\n")
+                  output.append(format_issues(fixed_issues, "Fixed Issues"))
+                  output.append("</details>\n")
+
+              if preexisting:
+                  output.append("<details>")
+                  output.append("<summary>Pre-existing Issues ({} total)</summary>\n".format(len(preexisting)))
+                  output.append(format_issues(preexisting, "Pre-existing Issues"))
+                  output.append("</details>\n")
+
+              has_new_issues = len(new_issues) > 0
+          else:
+              # Full report mode (push / schedule)
+              all_issues = load_report("infer-out-pr/report.json")
+              if not all_issues:
+                  output.append(":white_check_mark: **No issues found.**\n")
+              else:
+                  output.append(f":warning: **Found {len(all_issues)} issue(s).**\n")
+              output.append(format_issues(all_issues, "All Issues"))
+              has_new_issues = False
+
+          output.append("---")
+          output.append("> **Note:** Infer may report false positives. Please review each issue carefully before making changes.")
+          output.append("")
+          output.append(f"*Analysis performed with [Infer](https://fbinfer.com/) v{os.environ.get('INFER_VERSION', 'unknown')} at {timestamp}*")
+
+          report = "\n".join(output)
+
+          with open("infer-report.md", "w") as f:
+              f.write(report)
+
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary_path:
+              with open(summary_path, "a") as f:
+                  f.write(report)
+
+          output_path = os.environ.get("GITHUB_OUTPUT")
+          if output_path:
+              with open(output_path, "a") as f:
+                  f.write(f"has_new_issues={'true' if has_new_issues else 'false'}\n")
+
+          print(report)
+          PYTHON_SCRIPT
+        env:
+          IS_PR: ${{ github.event_name == 'pull_request' }}
+          INFER_VERSION: ${{ env.INFER_VERSION }}
+          GITHUB_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      # ── PR Comment ────────────────────────────────────────────
+      - name: Comment on PR
+        if: |
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          (steps.report.outputs.has_new_issues == 'true' || env.COMMENT_ON_CLEAN == 'true')
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          file-path: infer-report.md
+          comment-tag: infer-analysis-report
+
+      - name: Remove PR Comment if No Issues
+        if: |
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          steps.report.outputs.has_new_issues != 'true' &&
+          env.COMMENT_ON_CLEAN != 'true'
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          comment-tag: infer-analysis-report
+          mode: delete
+
+      # ── Fail on New Issues ────────────────────────────────────
+      - name: Fail if New Issues Found
+        if: github.event_name == 'pull_request' && steps.report.outputs.has_new_issues == 'true'
+        run: |
+          echo "Infer found new issues introduced by this PR"
+          exit 1
+
+      # ── Artifacts ─────────────────────────────────────────────
+      - name: Upload Infer Results
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: infer-results
+          path: |
+            infer-out-pr/
+            infer-out-base/
+            infer-report.md
+            pr-branch/compile_commands.json
+            pr-branch/compile_commands_c_only.json
+          retention-days: 30

--- a/.github/workflows/leaks.yml
+++ b/.github/workflows/leaks.yml
@@ -285,7 +285,10 @@ jobs:
           retention-days: 30
 
       - name: Comment PR with Results
-        if: github.event_name == 'pull_request' && steps.report.outputs.has_real_leaks == 'true'
+        if: |
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          steps.report.outputs.has_real_leaks == 'true'
         uses: thollander/actions-comment-pull-request@v3
         with:
           file-path: leaks_report.md

--- a/.github/workflows/static-analyzer.yml
+++ b/.github/workflows/static-analyzer.yml
@@ -15,6 +15,10 @@ on:
   schedule:
     - cron: "0 0 1 * *"
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -129,33 +133,25 @@ jobs:
           # Also write to job summary
           cat /tmp/analyzer-report.md >> $GITHUB_STEP_SUMMARY
 
-      - name: Comment on PR
+      - name: Check for Warnings
         if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
+        id: check-warnings
         run: |
-          if ! grep -q ":warning:" /tmp/analyzer-report.md; then
-            echo "No warnings found - skipping comment"
-            exit 0
-          fi
-
-          # Add hidden marker to identify our comment
-          echo "<!-- static-analyzer-report -->" > /tmp/pr-comment.md
-          cat /tmp/analyzer-report.md >> /tmp/pr-comment.md
-
-          # Find existing comment with our marker
-          COMMENT_ID=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
-            --jq '.[] | select(.body | contains("<!-- static-analyzer-report -->")) | .id' | head -1)
-
-          if [ -n "$COMMENT_ID" ]; then
-            # Update existing comment
-            gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID \
-              -X PATCH \
-              -F body=@/tmp/pr-comment.md
+          if grep -q ":warning:" /tmp/analyzer-report.md; then
+            echo "has_warnings=true" >> $GITHUB_OUTPUT
           else
-            # Create new comment
-            gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/pr-comment.md
+            echo "has_warnings=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Comment on PR
+        if: |
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          steps.check-warnings.outputs.has_warnings == 'true'
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          file-path: /tmp/analyzer-report.md
+          comment-tag: static-analyzer-report
 
       - name: Fail if warnings found
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ Gemfile.lock
 /Benchmarks/KSCrashBenchmarks.xcworkspace
 /.github/scripts/__pycache__
 Benchmarks/benchmark_results.md
+### Infer ###
+infer-out/
+compile_commands.json
+compile_commands_c_only.json


### PR DESCRIPTION
### Infer Static Analysis Workflow
- Add Infer static analysis workflow for C/ObjC code
- **PR mode:** Runs analysis on both PR and base branches, compares results scoped to changed files only — new issues are those present in the PR but not the base for files modified by the PR
- **Push/schedule mode:** Full analysis of the entire codebase
- Runs `infer analyze` 5 times per branch and merges results to reduce non-deterministic false positives/negatives
- PR comments include clickable links to source locations and Infer documentation for each issue type
- Comments are posted only when new issues are found; deleted when the PR is clean (configurable via `COMMENT_ON_CLEAN` env var)
- Supports `workflow_dispatch` for manual runs
- Includes a helper script to filter `compile_commands.json` to C/ObjC files only

### Fork PR Comment Fixes
- Skip PR comment steps for fork PRs in `infer.yml`, `static-analyzer.yml`, and `leaks.yml` (fork `GITHUB_TOKEN` lacks write permissions)
- Fork PRs still get full analysis, job summaries, and uploaded artifacts

### Other
- Refactor `static-analyzer.yml` to use `thollander/actions-comment-pull-request` for consistency
- Add infer-related entries to `.gitignore`

## Example

<img width="946" height="490" alt="Screenshot 2026-01-29 at 4 54 41 PM" src="https://github.com/user-attachments/assets/195f02d0-c0bb-49b1-af82-9c9352c72e90" />
