### PR TITLE
fix: add missing signal code to injected termination reports

### DIFF
--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Termination.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Termination.m
@@ -112,6 +112,7 @@ static void injectReport(const char *lastRunID, const KSCrash_LifecycleData *lif
     errorSection[KSCrashExcType_Signal] = @{
         KSCrashField_Signal : @(SIGKILL),
         KSCrashField_Name : @"SIGKILL",
+        KSCrashField_Code : @0,
     };
 
     NSMutableDictionary *crashSection = [NSMutableDictionary dictionary];


### PR DESCRIPTION
The synthetic SIGKILL signal section in injected termination reports (OOM, thermal, CPU, unexplained kills) was missing the `code` field. Consumers that decode the signal section with non-optional `code` (like the Swift Report module's `SignalError`) would fail to parse these reports.