### PR TITLE
Let consumers opt out of KSLogger.h's DEBUG/ERROR/etc. aliases

### DIFF
--- a/.github/workflows/static-analyzer.yml
+++ b/.github/workflows/static-analyzer.yml
@@ -153,6 +153,17 @@ jobs:
           file-path: /tmp/analyzer-report.md
           comment-tag: static-analyzer-report
 
+      - name: Delete stale comment when clean
+        if: |
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          steps.check-warnings.outputs.has_warnings == 'false'
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          comment-tag: static-analyzer-report
+          mode: delete
+          create-if-not-exists: false
+
       - name: Fail if warnings found
         if: always()
         run: |

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
@@ -24,13 +24,15 @@
 // THE SOFTWARE.
 //
 
-// Capture DEBUG before KSLogger.h's macro dance can rebind it, otherwise
-// `#if DEBUG` inside this file hits -Wambiguous-macro when the app defines
-// DEBUG on the command line.
+// Capture DEBUG before KSLogger.h's alias dance can rebind it. KSLogger.h
+// temporarily redefines DEBUG as a log-level number and restores it via an
+// indirection macro; after that, `#if DEBUG` trips -Wambiguous-macro when the
+// app also passes -DDEBUG on the command line. This capture must stay at the
+// top of the file, before any header that transitively includes KSLogger.h.
 #if DEBUG
-#define KSCRASH_SYSTEM_IS_DEBUG_BUILD 1
+#define KSCRASH_IS_DEBUG_BUILD 1
 #else
-#define KSCRASH_SYSTEM_IS_DEBUG_BUILD 0
+#define KSCRASH_IS_DEBUG_BUILD 0
 #endif
 
 #import "KSCrashMonitor_System.h"
@@ -267,7 +269,7 @@ static bool procTranslated(void)
 
 static bool isDebugBuild(void)
 {
-#if KSCRASH_SYSTEM_IS_DEBUG_BUILD
+#if KSCRASH_IS_DEBUG_BUILD
     return YES;
 #else
     return NO;

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
@@ -24,6 +24,15 @@
 // THE SOFTWARE.
 //
 
+// Capture DEBUG before KSLogger.h's macro dance can rebind it, otherwise
+// `#if DEBUG` inside this file hits -Wambiguous-macro when the app defines
+// DEBUG on the command line.
+#if DEBUG
+#define KSCRASH_SYSTEM_IS_DEBUG_BUILD 1
+#else
+#define KSCRASH_SYSTEM_IS_DEBUG_BUILD 0
+#endif
+
 #import "KSCrashMonitor_System.h"
 
 #import "KSBinaryImageCache.h"
@@ -258,7 +267,7 @@ static bool procTranslated(void)
 
 static bool isDebugBuild(void)
 {
-#ifdef DEBUG
+#if KSCRASH_SYSTEM_IS_DEBUG_BUILD
     return YES;
 #else
     return NO;

--- a/Sources/KSCrashRecordingCore/include/KSLogger.h
+++ b/Sources/KSCrashRecordingCore/include/KSLogger.h
@@ -53,9 +53,12 @@
  *
  * If your project already defines any of TRACE/DEBUG/INFO/WARN/ERROR and you
  * do not want KSLogger.h to temporarily redefine them, define
- * KSLOGGER_NO_LEVEL_ALIASES=1. In that case, set KSLogger_Level using the
- * prefixed form (e.g. KSLogger_Level=KSLogger_Level_Warn) or the numeric value
- * (e.g. KSLogger_Level=20).
+ * KSLOGGER_NO_LEVEL_ALIASES=1. In that case both KSLogger_Level AND any
+ * per-file KSLogger_LocalLevel must use the prefixed form (e.g.
+ * KSLogger_Level_Warn) or the numeric value (e.g. 20). The short TRACE/DEBUG/
+ * INFO/WARN/ERROR names will no longer resolve to level numbers, so a stray
+ * `#define KSLogger_LocalLevel TRACE` would otherwise silently compile all
+ * trace/debug logs out.
  *
  * Anything below the level specified for KSLogger_Level will not be compiled
  * or printed.
@@ -127,6 +130,9 @@
  * #define KSLogger_LocalLevel TRACE
  * #import "KSLogger.h"
  *
+ * If KSLOGGER_NO_LEVEL_ALIASES=1 is in effect, the short TRACE name does not
+ * resolve to a number, so use KSLogger_Level_Trace (or the numeric 50) here.
+ *
  *
  * ===============
  * IMPORTANT NOTES
@@ -195,10 +201,6 @@ void i_kslog_logCBasic(const char *fmt, ...);
  * opt out by defining KSLOGGER_NO_LEVEL_ALIASES; they must then use the
  * prefixed or numeric form for KSLogger_Level. */
 #ifndef KSLOGGER_NO_LEVEL_ALIASES
-#if defined(DEBUG) || defined(ERROR) || defined(WARN) || defined(INFO) || defined(TRACE)
-#pragma message( \
-    "KSLogger.h: one of DEBUG/ERROR/WARN/INFO/TRACE is already defined; if this causes issues, define KSLOGGER_NO_LEVEL_ALIASES=1 and set KSLogger_Level using KSLogger_Level_* or a numeric value.")
-#endif
 #ifdef KS_NONE
 #define KSLOG_BAK_NONE KS_NONE
 #undef KS_NONE

--- a/Sources/KSCrashRecordingCore/include/KSLogger.h
+++ b/Sources/KSCrashRecordingCore/include/KSLogger.h
@@ -197,7 +197,7 @@ void i_kslog_logCBasic(const char *fmt, ...);
 #ifndef KSLOGGER_NO_LEVEL_ALIASES
 #if defined(DEBUG) || defined(ERROR) || defined(WARN) || defined(INFO) || defined(TRACE)
 #pragma message( \
-    "KSLogger.h: one of DEBUG/ERROR/WARN/INFO/TRACE is already defined; if this causes -Wambiguous-macro, define KSLOGGER_NO_LEVEL_ALIASES=1 and set KSLogger_Level using KSLogger_Level_* or a numeric value.")
+    "KSLogger.h: one of DEBUG/ERROR/WARN/INFO/TRACE is already defined; if this causes issues, define KSLOGGER_NO_LEVEL_ALIASES=1 and set KSLogger_Level using KSLogger_Level_* or a numeric value.")
 #endif
 #ifdef KS_NONE
 #define KSLOG_BAK_NONE KS_NONE

--- a/Sources/KSCrashRecordingCore/include/KSLogger.h
+++ b/Sources/KSCrashRecordingCore/include/KSLogger.h
@@ -51,6 +51,12 @@
  *
  * Example: KSLogger_Level=WARN
  *
+ * If your project already defines any of TRACE/DEBUG/INFO/WARN/ERROR and you
+ * do not want KSLogger.h to temporarily redefine them, define
+ * KSLOGGER_NO_LEVEL_ALIASES=1. In that case, set KSLogger_Level using the
+ * prefixed form (e.g. KSLogger_Level=KSLogger_Level_Warn) or the numeric value
+ * (e.g. KSLogger_Level=20).
+ *
  * Anything below the level specified for KSLogger_Level will not be compiled
  * or printed.
  *
@@ -176,7 +182,19 @@ void i_kslog_logCBasic(const char *fmt, ...);
 
 #endif  // __OBJC__
 
-/* Back up any existing defines by the same name */
+#define KSLogger_Level_None 0
+#define KSLogger_Level_Error 10
+#define KSLogger_Level_Warn 20
+#define KSLogger_Level_Info 30
+#define KSLogger_Level_Debug 40
+#define KSLogger_Level_Trace 50
+
+/* Back up any existing defines by the same name and alias the short forms to
+ * the KSLogger_Level_* values, so KSLogger_Level=DEBUG (etc.) works. Consumers
+ * that already define any of these names and do not want them touched can
+ * opt out by defining KSLOGGER_NO_LEVEL_ALIASES; they must then use the
+ * prefixed or numeric form for KSLogger_Level. */
+#ifndef KSLOGGER_NO_LEVEL_ALIASES
 #ifdef KS_NONE
 #define KSLOG_BAK_NONE KS_NONE
 #undef KS_NONE
@@ -202,19 +220,13 @@ void i_kslog_logCBasic(const char *fmt, ...);
 #undef TRACE
 #endif
 
-#define KSLogger_Level_None 0
-#define KSLogger_Level_Error 10
-#define KSLogger_Level_Warn 20
-#define KSLogger_Level_Info 30
-#define KSLogger_Level_Debug 40
-#define KSLogger_Level_Trace 50
-
 #define KS_NONE KSLogger_Level_None
 #define ERROR KSLogger_Level_Error
 #define WARN KSLogger_Level_Warn
 #define INFO KSLogger_Level_Info
 #define DEBUG KSLogger_Level_Debug
 #define TRACE KSLogger_Level_Trace
+#endif  // KSLOGGER_NO_LEVEL_ALIASES
 
 #ifndef KSLogger_Level
 #define KSLogger_Level KSLogger_Level_Error
@@ -332,6 +344,7 @@ bool kslog_clearLogFile(void);
 // ============================================================================
 
 /* Put everything back to the way we found it. */
+#ifndef KSLOGGER_NO_LEVEL_ALIASES
 #undef ERROR
 #ifdef KSLOG_BAK_ERROR
 #define ERROR KSLOG_BAK_ERROR
@@ -357,6 +370,7 @@ bool kslog_clearLogFile(void);
 #define TRACE KSLOG_BAK_TRACE
 #undef KSLOG_BAK_TRACE
 #endif
+#endif  // KSLOGGER_NO_LEVEL_ALIASES
 
 #ifdef __cplusplus
 }

--- a/Sources/KSCrashRecordingCore/include/KSLogger.h
+++ b/Sources/KSCrashRecordingCore/include/KSLogger.h
@@ -195,6 +195,10 @@ void i_kslog_logCBasic(const char *fmt, ...);
  * opt out by defining KSLOGGER_NO_LEVEL_ALIASES; they must then use the
  * prefixed or numeric form for KSLogger_Level. */
 #ifndef KSLOGGER_NO_LEVEL_ALIASES
+#if defined(DEBUG) || defined(ERROR) || defined(WARN) || defined(INFO) || defined(TRACE)
+#pragma message( \
+    "KSLogger.h: one of DEBUG/ERROR/WARN/INFO/TRACE is already defined; if this causes -Wambiguous-macro, define KSLOGGER_NO_LEVEL_ALIASES=1 and set KSLogger_Level using KSLogger_Level_* or a numeric value.")
+#endif
 #ifdef KS_NONE
 #define KSLOG_BAK_NONE KS_NONE
 #undef KS_NONE


### PR DESCRIPTION
Apps that define `DEBUG` on the command line hit issues in translation units that later evaluate `#if DEBUG`. The root cause is KSLogger.h's backup/restore dance.

This PR gates the `DEBUG`/`ERROR`/`WARN`/`INFO`/`TRACE` alias block behind `KSLOGGER_NO_LEVEL_ALIASES`. Consumers hit by collisions set `-DKSLOGGER_NO_LEVEL_ALIASES=1` and use the prefixed form (`KSLogger_Level=KSLogger_Level_Warn`) or numeric value (`KSLogger_Level=20`) to set the log level. Default behavior is unchanged. The same constraint applies to any per-file `KSLogger_LocalLevel` override.

## KSCrashMonitor_System.m

`isDebugBuild()` changed from `#ifdef DEBUG` to `#if DEBUG`, so a release build that explicitly sets `DEBUG=0` is no longer mislabeled as "debug".