### PR TITLE
Collapse category sections in benchmark report

### DIFF
--- a/.github/scripts/parse_benchmarks.py
+++ b/.github/scripts/parse_benchmarks.py
@@ -331,7 +331,7 @@ def generate_report(pr_results, base_results, config, device_info):
         if not has_results:
             continue
 
-        output.append("<details open>")
+        output.append("<details>")
         output.append(f"<summary><h3>{cat['name']}</h3></summary>\n")
 
         # Build header based on category settings


### PR DESCRIPTION
Collapse the per-category detail sections in the benchmark PR comment so only the "Changes from Base Branch" comparison table is expanded by default. Makes the comment easier to scan at a glance.