### PR TITLE
fix: restore AppStateTracker addObserverWithBlock: 2.5.1 return type

### DIFF
--- a/Sources/KSCrashCore/include/KSCrashNamespace.h
+++ b/Sources/KSCrashCore/include/KSCrashNamespace.h
@@ -101,6 +101,7 @@
 #define KSCrashAppMemoryTracker KSCRASH_NS(KSCrashAppMemoryTracker)
 #define KSCrashAppMemoryTrackerDelegate KSCRASH_NS(KSCrashAppMemoryTrackerDelegate)
 #define KSCrashAppStateTracker KSCRASH_NS(KSCrashAppStateTracker)
+#define KSCrashAppStateTrackerBlockObserver KSCRASH_NS(KSCrashAppStateTrackerBlockObserver)
 #define KSCrashBasicMonitorPlugin KSCRASH_NS(KSCrashBasicMonitorPlugin)
 #define KSCrashCPU KSCRASH_NS(KSCrashCPU)
 #define KSCrashCPUCriticalThreshold KSCRASH_NS(KSCrashCPUCriticalThreshold)

--- a/Sources/KSCrashRecording/KSCrashAppStateTracker.m
+++ b/Sources/KSCrashRecording/KSCrashAppStateTracker.m
@@ -84,6 +84,31 @@ bool ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionState state)
     }
 }
 
+// Source-compat wrapper for the deprecated -addObserverWithBlock: shim.
+// Holds the heap-copied block strongly so the weak reference inside _observers
+// stays alive as long as the caller retains this token. The protocol
+// conformance is honest (the typed return is not a cast lie), but the tracker
+// invokes the block directly via _observers — the protocol method exists only
+// so that the typed return value compiles for legacy 2.5.1-shaped call sites.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+@interface KSCrashAppStateTrackerBlockObserver : NSObject <KSCrashAppStateTrackerObserving>
+@property(nonatomic, copy) KSCrashAppStateTrackerObserverBlock block;
+@end
+
+@implementation KSCrashAppStateTrackerBlockObserver
+- (void)appStateTracker:(__unused KSCrashAppStateTracker *)tracker
+    didTransitionToState:(KSCrashAppTransitionState)transitionState
+{
+    KSCrashAppStateTrackerObserverBlock block = self.block;
+    if (block) {
+        block(transitionState);
+    }
+}
+@end
+#pragma clang diagnostic pop
+
 @interface KSCrashAppStateTracker () {
     NSNotificationCenter *_center;
     NSArray<id<NSObject>> *_registrations;
@@ -140,7 +165,7 @@ bool ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionState state)
     [self stop];
 }
 
-- (id)addObserverWithBlock:(KSCrashAppStateTrackerObserverBlock)block
+- (id)subscribeWithBlock:(KSCrashAppStateTrackerObserverBlock)block
 {
     if (!block) {
         return nil;
@@ -155,7 +180,7 @@ bool ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionState state)
     // Deliver the current state so the observer doesn't miss transitions
     // that already happened (e.g. on macOS, Active is set during start()
     // before any observers are registered). Dispatch async to avoid
-    // re-entering the caller while still inside addObserverWithBlock:.
+    // re-entering the caller while still inside subscribeWithBlock:.
     dispatch_async(dispatch_get_main_queue(), ^{
         ((KSCrashAppStateTrackerObserverBlock)heapBlock)(currentState);
     });
@@ -166,12 +191,31 @@ bool ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionState state)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-implementations"
 
+- (id<KSCrashAppStateTrackerObserving>)addObserverWithBlock:(KSCrashAppStateTrackerObserverBlock)block
+{
+    // Deprecated source-compat shim. Returns a wrapper conforming to
+    // KSCrashAppStateTrackerObserving so that 2.5.1-shaped call sites that
+    // assigned the result to id<KSCrashAppStateTrackerObserving> still
+    // compile. The wrapper retains the heap-copied block returned by
+    // -subscribeWithBlock: so the weak reference in _observers stays alive.
+    if (!block) {
+        return nil;
+    }
+    KSCrashAppStateTrackerObserverBlock token = (KSCrashAppStateTrackerObserverBlock)[self subscribeWithBlock:block];
+    if (!token) {
+        return nil;
+    }
+    KSCrashAppStateTrackerBlockObserver *wrapper = [[KSCrashAppStateTrackerBlockObserver alloc] init];
+    wrapper.block = token;
+    return wrapper;
+}
+
 - (void)addObserver:(id<KSCrashAppStateTrackerObserving>)observer
 {
     // Deprecated: wrap the protocol observer into a block observer.
     __weak id<KSCrashAppStateTrackerObserving> weakObserver = observer;
     __weak typeof(self) weakSelf = self;
-    [self addObserverWithBlock:^(KSCrashAppTransitionState transitionState) {
+    [self subscribeWithBlock:^(KSCrashAppTransitionState transitionState) {
         [weakObserver appStateTracker:weakSelf didTransitionToState:transitionState];
     }];
 }

--- a/Sources/KSCrashRecording/KSCrashAppStateTracker.m
+++ b/Sources/KSCrashRecording/KSCrashAppStateTracker.m
@@ -167,10 +167,14 @@ bool ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionState state)
 
 - (id)subscribeWithBlock:(KSCrashAppStateTrackerObserverBlock)block
 {
-    if (!block) {
-        return nil;
+    KSCrashAppStateTrackerObserverBlock heapBlock = [block copy];
+    if (!heapBlock) {
+        // Caller violated the non-null param contract. Return a non-nil
+        // global no-op block so the non-null return contract is honored;
+        // do not register it as an observer.
+        return ^(KSCrashAppTransitionState __unused transitionState) {
+        };
     }
-    id heapBlock = [block copy];
     KSCrashAppTransitionState currentState;
     os_unfair_lock_lock(&_lock);
     [_observers addPointer:(__bridge void *_Nullable)(heapBlock)];
@@ -182,7 +186,7 @@ bool ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionState state)
     // before any observers are registered). Dispatch async to avoid
     // re-entering the caller while still inside subscribeWithBlock:.
     dispatch_async(dispatch_get_main_queue(), ^{
-        ((KSCrashAppStateTrackerObserverBlock)heapBlock)(currentState);
+        heapBlock(currentState);
     });
 
     return heapBlock;
@@ -198,13 +202,7 @@ bool ksapp_transitionStateIsUserPerceptible(KSCrashAppTransitionState state)
     // assigned the result to id<KSCrashAppStateTrackerObserving> still
     // compile. The wrapper retains the heap-copied block returned by
     // -subscribeWithBlock: so the weak reference in _observers stays alive.
-    if (!block) {
-        return nil;
-    }
     KSCrashAppStateTrackerObserverBlock token = (KSCrashAppStateTrackerObserverBlock)[self subscribeWithBlock:block];
-    if (!token) {
-        return nil;
-    }
     KSCrashAppStateTrackerBlockObserver *wrapper = [[KSCrashAppStateTrackerBlockObserver alloc] init];
     wrapper.block = token;
     return wrapper;

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Lifecycle.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Lifecycle.m
@@ -424,7 +424,7 @@ static void setEnabled(bool isEnabled, __unused void *context)
         ks_spinlock_unlock(&g_sidecarLock);
 
         g_appStateObserver =
-            [KSCrashAppStateTracker.sharedInstance addObserverWithBlock:^(KSCrashAppTransitionState transitionState) {
+            [KSCrashAppStateTracker.sharedInstance subscribeWithBlock:^(KSCrashAppTransitionState transitionState) {
                 onTransitionState(transitionState);
             }];
 

--- a/Sources/KSCrashRecording/include/KSCrashAppStateTracker.h
+++ b/Sources/KSCrashRecording/include/KSCrashAppStateTracker.h
@@ -66,11 +66,12 @@ NS_SWIFT_NAME(AppStateTracker)
 @property(atomic, readonly) KSCrashAppTransitionState transitionState;
 
 /**
- * Adds a block based observer.
+ * Subscribes a block-based observer.
  *
- *@return An object that when set to nil will remove the observer.
+ * @return An opaque token that keeps the observation alive while retained.
+ *         Set to nil to remove the observer.
  */
-- (id)addObserverWithBlock:(KSCrashAppStateTrackerObserverBlock)block;
+- (id)subscribeWithBlock:(KSCrashAppStateTrackerObserverBlock)block;
 
 /**
  * Start the tracker.
@@ -86,19 +87,26 @@ NS_SWIFT_NAME(AppStateTracker)
  */
 - (void)stop;
 
-/** @deprecated Use `addObserverWithBlock:` instead. */
-- (void)addObserver:(id<KSCrashAppStateTrackerObserving>)observer
-    KSCRASH_DEPRECATED("Use -addObserverWithBlock: instead");
+/**
+ * @deprecated Use `-subscribeWithBlock:` instead. The returned token is opaque;
+ *             do not invoke protocol methods on it directly.
+ */
+- (id<KSCrashAppStateTrackerObserving>)addObserverWithBlock:(KSCrashAppStateTrackerObserverBlock)block
+    KSCRASH_DEPRECATED("Use -subscribeWithBlock: instead");
 
-/** @deprecated Use `addObserverWithBlock:` instead. */
+/** @deprecated Use `-subscribeWithBlock:` instead. */
+- (void)addObserver:(id<KSCrashAppStateTrackerObserving>)observer
+    KSCRASH_DEPRECATED("Use -subscribeWithBlock: instead");
+
+/** @deprecated Use `-subscribeWithBlock:` instead. */
 - (void)removeObserver:(id<KSCrashAppStateTrackerObserving>)observer
-    KSCRASH_DEPRECATED("Use -addObserverWithBlock: instead");
+    KSCRASH_DEPRECATED("Use -subscribeWithBlock: instead");
 
 @end
 
-/** @deprecated Use `addObserverWithBlock:` instead. */
+/** @deprecated Use `-subscribeWithBlock:` instead. */
 NS_SWIFT_NAME(AppStateTrackerObserving)
-KSCRASH_DEPRECATED("Use -addObserverWithBlock: instead")
+KSCRASH_DEPRECATED("Use -subscribeWithBlock: instead")
 @protocol KSCrashAppStateTrackerObserving <NSObject>
 - (void)appStateTracker:(KSCrashAppStateTracker *)tracker didTransitionToState:(KSCrashAppTransitionState)state;
 @end

--- a/Tests/KSCrashRecordingTests/KSCrashAppMemory_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashAppMemory_Tests.m
@@ -94,7 +94,7 @@ static KSCrashAppMemory *Memory(uint64_t footprint)
     __block KSCrashAppTransitionState state;
 
     KSCrashAppStateTracker *tracker = [KSCrashAppStateTracker new];
-    [tracker addObserverWithBlock:^(KSCrashAppTransitionState transitionState) {
+    [tracker subscribeWithBlock:^(KSCrashAppTransitionState transitionState) {
         state = transitionState;
     }];
 


### PR DESCRIPTION
## Summary

Adds `-[KSCrashAppStateTracker subscribeWithBlock:]` as the new canonical block-observer API, and restores the 2.5.1 return type on `-addObserverWithBlock:` as a deprecated source-compat shim.

This closes the only real source-breaking change between `2.5.1` and `2.6.0-beta.1` flagged by the api-diff CI gate from #828:

> Func AppStateTracker.addObserver(_:) has return type change from `any AppStateTrackerObserving` to `Any` — `KSCrashAppStateTracker.h`

## Why

ObjC consumers that wrote `id<KSCrashAppStateTrackerObserving> token = [tracker addObserverWithBlock:^{...}];` against 2.5.1 would not compile against 2.6.0. ObjC has no method overloading by return type, so the fix uses a new selector for the canonical API and keeps the old selector as a typed-return shim.

## What changed

- **New canonical API**: `-subscribeWithBlock:` returning `id`. Implementation is the current `release/2.6.0` `-addObserverWithBlock:` body, just renamed. Same weak-storage semantics — caller must retain the returned token.
- **Deprecated shim**: `-addObserverWithBlock:` keeps its 2.5.1 return type `id<KSCrashAppStateTrackerObserving>`. It now wraps the heap-copied block in a private `KSCrashAppStateTrackerBlockObserver` that genuinely conforms to the protocol (the typed return is honest, not a cast lie). The wrapper retains the heap block so the weak reference inside `_observers` stays alive.
- **Internal callers** in `KSCrashMonitor_Lifecycle.m` and `KSCrashAppMemory_Tests.m` migrated from `-addObserverWithBlock:` to `-subscribeWithBlock:`.
- **Deprecation messages** on `-addObserver:`, `-removeObserver:`, and the `KSCrashAppStateTrackerObserving` protocol updated to point at `-subscribeWithBlock:`.

After this, the api-digester sees `-addObserverWithBlock:` keeping its 2.5.1 return type and the Type Change disappears from the diff. `-subscribeWithBlock:` is additive and silent. Old call sites (typed and untyped, ObjC and Swift) compile unchanged.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — full suite, 1402 tests, 4 skipped, 0 failures
- [x] `make check-format` — clean
- [ ] After this lands, re-run `bash scripts/api-diff.sh compare 2.5.1 release/2.6.0` from #828's branch — `AppStateTracker.addObserver(_:)` Type Change line should be gone; only the `MonitorType.experimental` ignored entry and the C-struct memberwise-init noise should remain.