### PR TITLE
fix: watchdog stitch no longer overwrites is_fatal on non-watchdog reports

### DIFF
--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_WatchdogStitch.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_WatchdogStitch.m
@@ -116,7 +116,7 @@ CFDictionaryRef kscm_watchdog_createStitchedReport(CFDictionaryRef reportDict, c
         hang[KSCrashField_HangRecovered] = @YES;
 
         if (isWatchdogReport) {
-            errorDict[KSCrashField_Type] = KSCrashField_Hang;
+            errorDict[KSCrashField_Type] = KSCrashExcType_Hang;
             [errorDict removeObjectForKey:KSCrashField_Signal];
             [errorDict removeObjectForKey:KSCrashField_Mach];
             [errorDict removeObjectForKey:KSCrashField_ExitReason];

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_WatchdogStitch.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_WatchdogStitch.m
@@ -75,6 +75,18 @@ CFDictionaryRef kscm_watchdog_createStitchedReport(CFDictionaryRef reportDict, c
 
     NSMutableDictionary *dict = [(__bridge NSDictionary *)reportDict mutableCopy];
 
+    // Check if this report was written by the Watchdog monitor.
+    // The hang section is added to all reports as context, but only
+    // Watchdog reports get their fatality and error type modified.
+    bool isWatchdogReport = false;
+    id reportSectionVal = dict[KSCrashField_Report];
+    if ([reportSectionVal isKindOfClass:[NSDictionary class]]) {
+        id monitorIdVal = ((NSDictionary *)reportSectionVal)[KSCrashField_MonitorId];
+        if ([monitorIdVal isKindOfClass:[NSString class]]) {
+            isWatchdogReport = [monitorIdVal isEqualToString:@"Watchdog"];
+        }
+    }
+
     // Navigate to crash.error, create hang section from sidecar data.
     id crashVal = dict[KSCrashField_Crash];
     if (![crashVal isKindOfClass:[NSDictionary class]]) {
@@ -90,7 +102,8 @@ CFDictionaryRef kscm_watchdog_createStitchedReport(CFDictionaryRef reportDict, c
     }
     NSMutableDictionary *errorDict = [errorVal mutableCopy];
 
-    // Build the hang section entirely from the sidecar.
+    // The hang section is added to all reports from the run as context
+    // (e.g., an exception that occurred during a hang).
     NSMutableDictionary *hang = [NSMutableDictionary dictionary];
     hang[KSCrashField_HangStartNanoseconds] = @(sc.startTimestamp);
     hang[KSCrashField_HangStartRole] = @(kstaskrole_toString(sc.startRole));
@@ -102,18 +115,15 @@ CFDictionaryRef kscm_watchdog_createStitchedReport(CFDictionaryRef reportDict, c
     if (recovered) {
         hang[KSCrashField_HangRecovered] = @YES;
 
-        // Change the error type to "hang"
-        errorDict[KSCrashField_Type] = KSCrashField_Hang;
-
-        // Remove crash-only fields since this is a recovered hang, not a crash
-        [errorDict removeObjectForKey:KSCrashField_Signal];
-        [errorDict removeObjectForKey:KSCrashField_Mach];
-        [errorDict removeObjectForKey:KSCrashField_ExitReason];
-        errorDict[KSCrashField_IsFatal] = @NO;
-        [errorDict removeObjectForKey:KSCrashField_IsCleanExit];
-    } else {
-        // Unrecovered hang: the OS killed the process, mark as fatal.
-        // The report already has the correct type from the report writer.
+        if (isWatchdogReport) {
+            errorDict[KSCrashField_Type] = KSCrashField_Hang;
+            [errorDict removeObjectForKey:KSCrashField_Signal];
+            [errorDict removeObjectForKey:KSCrashField_Mach];
+            [errorDict removeObjectForKey:KSCrashField_ExitReason];
+            errorDict[KSCrashField_IsFatal] = @NO;
+            [errorDict removeObjectForKey:KSCrashField_IsCleanExit];
+        }
+    } else if (isWatchdogReport) {
         errorDict[KSCrashField_IsFatal] = @YES;
         errorDict[KSCrashField_IsCleanExit] = @NO;
     }

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_WatchdogStitch_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_WatchdogStitch_Tests.m
@@ -57,6 +57,7 @@ static NSString *writeSidecar(NSString *dir, KSHangSidecar sc)
 static NSDictionary *makeMinimalHangReport(uint64_t startNanos, task_role_t startRole)
 {
     return @{
+        @"report" : @ { @"monitor_id" : @"Watchdog" },
         @"crash" : @ {
             @"error" : @ {
                 @"type" : @"signal",
@@ -614,6 +615,81 @@ static NSDictionary *makeMinimalHangReport(uint64_t startNanos, task_role_t star
     NSDictionary *error = result[@"crash"][@"error"];
     XCTAssertEqualObjects(error[@"type"], @"signal", @"Type should be unchanged");
     XCTAssertEqualObjects(error[@"is_fatal"], @YES, @"is_fatal should be unchanged");
+}
+
+#pragma mark - Non-Watchdog Reports
+
+- (void)testNonWatchdogReportKeepsOriginalFatality
+{
+    KSHangSidecar sc = {
+        .magic = KSHANG_SIDECAR_MAGIC,
+        .version = KSHANG_SIDECAR_VERSION_1_0,
+        .startTimestamp = 1000,
+        .startRole = TASK_FOREGROUND_APPLICATION,
+        .endTimestamp = 5000,
+        .endRole = TASK_DEFAULT_APPLICATION,
+        .recovered = false,
+    };
+    NSString *path = writeSidecar(self.tempDir, sc);
+
+    NSDictionary *report = @{
+        @"report" : @ { @"monitor_id" : @"profile" },
+        @"crash" : @ {
+            @"error" : @ {
+                @"type" : @"profile",
+                @"is_fatal" : @NO,
+            },
+        },
+    };
+
+    NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
+    XCTAssertNotNil(result);
+
+    NSDictionary *error = result[@"crash"][@"error"];
+    XCTAssertEqualObjects(error[@"is_fatal"], @NO, @"Non-watchdog report should keep its original is_fatal");
+    XCTAssertEqualObjects(error[@"type"], @"profile", @"Non-watchdog report should keep its original type");
+    XCTAssertNil(error[@"is_clean_exit"], @"Non-watchdog report should not gain is_clean_exit");
+    XCTAssertNotNil(error[@"hang"], @"Hang section should still be added as context");
+}
+
+- (void)testNonWatchdogRecoveredHangKeepsOriginalFields
+{
+    KSHangSidecar sc = {
+        .magic = KSHANG_SIDECAR_MAGIC,
+        .version = KSHANG_SIDECAR_VERSION_1_0,
+        .startTimestamp = 1000,
+        .startRole = TASK_FOREGROUND_APPLICATION,
+        .endTimestamp = 5000,
+        .endRole = TASK_DEFAULT_APPLICATION,
+        .recovered = true,
+    };
+    NSString *path = writeSidecar(self.tempDir, sc);
+
+    NSDictionary *report = @{
+        @"report" : @ { @"monitor_id" : @"Signal" },
+        @"crash" : @ {
+            @"error" : @ {
+                @"type" : @"signal",
+                @"is_fatal" : @YES,
+                @"is_clean_exit" : @NO,
+                @"signal" : @ { @"name" : @"SIGSEGV" },
+                @"mach" : @ { @"exception" : @(1) },
+            },
+        },
+    };
+
+    NSDictionary *result = (__bridge_transfer NSDictionary *)kscm_watchdog_createStitchedReport(
+        (__bridge CFDictionaryRef)report, path.UTF8String, KSCrashSidecarScopeRun, NULL);
+    XCTAssertNotNil(result);
+
+    NSDictionary *error = result[@"crash"][@"error"];
+    XCTAssertEqualObjects(error[@"type"], @"signal", @"Signal report should keep its type");
+    XCTAssertEqualObjects(error[@"is_fatal"], @YES, @"Signal report should keep its fatality");
+    XCTAssertNotNil(error[@"signal"], @"Signal section should not be removed");
+    XCTAssertNotNil(error[@"mach"], @"Mach section should not be removed");
+    XCTAssertNotNil(error[@"hang"], @"Hang section should be added as context");
+    XCTAssertEqualObjects(error[@"hang"][@"hang_recovered"], @YES);
 }
 
 #pragma mark - Start Values From Sidecar


### PR DESCRIPTION
The watchdog run sidecar stitch was unconditionally setting `is_fatal=YES` on all reports from a process run that had an unrecovered hang. This corrupted non-watchdog reports (profiles, user reports, etc.) that happened to share the same run.

Now only Watchdog reports get their fatality and error type modified. The `hang` section is still stitched into all reports as context, so a crash during a hang still carries the hang timing info.