### PR TITLE
Track app transition state in hang reports, suppress startup hangs

### DIFF
--- a/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
+++ b/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
@@ -250,7 +250,7 @@ NSString *const KSCrashNSExceptionStacktraceFuncName = @"exceptionWithStacktrace
     // (threshold is 250ms), then spin the run loop so the BeforeWaiting
     // observer fires and finalizes the recovered hang report in-place.
     [NSThread sleepForTimeInterval:2.0];
-    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:5.0]];
 }
 
 + (void)trigger_other_sigkill

--- a/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
+++ b/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
@@ -250,7 +250,7 @@ NSString *const KSCrashNSExceptionStacktraceFuncName = @"exceptionWithStacktrace
     // (threshold is 250ms), then spin the run loop so the BeforeWaiting
     // observer fires and finalizes the recovered hang report in-place.
     [NSThread sleepForTimeInterval:2.0];
-    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:5.0]];
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
 }
 
 + (void)trigger_other_sigkill

--- a/Samples/Common/Sources/IntegrationTestsHelper/IntegrationTestRunner.swift
+++ b/Samples/Common/Sources/IntegrationTestsHelper/IntegrationTestRunner.swift
@@ -31,10 +31,12 @@ public final class IntegrationTestRunner {
     public struct RunConfig: Codable {
         var delay: TimeInterval?
         var stateSavePath: String?
+        var runEarly: Bool?
 
-        public init(delay: TimeInterval? = nil, stateSavePath: String? = nil) {
+        public init(delay: TimeInterval? = nil, stateSavePath: String? = nil, runEarly: Bool? = nil) {
             self.delay = delay
             self.stateSavePath = stateSavePath
+            self.runEarly = runEarly
         }
     }
 
@@ -53,14 +55,35 @@ public final class IntegrationTestRunner {
         ProcessInfo.processInfo.environment[Self.envKey] != nil
     }
 
+    /// Runs the script during app init, before the app becomes active.
+    /// Only executes if `config.runEarly` is true.
+    public static func runEarlyIfNeeded() {
+        guard let script = decodeScript(), script.config?.runEarly == true else {
+            return
+        }
+        executeScript(script)
+    }
+
+    /// Runs the script from onAppear, after the app is active.
+    /// Skips if `config.runEarly` is true (already handled).
     public static func runIfNeeded() {
-        guard let scriptString = ProcessInfo.processInfo.environment[Self.envKey],
+        guard let script = decodeScript(), script.config?.runEarly != true else {
+            return
+        }
+        executeScript(script)
+    }
+
+    private static func decodeScript() -> Script? {
+        guard let scriptString = ProcessInfo.processInfo.environment[envKey],
             let data = Data(base64Encoded: scriptString),
             let script = try? JSONDecoder().decode(Script.self, from: data)
         else {
-            return
+            return nil
         }
+        return script
+    }
 
+    private static func executeScript(_ script: Script) {
         if let installConfig = script.install {
             try! installConfig.install()
         }

--- a/Samples/Sources/App.swift
+++ b/Samples/Sources/App.swift
@@ -24,6 +24,7 @@
 // THE SOFTWARE.
 //
 
+import IntegrationTestsHelper
 import SampleUI
 import SwiftUI
 
@@ -35,6 +36,7 @@ struct SampleApp: App {
 
     init() {
         runLeaksTestIfRequired()
+        IntegrationTestRunner.runEarlyIfNeeded()
     }
 
     var body: some Scene {

--- a/Samples/Tests/WatchdogTests.swift
+++ b/Samples/Tests/WatchdogTests.swift
@@ -153,37 +153,43 @@ import XCTest
             }
         }
 
-        func testStartupHangIsSuppressed() throws {
-            // Trigger a hang during app init (before UIApplicationDidBecomeActive).
-            // The watchdog detects and writes a report, but since the hang started
-            // before Active, the report should be deleted on recovery.
-            var installConfig = InstallConfig(installPath: installUrl.path)
-            installConfig.isWatchdogEnabled = true
-            installConfig.isHangReportingEnabled = true
-            app.launchEnvironment[IntegrationTestRunner.envKey] = try IntegrationTestRunner.script(
-                crash: .init(triggerId: .other_appHang),
-                install: installConfig,
-                config: .init(delay: 0, stateSavePath: stateUrl.path, runEarly: true)
-            )
-            launchAppAndRunScript()
+        // macOS sets Active during +load (before any observer registers), so
+        // there is no pre-Active startup phase for the suppression boundary to
+        // detect. This test is only meaningful on iOS/tvOS where the app
+        // transitions through Launching -> Active via UIKit notifications.
+        #if os(iOS) || os(tvOS)
+            func testStartupHangIsSuppressed() throws {
+                // Trigger a hang during app init (before UIApplicationDidBecomeActive).
+                // The watchdog detects and writes a report, but since the hang started
+                // before Active, the report should be deleted on recovery.
+                var installConfig = InstallConfig(installPath: installUrl.path)
+                installConfig.isWatchdogEnabled = true
+                installConfig.isHangReportingEnabled = true
+                app.launchEnvironment[IntegrationTestRunner.envKey] = try IntegrationTestRunner.script(
+                    crash: .init(triggerId: .other_appHang),
+                    install: installConfig,
+                    config: .init(delay: 0, stateSavePath: stateUrl.path, runEarly: true)
+                )
+                launchAppAndRunScript()
 
-            // Wait for the hang to resolve and any reports to be cleaned up.
-            // A startup hang report is created during detection but deleted on
-            // recovery, so the Reports directory should end up empty.
-            let reportsDirUrl = installUrl.appendingPathComponent("Reports")
-            let emptyExpectation = XCTNSPredicateExpectation(
-                predicate: NSPredicate { _, _ in
-                    guard let files = try? FileManager.default.contentsOfDirectory(atPath: reportsDirUrl.path)
-                    else { return true }
-                    return files.isEmpty
-                },
-                object: nil
-            )
-            wait(for: [emptyExpectation], timeout: 10.0)
+                // Wait for the hang to resolve and any reports to be cleaned up.
+                // A startup hang report is created during detection but deleted on
+                // recovery, so the Reports directory should end up empty.
+                let reportsDirUrl = installUrl.appendingPathComponent("Reports")
+                let emptyExpectation = XCTNSPredicateExpectation(
+                    predicate: NSPredicate { _, _ in
+                        guard let files = try? FileManager.default.contentsOfDirectory(atPath: reportsDirUrl.path)
+                        else { return true }
+                        return files.isEmpty
+                    },
+                    object: nil
+                )
+                wait(for: [emptyExpectation], timeout: 10.0)
 
-            let files = (try? FileManager.default.contentsOfDirectory(atPath: reportsDirUrl.path)) ?? []
-            XCTAssertTrue(files.isEmpty, "Startup hang should be suppressed, but found reports: \(files)")
-        }
+                let files = (try? FileManager.default.contentsOfDirectory(atPath: reportsDirUrl.path)) ?? []
+                XCTAssertTrue(files.isEmpty, "Startup hang should be suppressed, but found reports: \(files)")
+            }
+        #endif
 
         func testExceptionDuringHangReportsExceptionNotHang() throws {
             // Trigger a hang, then throw an exception while hung.

--- a/Samples/Tests/WatchdogTests.swift
+++ b/Samples/Tests/WatchdogTests.swift
@@ -153,6 +153,29 @@ import XCTest
             }
         }
 
+        func testStartupHangIsSuppressed() throws {
+            // Trigger a hang during app init (before UIApplicationDidBecomeActive).
+            // The watchdog detects and writes a report, but since the hang started
+            // before Active, the report should be deleted on recovery.
+            var installConfig = InstallConfig(installPath: installUrl.path)
+            installConfig.isWatchdogEnabled = true
+            installConfig.isHangReportingEnabled = true
+            app.launchEnvironment[IntegrationTestRunner.envKey] = try IntegrationTestRunner.script(
+                crash: .init(triggerId: .other_appHang),
+                install: installConfig,
+                config: .init(delay: 0, stateSavePath: stateUrl.path, runEarly: true)
+            )
+            launchAppAndRunScript()
+
+            // Wait long enough for the hang to resolve and cleanup to happen
+            Thread.sleep(forTimeInterval: 5.0)
+
+            // No finalized hang report should exist
+            let reportsDirUrl = installUrl.appendingPathComponent("Reports")
+            let files = (try? FileManager.default.contentsOfDirectory(atPath: reportsDirUrl.path)) ?? []
+            XCTAssertTrue(files.isEmpty, "Startup hang should be suppressed, but found reports: \(files)")
+        }
+
         func testExceptionDuringHangReportsExceptionNotHang() throws {
             // Trigger a hang, then throw an exception while hung.
             // The fatal exception should be reported, not the hang.

--- a/Samples/Tests/WatchdogTests.swift
+++ b/Samples/Tests/WatchdogTests.swift
@@ -60,6 +60,10 @@ import XCTest
             if let hangInfo = hangInfo {
                 let durationSeconds = Double(hangInfo.hangEndNanos - hangInfo.hangStartNanos) / 1_000_000_000.0
                 XCTAssertGreaterThan(durationSeconds, 1.0, "Hang duration should be at least 1 second")
+
+                // Transition states should be present
+                XCTAssertNotNil(hangInfo.hangStartTransitionState, "Start transition state should be present")
+                XCTAssertNotNil(hangInfo.hangEndTransitionState, "End transition state should be present")
             }
 
             // Verify we got a SIGKILL
@@ -142,6 +146,10 @@ import XCTest
                 let durationSeconds =
                     Double(hangInfo.hangEndNanos - hangInfo.hangStartNanos) / 1_000_000_000.0
                 XCTAssertGreaterThan(durationSeconds, 0.25, "Hang should exceed the watchdog threshold")
+
+                // Transition states should be present
+                XCTAssertNotNil(hangInfo.hangStartTransitionState, "Start transition state should be present")
+                XCTAssertNotNil(hangInfo.hangEndTransitionState, "End transition state should be present")
             }
         }
 
@@ -164,9 +172,11 @@ import XCTest
                 rawReport.crash.error.reason, "Exception during hang",
                 "Should have the exception reason")
 
-            // Verify hang info is NOT present - the fatal exception takes precedence
+            // Hang context is present from the run sidecar, providing diagnostic
+            // context that a hang was active when the exception fired.
             let hangInfo = rawReport.crash.error.hang
-            XCTAssertNil(hangInfo, "Hang info should NOT be present when a fatal exception occurred")
+            XCTAssertNotNil(hangInfo, "Hang context should be present from the run sidecar")
+            XCTAssertNil(hangInfo?.hangRecovered, "Hang should not be marked as recovered")
 
             let state = try readState()
             XCTAssertTrue(state.crashedLastLaunch)

--- a/Samples/Tests/WatchdogTests.swift
+++ b/Samples/Tests/WatchdogTests.swift
@@ -127,7 +127,7 @@ import XCTest
                 },
                 object: nil
             )
-            wait(for: [finalizedExpectation], timeout: actionDelay + 10.0)
+            wait(for: [finalizedExpectation], timeout: actionDelay + 20.0)
 
             let reportData = try readRawCrashReportData()
             let report = try decodeCrashReport(reportData: reportData)
@@ -167,11 +167,20 @@ import XCTest
             )
             launchAppAndRunScript()
 
-            // Wait long enough for the hang to resolve and cleanup to happen
-            Thread.sleep(forTimeInterval: 5.0)
-
-            // No finalized hang report should exist
+            // Wait for the hang to resolve and any reports to be cleaned up.
+            // A startup hang report is created during detection but deleted on
+            // recovery, so the Reports directory should end up empty.
             let reportsDirUrl = installUrl.appendingPathComponent("Reports")
+            let emptyExpectation = XCTNSPredicateExpectation(
+                predicate: NSPredicate { _, _ in
+                    guard let files = try? FileManager.default.contentsOfDirectory(atPath: reportsDirUrl.path)
+                    else { return true }
+                    return files.isEmpty
+                },
+                object: nil
+            )
+            wait(for: [emptyExpectation], timeout: 10.0)
+
             let files = (try? FileManager.default.contentsOfDirectory(atPath: reportsDirUrl.path)) ?? []
             XCTAssertTrue(files.isEmpty, "Startup hang should be suppressed, but found reports: \(files)")
         }

--- a/Sources/KSCrashCore/include/KSCrashNamespace.h
+++ b/Sources/KSCrashCore/include/KSCrashNamespace.h
@@ -408,6 +408,7 @@
 #define kskvs_setInt64 KSCRASH_NS(kskvs_setInt64)
 #define kskvs_setString KSCRASH_NS(kskvs_setString)
 #define kskvs_setUInt64 KSCRASH_NS(kskvs_setUInt64)
+#define kslifecycle_currentTransitionState KSCRASH_NS(kslifecycle_currentTransitionState)
 #define kslifecycle_getSnapshotForRunID KSCRASH_NS(kslifecycle_getSnapshotForRunID)
 #define kslifecycle_readData KSCRASH_NS(kslifecycle_readData)
 #define kslog_clearLogFile KSCRASH_NS(kslog_clearLogFile)

--- a/Sources/KSCrashRecording/KSCrashAppStateTracker.m
+++ b/Sources/KSCrashRecording/KSCrashAppStateTracker.m
@@ -146,9 +146,20 @@ bool ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionState state)
         return nil;
     }
     id heapBlock = [block copy];
+    KSCrashAppTransitionState currentState;
     os_unfair_lock_lock(&_lock);
     [_observers addPointer:(__bridge void *_Nullable)(heapBlock)];
+    currentState = _transitionState;
     os_unfair_lock_unlock(&_lock);
+
+    // Deliver the current state so the observer doesn't miss transitions
+    // that already happened (e.g. on macOS, Active is set during start()
+    // before any observers are registered). Dispatch async to avoid
+    // re-entering the caller while still inside addObserverWithBlock:.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        ((KSCrashAppStateTrackerObserverBlock)heapBlock)(currentState);
+    });
+
     return heapBlock;
 }
 

--- a/Sources/KSCrashRecording/KSCrashReportC.c
+++ b/Sources/KSCrashRecording/KSCrashReportC.c
@@ -1402,30 +1402,11 @@ static void writeError(const KSCrashReportWriter *const writer, const char *cons
             writer->endContainer(writer);
         }
 
-        // Write any current hang info if available
-        if (crash->Hang.inProgress) {
-            writer->beginObject(writer, KSCrashField_Hang);
-            {
-                writer->addUIntegerElement(writer, KSCrashField_HangStartNanoseconds, crash->Hang.timestamp);
-                writer->addStringElement(writer, KSCrashField_HangStartRole, kstaskrole_toString(crash->Hang.role));
-
-                writer->addUIntegerElement(writer, KSCrashField_HangEndNanoseconds, crash->Hang.endTimestamp);
-                writer->addStringElement(writer, KSCrashField_HangEndRole, kstaskrole_toString(crash->Hang.endRole));
-            }
-            writer->endContainer(writer);
-        }
-
         if (isCrashOfMonitorType(crash, kscm_watchdog_getAPI())) {
-            // We're leaning towards a SIGKILL watchdog timeout
-            if (crash->Hang.inProgress) {
-                writer->addStringElement(writer, KSCrashField_Type, KSCrashExcType_Mach);
-            }
-
-            // This is going to be a non-fatal hang.
-            else {
-                writer->addStringElement(writer, KSCrashField_Type, KSCrashExcType_Hang);
-            }
-
+            // Hang details (timestamps, roles, transition states) come from
+            // the run sidecar stitch. The type may be changed to "hang" by
+            // the stitch if the hang recovers.
+            writer->addStringElement(writer, KSCrashField_Type, KSCrashExcType_Mach);
         }
 
         else if (isCrashOfMonitorType(crash, kscm_nsexception_getAPI())) {

--- a/Sources/KSCrashRecording/KSHang.h
+++ b/Sources/KSCrashRecording/KSHang.h
@@ -50,11 +50,17 @@ typedef struct KSHangState {
     /** Task role when the hang started. */
     task_role_t role;
 
+    /** App transition state (KSCrashAppTransitionState) when the hang started. */
+    uint8_t transitionState;
+
     /** Monotonic timestamp (in nanoseconds) of the current/end state. */
     uint64_t endTimestamp;
 
     /** Task role at the current/end state. */
     task_role_t endRole;
+
+    /** App transition state (KSCrashAppTransitionState) at the current/end state. */
+    uint8_t endTransitionState;
 
     /** The report ID assigned to this hang. */
     int64_t reportId;
@@ -66,14 +72,16 @@ typedef struct KSHangState {
     bool active;
 } KSHangState;
 
-/** Initialize a hang state with the given start timestamp and role. */
-static inline void kshangstate_init(KSHangState *state, uint64_t timestamp, task_role_t role)
+/** Initialize a hang state with the given start timestamp, role, and transition state. */
+static inline void kshangstate_init(KSHangState *state, uint64_t timestamp, task_role_t role, uint8_t transitionState)
 {
     memset(state, 0, sizeof(*state));
     state->timestamp = timestamp;
     state->role = role;
+    state->transitionState = transitionState;
     state->endTimestamp = timestamp;
     state->endRole = role;
+    state->endTransitionState = transitionState;
     state->active = true;
 }
 

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Lifecycle.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Lifecycle.h
@@ -42,6 +42,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "KSCrashAppTransitionState.h"
 #include "KSCrashMonitorAPI.h"
 #include "KSCrashNamespace.h"
 #include "KSSystemCapabilities.h"
@@ -172,6 +173,11 @@ bool kslifecycle_readData(const char *path, KSCrash_LifecycleData *out);
  *  Returns false if the run ID has no valid sidecar or data fails validation.
  */
 bool kslifecycle_getSnapshotForRunID(const char *runID, KSCrash_LifecycleData *outData);
+
+/** Returns the most recently observed app transition state.
+ *  Lock-free (atomic load). Safe to call from any thread.
+ */
+KSCrashAppTransitionState kslifecycle_currentTransitionState(void);
 
 /** Access the Lifecycle Monitor API.
  */

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Lifecycle.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Lifecycle.m
@@ -62,6 +62,7 @@ static KSHangObserverToken g_hangObserverToken = KSHangObserverTokenNotFound;
 static dispatch_source_t g_taskRoleHeartbeatTimer = NULL;
 
 static atomic_bool g_isEnabled = false;
+static _Atomic KSCrashAppTransitionState g_transitionState = KSCrashAppTransitionStateStartup;
 
 /** Write the current task role to the sidecar if it changed.
  *  Call under the sidecar lock.
@@ -177,6 +178,8 @@ bool kslifecycle_getSnapshotForRunID(const char *runID, KSCrash_LifecycleData *o
 
 static void onTransitionState(KSCrashAppTransitionState transitionState)
 {
+    atomic_store_explicit(&g_transitionState, transitionState, memory_order_relaxed);
+
     ks_spinlock_lock(&g_sidecarLock);
     KSCrash_LifecycleData *sc = g_sidecar;
     if (sc == NULL) {
@@ -287,6 +290,11 @@ const KSCrash_AppState *kscrashstate_currentState(void)
     return &state;
 }
 #pragma clang diagnostic pop
+
+KSCrashAppTransitionState kslifecycle_currentTransitionState(void)
+{
+    return atomic_load_explicit(&g_transitionState, memory_order_relaxed);
+}
 
 // ============================================================================
 #pragma mark - Monitor API -

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.h
@@ -96,9 +96,11 @@ typedef struct {
     uint64_t freeStorageSize;
     uint64_t freeMemory;
     uint64_t usableMemory;
+    uint64_t processStartWallClockNs;  // unix epoch nanoseconds (from kernel p_starttime)
+    uint64_t processStartMonotonicNs;  // CLOCK_MONOTONIC_RAW nanoseconds (derived, no boot time)
 } KSCrash_SystemData;
 
-_Static_assert(sizeof(KSCrash_SystemData) == 2968, "KSCrash_SystemData size changed — update sidecar version");
+_Static_assert(sizeof(KSCrash_SystemData) == 2984, "KSCrash_SystemData size changed — update sidecar version");
 
 // ============================================================================
 #pragma mark - API -

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.h
@@ -96,8 +96,8 @@ typedef struct {
     uint64_t freeStorageSize;
     uint64_t freeMemory;
     uint64_t usableMemory;
-    uint64_t processStartWallClockNs;  // unix epoch nanoseconds (from kernel p_starttime)
-    uint64_t processStartMonotonicNs;  // CLOCK_MONOTONIC_RAW nanoseconds (derived, no boot time)
+    uint64_t processStartWallClockNs;  // unix epoch nanoseconds at sidecar creation
+    uint64_t processStartMonotonicNs;  // CLOCK_MONOTONIC_RAW nanoseconds at sidecar creation
 } KSCrash_SystemData;
 
 _Static_assert(sizeof(KSCrash_SystemData) == 2984, "KSCrash_SystemData size changed — update sidecar version");

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
@@ -427,6 +427,21 @@ static void initialize(void)
 
     sd->appStartTimestamp = (int64_t)ksdate_seconds();
 
+    // Kernel process start time (actual fork/exec, before main()).
+    // Derive monotonic uptime without kern.boottime by comparing
+    // wall clocks: mono = now_mono - (now_wall - p_starttime).
+    struct kinfo_proc procInfo;
+    if (kssysctl_getProcessInfo(sd->processID, &procInfo)) {
+        struct timeval pstart = procInfo.kp_proc.p_starttime;
+        uint64_t pstartNs = (uint64_t)pstart.tv_sec * 1000000000ULL + (uint64_t)pstart.tv_usec * 1000ULL;
+        sd->processStartWallClockNs = pstartNs;
+
+        uint64_t nowWallNs = ksdate_wallClockNanoseconds();
+        uint64_t nowMonoNs = ksdate_continuousNanoseconds();
+        uint64_t elapsedNs = nowWallNs - pstartNs;
+        sd->processStartMonotonicNs = (elapsedNs <= nowMonoNs) ? (nowMonoNs - elapsedNs) : 0;
+    }
+
     safeNSStringCopy(sd->executablePath, getExecutablePath(), sizeof(sd->executablePath));
     safeNSStringCopy(sd->executableName, infoDict[@"CFBundleExecutable"], sizeof(sd->executableName));
     safeNSStringCopy(sd->bundleID, infoDict[@"CFBundleIdentifier"], sizeof(sd->bundleID));

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
@@ -427,20 +427,11 @@ static void initialize(void)
 
     sd->appStartTimestamp = (int64_t)ksdate_seconds();
 
-    // Kernel process start time (actual fork/exec, before main()).
-    // Derive monotonic uptime without kern.boottime by comparing
-    // wall clocks: mono = now_mono - (now_wall - p_starttime).
-    struct kinfo_proc procInfo;
-    if (kssysctl_getProcessInfo(sd->processID, &procInfo)) {
-        struct timeval pstart = procInfo.kp_proc.p_starttime;
-        uint64_t pstartNs = (uint64_t)pstart.tv_sec * 1000000000ULL + (uint64_t)pstart.tv_usec * 1000ULL;
-        sd->processStartWallClockNs = pstartNs;
-
-        uint64_t nowWallNs = ksdate_wallClockNanoseconds();
-        uint64_t nowMonoNs = ksdate_continuousNanoseconds();
-        uint64_t elapsedNs = nowWallNs - pstartNs;
-        sd->processStartMonotonicNs = (elapsedNs <= nowMonoNs) ? (nowMonoNs - elapsedNs) : 0;
-    }
+    // Reference pair sampled at the same instant, same pattern as the
+    // Lifecycle sidecar. Consumers convert between clock domains using:
+    //   wallNs = processStartWallClockNs + (monoNs - processStartMonotonicNs)
+    sd->processStartMonotonicNs = ksdate_continuousNanoseconds();
+    sd->processStartWallClockNs = ksdate_wallClockNanoseconds();
 
     safeNSStringCopy(sd->executablePath, getExecutablePath(), sizeof(sd->executablePath));
     safeNSStringCopy(sd->executableName, infoDict[@"CFBundleExecutable"], sizeof(sd->executableName));

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_SystemStitch.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_SystemStitch.m
@@ -84,6 +84,8 @@ CFDictionaryRef kscm_system_createStitchedReport(CFDictionaryRef reportDict, con
     systemDict[KSCrashField_Jailbroken] = sc.isJailbroken ? @YES : @NO;
     systemDict[KSCrashField_ProcTranslated] = sc.procTranslated ? @YES : @NO;
     setTimestamp(systemDict, KSCrashField_AppStartTime, sc.appStartTimestamp);
+    systemDict[KSCrashField_ProcessStartWallClockNs] = @(sc.processStartWallClockNs);
+    systemDict[KSCrashField_ProcessStartMonotonicNs] = @(sc.processStartMonotonicNs);
     setStringIfNonEmpty(systemDict, KSCrashField_ExecutablePath, sc.executablePath);
     setStringIfNonEmpty(systemDict, KSCrashField_Executable, sc.executableName);
     setStringIfNonEmpty(systemDict, KSCrashField_BundleID, sc.bundleID);

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Watchdog.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Watchdog.c
@@ -401,12 +401,18 @@ static void finalizeResolvedHang(KSHangMonitor *monitor, KSHangState hang)
             // the purpose. It would also race with report deletion (the
             // background write-back could resurrect a deleted report).
             if (!kscrs_finalizeReport(hang.path, hang.reportId)) {
-                // With a run sidecar, falling back to next-launch stitching
-                // is unsafe: a second hang would overwrite the same sidecar
-                // and the first report would get the wrong data. Delete it.
                 KSLOG_ERROR("Failed to finalize hang report %" PRIx64 ", deleting to prevent stale stitching",
                             hang.reportId);
                 unlink(hang.path);
+            }
+
+            // Delete the run sidecar now that the hang has recovered.
+            // kscrs_finalizeReport already read it, so it's no longer needed.
+            // Leaving it would contaminate later crash reports from this run
+            // with stale hang data.
+            if (monitor->sidecarPath[0] != '\0') {
+                unlink(monitor->sidecarPath);
+                monitor->sidecarPath[0] = '\0';
             }
         } else {
             sidecar_delete(monitor);

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Watchdog.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Watchdog.c
@@ -42,6 +42,7 @@
 
 #include "KSCrashMonitorContext.h"
 #include "KSCrashMonitorHelper.h"
+#include "KSCrashMonitor_Lifecycle.h"
 #include "KSCrashMonitor_WatchdogSidecar.h"
 #include "KSCrashNamespace.h"
 #include "KSCrashReportFields.h"
@@ -182,14 +183,13 @@ static KSCrash_ExceptionHandlerCallbacks g_callbacks = { 0 };
 
 static const char *monitorId(__unused void *context);
 
-static KSHangSidecar *sidecar_open(KSHangMonitor *monitor, int64_t reportID)
+static KSHangSidecar *sidecar_open(KSHangMonitor *monitor)
 {
-    if (!g_callbacks.getReportSidecarPath) {
+    if (!g_callbacks.getRunSidecarPath) {
         return NULL;
     }
 
-    if (!g_callbacks.getReportSidecarPath(monitorId(NULL), reportID, monitor->sidecarPath,
-                                          sizeof(monitor->sidecarPath))) {
+    if (!g_callbacks.getRunSidecarPath(monitorId(NULL), monitor->sidecarPath, sizeof(monitor->sidecarPath))) {
         monitor->sidecarPath[0] = '\0';
         return NULL;
     }
@@ -207,13 +207,14 @@ static KSHangSidecar *sidecar_open(KSHangMonitor *monitor, int64_t reportID)
     return sc;
 }
 
-static void sidecar_update(KSHangSidecar *sc, uint64_t endTimestamp, task_role_t endRole)
+static void sidecar_update(KSHangSidecar *sc, uint64_t endTimestamp, task_role_t endRole, uint8_t endTransitionState)
 {
     if (!sc) {
         return;
     }
     sc->endTimestamp = endTimestamp;
     sc->endRole = endRole;
+    sc->endTransitionState = endTransitionState;
 }
 
 static void sidecar_finalize(KSHangMonitor *monitor, bool recovered)
@@ -316,12 +317,6 @@ static void populateReportForCurrentHang(KSHangMonitor *monitor)
 
     crashContext->exitReason.code = 0x8badf00d;
 
-    crashContext->Hang.inProgress = true;
-    crashContext->Hang.timestamp = hang.timestamp;
-    crashContext->Hang.role = hang.role;
-    crashContext->Hang.endTimestamp = hang.endTimestamp;
-    crashContext->Hang.endRole = hang.endRole;
-
     KSCrash_ReportResult result = { 0 };
     g_callbacks.handleWithResult(crashContext, &result, false);
 
@@ -336,8 +331,12 @@ static void populateReportForCurrentHang(KSHangMonitor *monitor)
         if (strlcpy(monitor->hang.path, result.path, PATH_MAX) >= PATH_MAX) {
             KSLOG_ERROR("Report path too long, discarding hang report");
         } else {
-            monitor->sidecar = sidecar_open(monitor, result.reportId);
-            sidecar_update(monitor->sidecar, monitor->hang.endTimestamp, monitor->hang.endRole);
+            monitor->sidecar = sidecar_open(monitor);
+            monitor->sidecar->startTimestamp = monitor->hang.timestamp;
+            monitor->sidecar->startRole = monitor->hang.role;
+            monitor->sidecar->startTransitionState = monitor->hang.transitionState;
+            sidecar_update(monitor->sidecar, monitor->hang.endTimestamp, monitor->hang.endRole,
+                           monitor->hang.endTransitionState);
         }
     } else {
         KSLOG_DEBUG("hang changed during report population - discarding");
@@ -361,7 +360,7 @@ static void writeUpdatedReport(KSHangMonitor *monitor)
     }
     timestampStart = monitor->hang.timestamp;
     timestampEnd = monitor->hang.endTimestamp;
-    sidecar_update(monitor->sidecar, timestampEnd, monitor->hang.endRole);
+    sidecar_update(monitor->sidecar, timestampEnd, monitor->hang.endRole, monitor->hang.endTransitionState);
     os_unfair_lock_unlock(&monitor->lock);
 
     notifyObservers(monitor, KSHangChangeTypeUpdated, timestampStart, timestampEnd);
@@ -369,8 +368,14 @@ static void writeUpdatedReport(KSHangMonitor *monitor)
 
 static void finalizeResolvedHang(KSHangMonitor *monitor, KSHangState hang)
 {
+    // Suppress non-fatal hang reports that started before the app became active.
+    // Startup hangs are expected (initialization work) and would be noise.
+    // The report still existed on disk while active, so WatchdogStitch can
+    // detect fatal hangs (OS kills the app during a startup hang).
+    bool startedDuringStartup = hang.transitionState < KSCrashAppTransitionStateActive;
+
     if (hang.path[0] != '\0') {
-        if (monitor->reportsHangs) {
+        if (monitor->reportsHangs && !startedDuringStartup) {
             sidecar_finalize(monitor, true);
 
             // Finalize the report synchronously so the stitched metadata
@@ -451,19 +456,22 @@ static void watchdogTimerFired(CFRunLoopTimerRef timer, void *info)
     }
 
     task_role_t currentRole = kstaskrole_current();
+    uint8_t currentTransition = kslifecycle_currentTransitionState();
 
     bool shouldStartNewHang = false;
     bool shouldUpdateHang = false;
 
     os_unfair_lock_lock(&monitor->lock);
     if (!monitor->hang.active) {
-        kshangstate_init(&monitor->hang, enter, currentRole);
+        kshangstate_init(&monitor->hang, enter, currentRole, currentTransition);
         monitor->hang.endTimestamp = now;
         monitor->hang.endRole = currentRole;
+        monitor->hang.endTransitionState = currentTransition;
         shouldStartNewHang = true;
     } else {
         monitor->hang.endTimestamp = now;
         monitor->hang.endRole = currentRole;
+        monitor->hang.endTransitionState = currentTransition;
         shouldUpdateHang = true;
     }
     os_unfair_lock_unlock(&monitor->lock);
@@ -520,6 +528,7 @@ static void mainRunLoopActivity(CFRunLoopObserverRef obs, CFRunLoopActivity acti
 
         hang.endTimestamp = ksdate_uptimeNanoseconds();
         hang.endRole = kstaskrole_current();
+        hang.endTransitionState = kslifecycle_currentTransitionState();
         finalizeResolvedHang(monitor, hang);
 
     } else if (activity == kCFRunLoopAfterWaiting) {

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Watchdog.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Watchdog.c
@@ -332,11 +332,15 @@ static void populateReportForCurrentHang(KSHangMonitor *monitor)
             KSLOG_ERROR("Report path too long, discarding hang report");
         } else {
             monitor->sidecar = sidecar_open(monitor);
-            monitor->sidecar->startTimestamp = monitor->hang.timestamp;
-            monitor->sidecar->startRole = monitor->hang.role;
-            monitor->sidecar->startTransitionState = monitor->hang.transitionState;
-            sidecar_update(monitor->sidecar, monitor->hang.endTimestamp, monitor->hang.endRole,
-                           monitor->hang.endTransitionState);
+            if (monitor->sidecar) {
+                monitor->sidecar->startTimestamp = monitor->hang.timestamp;
+                monitor->sidecar->startRole = monitor->hang.role;
+                monitor->sidecar->startTransitionState = monitor->hang.transitionState;
+                sidecar_update(monitor->sidecar, monitor->hang.endTimestamp, monitor->hang.endRole,
+                               monitor->hang.endTransitionState);
+            } else {
+                KSLOG_ERROR("Failed to open run sidecar for hang report");
+            }
         }
     } else {
         KSLOG_DEBUG("hang changed during report population - discarding");
@@ -397,8 +401,12 @@ static void finalizeResolvedHang(KSHangMonitor *monitor, KSHangState hang)
             // the purpose. It would also race with report deletion (the
             // background write-back could resurrect a deleted report).
             if (!kscrs_finalizeReport(hang.path, hang.reportId)) {
-                KSLOG_ERROR("Failed to finalize hang report %" PRIx64 " at %s, will fall back to next-launch stitching",
-                            hang.reportId, hang.path);
+                // With a run sidecar, falling back to next-launch stitching
+                // is unsafe: a second hang would overwrite the same sidecar
+                // and the first report would get the wrong data. Delete it.
+                KSLOG_ERROR("Failed to finalize hang report %" PRIx64 ", deleting to prevent stale stitching",
+                            hang.reportId);
+                unlink(hang.path);
             }
         } else {
             sidecar_delete(monitor);

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Watchdog.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Watchdog.c
@@ -372,11 +372,10 @@ static void writeUpdatedReport(KSHangMonitor *monitor)
 
 static void finalizeResolvedHang(KSHangMonitor *monitor, KSHangState hang)
 {
-    // Suppress non-fatal hang reports that started before the app became active.
-    // Startup hangs are expected (initialization work) and would be noise.
-    // The report still existed on disk while active, so WatchdogStitch can
-    // detect fatal hangs (OS kills the app during a startup hang).
-    bool startedDuringStartup = hang.transitionState < KSCrashAppTransitionStateActive;
+    // Suppress non-fatal hangs that started during launch (Startup,
+    // StartupPrewarm, Launching). The report still existed on disk while
+    // active, so WatchdogStitch can detect fatal hangs during startup.
+    bool startedDuringStartup = hang.transitionState <= KSCrashAppTransitionStateLaunching;
 
     if (hang.path[0] != '\0') {
         if (monitor->reportsHangs && !startedDuringStartup) {

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Watchdog.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Watchdog.c
@@ -813,10 +813,8 @@ static void addContextualInfoToEvent(struct KSCrash_MonitorContext *eventContext
         return;
     }
 
-    if (monitor->sidecarPath[0] != '\0') {
-        unlink(monitor->sidecarPath);
-    }
-
+    // Delete the incomplete hang report — the fatal crash supersedes it.
+    // Keep the run sidecar so the crash report gets hang context at stitch time.
     if (monitor->hang.path[0] != '\0') {
         unlink(monitor->hang.path);
     }

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Watchdog.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Watchdog.c
@@ -123,8 +123,8 @@ typedef struct {
 //
 // Sidecar files
 // -------------
-// A sidecar is a small mmap'd binary file (KSHangSidecar, 24 bytes) written
-// alongside the crash report.  It stores the latest end-timestamp and task
+// A sidecar is a small mmap'd binary file (KSHangSidecar) written alongside
+// the crash report.  It stores the latest end-timestamp and task
 // role, and is updated in-place on each timer fire via direct memory writes
 // (the kernel flushes dirty pages to disk).  This avoids re-writing the
 // full JSON report on every update.  At next launch, the stitch logic

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_WatchdogSidecar.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_WatchdogSidecar.h
@@ -49,19 +49,27 @@ extern "C" {
 typedef struct {
     int32_t magic;
     uint8_t version;
+    uint64_t startTimestamp;
+    task_role_t startRole;
+    uint8_t startTransitionState;  // KSCrashAppTransitionState at hang start
     uint64_t endTimestamp;
     task_role_t endRole;
+    uint8_t endTransitionState;  // KSCrashAppTransitionState at hang end/current
     bool recovered;
 } KSHangSidecar;
 
 // Expected layout (same on 32-bit and 64-bit — no pointer-sized fields):
-//   offset  0: int32_t    magic          (4 bytes)
-//   offset  4: uint8_t    version        (1 byte + 3 padding)
-//   offset  8: uint64_t   endTimestamp   (8 bytes)
-//   offset 16: task_role_t endRole       (4 bytes)
-//   offset 20: bool       recovered      (1 byte + 3 padding)
-//   total: 24 bytes
-_Static_assert(sizeof(KSHangSidecar) == 24, "KSHangSidecar size changed — update sidecar version");
+//   offset  0: int32_t    magic                  (4 bytes)
+//   offset  4: uint8_t    version                (1 byte + 7 padding)
+//   offset  8: uint64_t   startTimestamp          (8 bytes)
+//   offset 16: task_role_t startRole              (4 bytes)
+//   offset 20: uint8_t    startTransitionState    (1 byte + 3 padding)
+//   offset 24: uint64_t   endTimestamp            (8 bytes)
+//   offset 32: task_role_t endRole                (4 bytes)
+//   offset 36: uint8_t    endTransitionState      (1 byte)
+//   offset 37: bool       recovered               (1 byte + 2 padding)
+//   total: 40 bytes
+_Static_assert(sizeof(KSHangSidecar) == 40, "KSHangSidecar size changed — update sidecar version");
 
 /** Stitch watchdog sidecar data into a crash report.
  *

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_WatchdogSidecar.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_WatchdogSidecar.h
@@ -60,7 +60,7 @@ typedef struct {
 
 // Expected layout (same on 32-bit and 64-bit — no pointer-sized fields):
 //   offset  0: int32_t    magic                  (4 bytes)
-//   offset  4: uint8_t    version                (1 byte + 7 padding)
+//   offset  4: uint8_t    version                (1 byte + 3 padding)
 //   offset  8: uint64_t   startTimestamp          (8 bytes)
 //   offset 16: task_role_t startRole              (4 bytes)
 //   offset 20: uint8_t    startTransitionState    (1 byte + 3 padding)

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_WatchdogStitch.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_WatchdogStitch.m
@@ -26,6 +26,7 @@
 
 #import "KSCrashMonitor_WatchdogSidecar.h"
 
+#import "KSCrashAppTransitionState.h"
 #import "KSCrashMonitor_Watchdog.h"
 #import "KSCrashReportFields.h"
 #import "KSCrashRunContext.h"
@@ -38,10 +39,14 @@
 #import "KSLogger.h"
 
 CFDictionaryRef kscm_watchdog_createStitchedReport(CFDictionaryRef reportDict, const char *sidecarPath,
-                                                   __unused KSCrashSidecarScope scope, __unused void *context)
+                                                   KSCrashSidecarScope scope, __unused void *context)
 {
     if (!reportDict || !sidecarPath) {
         return NULL;
+    }
+    if (scope != KSCrashSidecarScopeRun) {
+        CFRetain(reportDict);
+        return reportDict;
     }
 
     // Read the sidecar from disk (can't use ksfu_mmap — it truncates with O_TRUNC)
@@ -63,13 +68,11 @@ CFDictionaryRef kscm_watchdog_createStitchedReport(CFDictionaryRef reportDict, c
         return NULL;
     }
 
-    uint64_t endTimestamp = sc.endTimestamp;
-    task_role_t endRole = sc.endRole;
     bool recovered = sc.recovered;
 
     NSMutableDictionary *dict = [(__bridge NSDictionary *)reportDict mutableCopy];
 
-    // Navigate to crash.error.hang, mutableCopy-ing only the levels we mutate.
+    // Navigate to crash.error, create hang section from sidecar data.
     id crashVal = dict[KSCrashField_Crash];
     if (![crashVal isKindOfClass:[NSDictionary class]]) {
         KSLOG_ERROR(@"Malformed report: 'crash' is missing or not a dictionary");
@@ -84,19 +87,16 @@ CFDictionaryRef kscm_watchdog_createStitchedReport(CFDictionaryRef reportDict, c
     }
     NSMutableDictionary *errorDict = [errorVal mutableCopy];
 
-    id hangVal = errorDict[KSCrashField_Hang];
-    if (![hangVal isKindOfClass:[NSDictionary class]]) {
-        KSLOG_ERROR(@"Malformed report: 'hang' is missing or not a dictionary");
-        return NULL;
-    }
-    NSMutableDictionary *hang = [hangVal mutableCopy];
-
-    // Update end timestamps from sidecar
-    hang[KSCrashField_HangEndNanoseconds] = @(endTimestamp);
-    hang[KSCrashField_HangEndRole] = @(kstaskrole_toString(endRole));
+    // Build the hang section entirely from the sidecar.
+    NSMutableDictionary *hang = [NSMutableDictionary dictionary];
+    hang[KSCrashField_HangStartNanoseconds] = @(sc.startTimestamp);
+    hang[KSCrashField_HangStartRole] = @(kstaskrole_toString(sc.startRole));
+    hang[KSCrashField_HangStartTransitionState] = @(ksapp_transitionStateToString(sc.startTransitionState));
+    hang[KSCrashField_HangEndNanoseconds] = @(sc.endTimestamp);
+    hang[KSCrashField_HangEndRole] = @(kstaskrole_toString(sc.endRole));
+    hang[KSCrashField_HangEndTransitionState] = @(ksapp_transitionStateToString(sc.endTransitionState));
 
     if (recovered) {
-        // Mark as recovered hang
         hang[KSCrashField_HangRecovered] = @YES;
 
         // Change the error type to "hang"
@@ -109,7 +109,8 @@ CFDictionaryRef kscm_watchdog_createStitchedReport(CFDictionaryRef reportDict, c
         errorDict[KSCrashField_IsFatal] = @NO;
         [errorDict removeObjectForKey:KSCrashField_IsCleanExit];
     } else {
-        // Unrecovered hang: the OS killed the process, so mark as fatal.
+        // Unrecovered hang: the OS killed the process, mark as fatal.
+        // The report already has the correct type from the report writer.
         errorDict[KSCrashField_IsFatal] = @YES;
         errorDict[KSCrashField_IsCleanExit] = @NO;
     }

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_WatchdogStitch.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_WatchdogStitch.m
@@ -38,6 +38,9 @@
 
 #import "KSLogger.h"
 
+// Returns a +1 CFDictionaryRef per the CF Create Rule, as specified by the
+// createStitchedReport contract in KSCrashMonitorAPI.h. The early-return for
+// non-run scopes retains the input to satisfy this ownership requirement.
 CFDictionaryRef kscm_watchdog_createStitchedReport(CFDictionaryRef reportDict, const char *sidecarPath,
                                                    KSCrashSidecarScope scope, __unused void *context)
 {

--- a/Sources/KSCrashRecording/include/KSCrashAppStateTracker.h
+++ b/Sources/KSCrashRecording/include/KSCrashAppStateTracker.h
@@ -68,6 +68,10 @@ NS_SWIFT_NAME(AppStateTracker)
 /**
  * Adds a block based observer.
  *
+ * The block is called immediately (asynchronously on the main queue) with the
+ * current transition state so the observer doesn't miss transitions that already
+ * happened before registration.
+ *
  *@return An object that when set to nil will remove the observer.
  */
 - (id)addObserverWithBlock:(KSCrashAppStateTrackerObserverBlock)block;

--- a/Sources/KSCrashRecording/include/KSCrashReportFields.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportFields.h
@@ -227,6 +227,8 @@ KSCRF_DEFINE_CONSTANT(KSCrashField, RecrashReport, recrashReport, "recrash_repor
 
 KSCRF_DEFINE_CONSTANT(KSCrashField, AppStartTime, appStartTime, "app_start_time")
 KSCRF_DEFINE_CONSTANT(KSCrashField, AppUUID, appUUID, "app_uuid")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ProcessStartWallClockNs, processStartWallClockNs, "process_start_wall_clock_ns")
+KSCRF_DEFINE_CONSTANT(KSCrashField, ProcessStartMonotonicNs, processStartMonotonicNs, "process_start_monotonic_ns")
 KSCRF_DEFINE_CONSTANT(KSCrashField, BootTime, bootTime, "boot_time")
 KSCRF_DEFINE_CONSTANT(KSCrashField, BundleID, bundleID, "CFBundleIdentifier")
 KSCRF_DEFINE_CONSTANT(KSCrashField, BundleName, bundleName, "CFBundleName")

--- a/Sources/KSCrashRecording/include/KSCrashReportFields.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportFields.h
@@ -280,8 +280,10 @@ KSCRF_DEFINE_CONSTANT(KSCrashField, TaskRole, taskRole, "task_role")
 
 KSCRF_DEFINE_CONSTANT(KSCrashField, HangStartNanoseconds, hangStartNanoseconds, "hang_start_nanos")
 KSCRF_DEFINE_CONSTANT(KSCrashField, HangStartRole, hangStartRole, "hang_start_role")
+KSCRF_DEFINE_CONSTANT(KSCrashField, HangStartTransitionState, hangStartTransitionState, "hang_start_transition_state")
 KSCRF_DEFINE_CONSTANT(KSCrashField, HangEndNanoseconds, hangEndNanoseconds, "hang_end_nanos")
 KSCRF_DEFINE_CONSTANT(KSCrashField, HangEndRole, hangEndRole, "hang_end_role")
+KSCRF_DEFINE_CONSTANT(KSCrashField, HangEndTransitionState, hangEndTransitionState, "hang_end_transition_state")
 KSCRF_DEFINE_CONSTANT(KSCrashField, HangRecovered, hangRecovered, "hang_recovered")
 
 #ifdef __cplusplus

--- a/Sources/KSCrashRecordingCore/include/KSCrashMonitorContext.h
+++ b/Sources/KSCrashRecordingCore/include/KSCrashMonitorContext.h
@@ -180,23 +180,6 @@ typedef struct KSCrash_MonitorContext {
         const char *reason;
     } ZombieException;
 
-    struct {
-        /** Whether the hang is currently in progress */
-        bool inProgress;
-
-        /** Start time of the hang in nanoseconds (monotonic uptime) **/
-        uint64_t timestamp;
-
-        /** Task role (task_role_t) at hang start time. */
-        int role;
-
-        /** End time (or last update time) of the hang in nanoseconds (monotonic uptime) **/
-        uint64_t endTimestamp;
-
-        /** Task role (task_role_t) at hang end time. */
-        int endRole;
-    } Hang;
-
     /** Full path to the console log, if any. */
     const char *consoleLogPath;
 

--- a/Sources/Report/Models/HangInfo.swift
+++ b/Sources/Report/Models/HangInfo.swift
@@ -34,11 +34,17 @@ public struct HangInfo: Codable, Sendable, Equatable {
     /// The app's task role when the hang started.
     public let hangStartRole: TaskRole
 
+    /// The app's transition state when the hang started.
+    public let hangStartTransitionState: AppTransitionState?
+
     /// Timestamp when the hang ended/was detected (in nanoseconds).
     public let hangEndNanos: UInt64
 
     /// The app's task role when the hang ended.
     public let hangEndRole: TaskRole
+
+    /// The app's transition state when the hang ended.
+    public let hangEndTransitionState: AppTransitionState?
 
     /// Whether this hang resolved on its own (true) or led to a termination (false/nil).
     public let hangRecovered: Bool?
@@ -46,8 +52,10 @@ public struct HangInfo: Codable, Sendable, Equatable {
     enum CodingKeys: String, CodingKey {
         case hangStartNanos = "hang_start_nanos"
         case hangStartRole = "hang_start_role"
+        case hangStartTransitionState = "hang_start_transition_state"
         case hangEndNanos = "hang_end_nanos"
         case hangEndRole = "hang_end_role"
+        case hangEndTransitionState = "hang_end_transition_state"
         case hangRecovered = "hang_recovered"
     }
 }

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_SystemStitch_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_SystemStitch_Tests.m
@@ -92,6 +92,8 @@ static KSCrash_SystemData makeValidSystemData(void)
     sc.freeStorageSize = 128000000000ULL;
     sc.freeMemory = 2000000000ULL;
     sc.usableMemory = 4000000000ULL;
+    sc.processStartWallClockNs = 1700000000ULL * 1000000000ULL;
+    sc.processStartMonotonicNs = 100000ULL * 1000000000ULL;
     return sc;
 }
 
@@ -283,6 +285,9 @@ static KSCrash_SystemData makeValidSystemData(void)
     XCTAssertTrue([system[KSCrashField_AppStartTime] isKindOfClass:[NSString class]]);
     XCTAssertNotNil(system[KSCrashField_BootTime]);
     XCTAssertTrue([system[KSCrashField_BootTime] isKindOfClass:[NSString class]]);
+
+    XCTAssertEqualObjects(system[KSCrashField_ProcessStartWallClockNs], @(1700000000ULL * 1000000000ULL));
+    XCTAssertEqualObjects(system[KSCrashField_ProcessStartMonotonicNs], @(100000ULL * 1000000000ULL));
 }
 
 - (void)testZeroTimestampNotWritten

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_WatchdogStitch_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_WatchdogStitch_Tests.m
@@ -175,7 +175,7 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, task_role_t star
 
 #pragma mark - No Hang In Report
 
-- (void)testReportWithoutHangReturnsNull
+- (void)testReportWithoutHangCreatesHangFromSidecar
 {
     KSHangSidecar sc = {
         .magic = KSHANG_SIDECAR_MAGIC,
@@ -495,7 +495,7 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, task_role_t star
     XCTAssertTrue(result == nil);
 }
 
-- (void)testHangIsNSNullReturnsNull
+- (void)testHangIsNSNullCreatesHangFromSidecar
 {
     KSHangSidecar sc = {
         .magic = KSHANG_SIDECAR_MAGIC,
@@ -612,8 +612,8 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, task_role_t star
 
     // Report scope should pass through unchanged — no hang modifications
     NSDictionary *error = result[@"crash"][@"error"];
-    XCTAssertEqualObjects(error[@"type"], @"signal", "Type should be unchanged");
-    XCTAssertEqualObjects(error[@"is_fatal"], @YES, "is_fatal should be unchanged");
+    XCTAssertEqualObjects(error[@"type"], @"signal", @"Type should be unchanged");
+    XCTAssertEqualObjects(error[@"is_fatal"], @YES, @"is_fatal should be unchanged");
 }
 
 #pragma mark - Start Values From Sidecar

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_WatchdogStitch_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_WatchdogStitch_Tests.m
@@ -28,6 +28,7 @@
 
 #import "KSCrashMonitor_WatchdogSidecar.h"
 #import "KSCrashReportFields.h"
+#import "KSTaskRole.h"
 
 #include <fcntl.h>
 #include <unistd.h>
@@ -52,7 +53,7 @@ static NSString *writeSidecar(NSString *dir, KSHangSidecar sc)
     return path;
 }
 
-static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startRole)
+static NSDictionary *makeMinimalHangReport(uint64_t startNanos, task_role_t startRole)
 {
     return @{
         @"crash" : @ {
@@ -60,7 +61,7 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
                 @"type" : @"signal",
                 @"hang" : @ {
                     @"hang_start_nanos" : @(startNanos),
-                    @"hang_start_role" : startRole,
+                    @"hang_start_role" : @(kstaskrole_toString(startRole)),
                     @"hang_end_nanos" : @(0),
                     @"hang_end_role" : @"unknown",
                 },
@@ -98,20 +99,20 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
 
 - (void)testNullReportReturnsNull
 {
-    XCTAssertTrue(kscm_watchdog_createStitchedReport(NULL, "/tmp/fake", KSCrashSidecarScopeReport, NULL) == NULL);
+    XCTAssertTrue(kscm_watchdog_createStitchedReport(NULL, "/tmp/fake", KSCrashSidecarScopeRun, NULL) == NULL);
 }
 
 - (void)testNullSidecarPathReturnsNull
 {
-    XCTAssertTrue(kscm_watchdog_createStitchedReport((__bridge CFDictionaryRef) @{}, NULL, KSCrashSidecarScopeReport,
-                                                     NULL) == NULL);
+    XCTAssertTrue(
+        kscm_watchdog_createStitchedReport((__bridge CFDictionaryRef) @{}, NULL, KSCrashSidecarScopeRun, NULL) == NULL);
 }
 
 - (void)testMissingSidecarFileReturnsNull
 {
     NSString *missingPath = [self.tempDir stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef) @{}, missingPath.UTF8String, KSCrashSidecarScopeReport, NULL);
+        (__bridge CFDictionaryRef) @{}, missingPath.UTF8String, KSCrashSidecarScopeRun, NULL);
     XCTAssertTrue(result == nil);
 }
 
@@ -128,10 +129,10 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     };
     NSString *path = writeSidecar(self.tempDir, sc);
 
-    NSDictionary *report = makeMinimalHangReport(500, @"foreground");
+    NSDictionary *report = makeMinimalHangReport(500, TASK_FOREGROUND_APPLICATION);
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
     XCTAssertTrue(result == nil);
 }
 
@@ -146,10 +147,10 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     };
     NSString *path = writeSidecar(self.tempDir, sc);
 
-    NSDictionary *report = makeMinimalHangReport(500, @"foreground");
+    NSDictionary *report = makeMinimalHangReport(500, TASK_FOREGROUND_APPLICATION);
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
     XCTAssertTrue(result == nil);
 }
 
@@ -164,10 +165,10 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     };
     NSString *path = writeSidecar(self.tempDir, sc);
 
-    NSDictionary *report = makeMinimalHangReport(500, @"foreground");
+    NSDictionary *report = makeMinimalHangReport(500, TASK_FOREGROUND_APPLICATION);
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
     XCTAssertTrue(result == nil);
 }
 
@@ -187,8 +188,10 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     NSDictionary *report = @{ @"crash" : @ { @"error" : @ { @"type" : @"signal" } } };
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
-    XCTAssertTrue(result == nil);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
+    XCTAssertNotNil(result);
+    // Hang section is created from the sidecar even when not in the original report
+    XCTAssertNotNil(result[@"crash"][@"error"][@"hang"]);
 }
 
 #pragma mark - Fatal Hang (not recovered)
@@ -205,10 +208,10 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     };
     NSString *path = writeSidecar(self.tempDir, sc);
 
-    NSDictionary *report = makeMinimalHangReport(100000000, @"foreground");
+    NSDictionary *report = makeMinimalHangReport(100000000, TASK_FOREGROUND_APPLICATION);
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
     XCTAssertTrue(result != nil);
 
     NSDictionary *hang = result[@"crash"][@"error"][@"hang"];
@@ -226,10 +229,10 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     };
     NSString *path = writeSidecar(self.tempDir, sc);
 
-    NSDictionary *report = makeMinimalHangReport(1000, @"foreground");
+    NSDictionary *report = makeMinimalHangReport(1000, TASK_FOREGROUND_APPLICATION);
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
     XCTAssertTrue(result != nil);
 
     NSDictionary *error = result[@"crash"][@"error"];
@@ -250,10 +253,10 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     };
     NSString *path = writeSidecar(self.tempDir, sc);
 
-    NSDictionary *report = makeMinimalHangReport(1000, @"foreground");
+    NSDictionary *report = makeMinimalHangReport(1000, TASK_FOREGROUND_APPLICATION);
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
     XCTAssertTrue(result != nil);
 
     NSDictionary *error = result[@"crash"][@"error"];
@@ -272,10 +275,10 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     };
     NSString *path = writeSidecar(self.tempDir, sc);
 
-    NSDictionary *report = makeMinimalHangReport(1000, @"foreground");
+    NSDictionary *report = makeMinimalHangReport(1000, TASK_FOREGROUND_APPLICATION);
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
     XCTAssertTrue(result != nil);
 
     NSDictionary *hang = result[@"crash"][@"error"][@"hang"];
@@ -295,10 +298,10 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     };
     NSString *path = writeSidecar(self.tempDir, sc);
 
-    NSDictionary *report = makeMinimalHangReport(1000, @"foreground");
+    NSDictionary *report = makeMinimalHangReport(1000, TASK_FOREGROUND_APPLICATION);
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
     XCTAssertTrue(result != nil);
 
     NSDictionary *hang = result[@"crash"][@"error"][@"hang"];
@@ -316,10 +319,10 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     };
     NSString *path = writeSidecar(self.tempDir, sc);
 
-    NSDictionary *report = makeMinimalHangReport(1000, @"foreground");
+    NSDictionary *report = makeMinimalHangReport(1000, TASK_FOREGROUND_APPLICATION);
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
     XCTAssertTrue(result != nil);
 
     NSDictionary *error = result[@"crash"][@"error"];
@@ -338,10 +341,10 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     };
     NSString *path = writeSidecar(self.tempDir, sc);
 
-    NSDictionary *report = makeMinimalHangReport(1000, @"foreground");
+    NSDictionary *report = makeMinimalHangReport(1000, TASK_FOREGROUND_APPLICATION);
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
     XCTAssertTrue(result != nil);
 
     NSString *type = result[@"crash"][@"error"][@"type"];
@@ -359,10 +362,10 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     };
     NSString *path = writeSidecar(self.tempDir, sc);
 
-    NSDictionary *report = makeMinimalHangReport(1000, @"foreground");
+    NSDictionary *report = makeMinimalHangReport(1000, TASK_FOREGROUND_APPLICATION);
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
     XCTAssertTrue(result != nil);
 
     NSDictionary *error = result[@"crash"][@"error"];
@@ -383,10 +386,10 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     };
     NSString *path = writeSidecar(self.tempDir, sc);
 
-    NSDictionary *report = makeMinimalHangReport(1000, @"foreground");
+    NSDictionary *report = makeMinimalHangReport(1000, TASK_FOREGROUND_APPLICATION);
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
     XCTAssertTrue(result != nil);
 
     NSDictionary *hang = result[@"crash"][@"error"][@"hang"];
@@ -399,21 +402,23 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     KSHangSidecar sc = {
         .magic = KSHANG_SIDECAR_MAGIC,
         .version = KSHANG_SIDECAR_VERSION_1_0,
+        .startTimestamp = startNanos,
+        .startRole = TASK_FOREGROUND_APPLICATION,
         .endTimestamp = 99000000,
         .endRole = TASK_DEFAULT_APPLICATION,
         .recovered = true,
     };
     NSString *path = writeSidecar(self.tempDir, sc);
 
-    NSDictionary *report = makeMinimalHangReport(startNanos, @"foreground");
+    NSDictionary *report = makeMinimalHangReport(startNanos, TASK_FOREGROUND_APPLICATION);
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
     XCTAssertTrue(result != nil);
 
     NSDictionary *hang = result[@"crash"][@"error"][@"hang"];
     XCTAssertEqualObjects(hang[@"hang_start_nanos"], @(startNanos));
-    XCTAssertEqualObjects(hang[@"hang_start_role"], @"foreground");
+    XCTAssertEqualObjects(hang[@"hang_start_role"], @(kstaskrole_toString(TASK_FOREGROUND_APPLICATION)));
 }
 
 #pragma mark - Truncated Sidecar
@@ -426,10 +431,10 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     write(fd, partial, sizeof(partial));
     close(fd);
 
-    NSDictionary *report = makeMinimalHangReport(1000, @"foreground");
+    NSDictionary *report = makeMinimalHangReport(1000, TASK_FOREGROUND_APPLICATION);
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
     XCTAssertTrue(result == nil);
 }
 
@@ -449,7 +454,7 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     NSDictionary *report = @{ @"other" : @"value" };
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
     XCTAssertTrue(result == nil);
 }
 
@@ -467,7 +472,7 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     NSDictionary *report = @{ @"crash" : [NSNull null] };
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
     XCTAssertTrue(result == nil);
 }
 
@@ -485,7 +490,7 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     NSDictionary *report = @{ @"crash" : @ { @"error" : [NSNull null] } };
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
     XCTAssertTrue(result == nil);
 }
 
@@ -503,8 +508,9 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     NSDictionary *report = @{ @"crash" : @ { @"error" : @ { @"type" : @"signal", @"hang" : [NSNull null] } } };
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
-    XCTAssertTrue(result == nil);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
+    XCTAssertNotNil(result);
+    XCTAssertNotNil(result[@"crash"][@"error"][@"hang"]);
 }
 
 #pragma mark - End Role
@@ -520,10 +526,10 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, NSString *startR
     };
     NSString *path = writeSidecar(self.tempDir, sc);
 
-    NSDictionary *report = makeMinimalHangReport(1000, @"foreground");
+    NSDictionary *report = makeMinimalHangReport(1000, TASK_FOREGROUND_APPLICATION);
 
     NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
-        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
     XCTAssertTrue(result != nil);
 
     NSDictionary *hang = result[@"crash"][@"error"][@"hang"];

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_WatchdogStitch_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_WatchdogStitch_Tests.m
@@ -26,6 +26,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import "KSCrashAppTransitionState.h"
 #import "KSCrashMonitor_WatchdogSidecar.h"
 #import "KSCrashReportFields.h"
 #import "KSTaskRole.h"
@@ -534,6 +535,116 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, task_role_t star
 
     NSDictionary *hang = result[@"crash"][@"error"][@"hang"];
     XCTAssertEqualObjects(hang[@"hang_end_role"], @"DEFAULT_APPLICATION");
+}
+
+#pragma mark - Transition State
+
+- (void)testStitchWritesTransitionStatesFromSidecar
+{
+    KSHangSidecar sc = {
+        .magic = KSHANG_SIDECAR_MAGIC,
+        .version = KSHANG_SIDECAR_VERSION_1_0,
+        .startTimestamp = 1000,
+        .startRole = TASK_FOREGROUND_APPLICATION,
+        .startTransitionState = KSCrashAppTransitionStateLaunching,
+        .endTimestamp = 5000,
+        .endRole = TASK_DEFAULT_APPLICATION,
+        .endTransitionState = KSCrashAppTransitionStateActive,
+        .recovered = true,
+    };
+    NSString *path = writeSidecar(self.tempDir, sc);
+
+    NSDictionary *report = makeMinimalHangReport(1000, TASK_FOREGROUND_APPLICATION);
+
+    NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
+    XCTAssertNotNil(result);
+
+    NSDictionary *hang = result[@"crash"][@"error"][@"hang"];
+    XCTAssertEqualObjects(hang[@"hang_start_transition_state"], @"launching");
+    XCTAssertEqualObjects(hang[@"hang_end_transition_state"], @"active");
+}
+
+- (void)testFatalHangIncludesTransitionStates
+{
+    KSHangSidecar sc = {
+        .magic = KSHANG_SIDECAR_MAGIC,
+        .version = KSHANG_SIDECAR_VERSION_1_0,
+        .startTimestamp = 1000,
+        .startRole = TASK_FOREGROUND_APPLICATION,
+        .startTransitionState = KSCrashAppTransitionStateActive,
+        .endTimestamp = 5000,
+        .endRole = TASK_FOREGROUND_APPLICATION,
+        .endTransitionState = KSCrashAppTransitionStateActive,
+        .recovered = false,
+    };
+    NSString *path = writeSidecar(self.tempDir, sc);
+
+    NSDictionary *report = makeMinimalHangReport(1000, TASK_FOREGROUND_APPLICATION);
+
+    NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
+    XCTAssertNotNil(result);
+
+    NSDictionary *hang = result[@"crash"][@"error"][@"hang"];
+    XCTAssertEqualObjects(hang[@"hang_start_transition_state"], @"active");
+    XCTAssertEqualObjects(hang[@"hang_end_transition_state"], @"active");
+}
+
+#pragma mark - Sidecar Scope
+
+- (void)testReportScopeIsNoOp
+{
+    KSHangSidecar sc = {
+        .magic = KSHANG_SIDECAR_MAGIC,
+        .version = KSHANG_SIDECAR_VERSION_1_0,
+        .endTimestamp = 5000,
+        .endRole = TASK_DEFAULT_APPLICATION,
+        .recovered = true,
+    };
+    NSString *path = writeSidecar(self.tempDir, sc);
+
+    NSDictionary *report = makeMinimalHangReport(1000, TASK_FOREGROUND_APPLICATION);
+
+    NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeReport, NULL);
+    XCTAssertNotNil(result);
+
+    // Report scope should pass through unchanged — no hang modifications
+    NSDictionary *error = result[@"crash"][@"error"];
+    XCTAssertEqualObjects(error[@"type"], @"signal", "Type should be unchanged");
+    XCTAssertEqualObjects(error[@"is_fatal"], @YES, "is_fatal should be unchanged");
+}
+
+#pragma mark - Start Values From Sidecar
+
+- (void)testStartValuesOverwriteJsonValues
+{
+    KSHangSidecar sc = {
+        .magic = KSHANG_SIDECAR_MAGIC,
+        .version = KSHANG_SIDECAR_VERSION_1_0,
+        .startTimestamp = 9999,
+        .startRole = TASK_DEFAULT_APPLICATION,
+        .startTransitionState = KSCrashAppTransitionStateBackground,
+        .endTimestamp = 20000,
+        .endRole = TASK_DEFAULT_APPLICATION,
+        .endTransitionState = KSCrashAppTransitionStateBackground,
+        .recovered = false,
+    };
+    NSString *path = writeSidecar(self.tempDir, sc);
+
+    // JSON has different start values than the sidecar
+    NSDictionary *report = makeMinimalHangReport(1111, TASK_FOREGROUND_APPLICATION);
+
+    NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
+    XCTAssertNotNil(result);
+
+    // Sidecar values must win
+    NSDictionary *hang = result[@"crash"][@"error"][@"hang"];
+    XCTAssertEqualObjects(hang[@"hang_start_nanos"], @(9999));
+    XCTAssertEqualObjects(hang[@"hang_start_role"], @"DEFAULT_APPLICATION");
+    XCTAssertEqualObjects(hang[@"hang_start_transition_state"], @"background");
 }
 
 @end


### PR DESCRIPTION
## Transition state tracking

Record the app transition state (launching, active, background, etc.) at hang start and end in the watchdog sidecar and stitched report. New fields: `hang_start_transition_state`, `hang_end_transition_state`.

## Startup hang suppression

Non-fatal hangs that started before the app became active are deleted on recovery instead of finalized. Startup hangs are expected (initialization work) and would be noise. Fatal hangs during startup are still detected since the report exists on disk for WatchdogStitch. For startup performance visibility, use the Profiler classes to capture a startup profile instead of relying on hang reports.

## Run sidecar

Move the watchdog sidecar from per-report to per-run scope. The hang section is now built entirely from the sidecar at stitch time rather than written at runtime. This means any report from the run gets hang context via stitching, including crash reports that occur during a hang.

## Fatal crash during hang

When a fatal crash occurs during a hang, only the hang report is deleted (superseded by the crash). The run sidecar is preserved so the crash report gets hang context at stitch time.

## Lifecycle accessor

Added `kslifecycle_currentTransitionState()`, a lock-free atomic read of the current app transition state. The watchdog reads this on each timer tick without touching the lifecycle spinlock.