### PR TITLE
Report: enum mirror sweep audit fixes

### DIFF
--- a/Sources/KSCrashRecording/include/KSCrashReportFields.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportFields.h
@@ -86,6 +86,7 @@ KSCRF_DEFINE_CONSTANT(KSCrashExcType, Termination, termination, "termination")
 /** @deprecated Use KSCrashExcType_Termination instead. Kept for reading legacy reports. */
 KSCRF_DEFINE_CONSTANT(KSCrashExcType, MemoryTermination, memoryTermination, "memory_termination")
 KSCRF_DEFINE_CONSTANT(KSCrashExcType, Hang, hang, "hang")
+KSCRF_DEFINE_CONSTANT(KSCrashExcType, Profile, profile, "profile")
 
 #pragma mark - Common -
 

--- a/Sources/Report/Models/AppMemoryInfo.swift
+++ b/Sources/Report/Models/AppMemoryInfo.swift
@@ -26,6 +26,47 @@
 
 import Foundation
 
+/// App memory state classification.
+///
+/// Mirrors the C `KSCrashAppMemoryState` enum (`KSCrashAppMemory.h`). Values are
+/// emitted as lowercase strings in the report JSON and used for both the app's
+/// own memory level and system-wide memory pressure.
+public enum MemoryState: RawRepresentable, Codable, Sendable, Equatable {
+    case normal
+    case warn
+    case urgent
+    case critical
+    case terminal
+    case unknown(String)
+
+    public init(rawValue: String) {
+        switch rawValue {
+        case "normal": self = .normal
+        case "warn": self = .warn
+        case "urgent": self = .urgent
+        case "critical": self = .critical
+        case "terminal": self = .terminal
+        default: self = .unknown(rawValue)
+        }
+    }
+
+    public var rawValue: String {
+        switch self {
+        case .normal: return "normal"
+        case .warn: return "warn"
+        case .urgent: return "urgent"
+        case .critical: return "critical"
+        case .terminal: return "terminal"
+        case .unknown(let value): return value
+        }
+    }
+
+    public var isUnknown: Bool {
+        if case .unknown = self { return true }
+        return false
+    }
+}
+
 /// App memory information at crash time.
 public struct AppMemoryInfo: Codable, Sendable, Equatable {
     /// Memory footprint of the app in bytes.
@@ -35,16 +76,16 @@ public struct AppMemoryInfo: Codable, Sendable, Equatable {
     public let memoryRemaining: UInt64?
 
     /// System memory pressure level.
-    public let memoryPressure: String?
+    public let memoryPressure: MemoryState?
 
     /// App memory level.
-    public let memoryLevel: String?
+    public let memoryLevel: MemoryState?
 
     /// Memory limit for the app in bytes.
     public let memoryLimit: UInt64?
 
     /// App transition state at crash time.
-    public let appTransitionState: String?
+    public let appTransitionState: AppTransitionState?
 
     enum CodingKeys: String, CodingKey {
         case memoryFootprint = "memory_footprint"

--- a/Tests/ReportTests/CrashReportDecodingTests.swift
+++ b/Tests/ReportTests/CrashReportDecodingTests.swift
@@ -1060,6 +1060,69 @@ final class CrashReportDecodingTests: XCTestCase {
         }
     }
 
+    func testDecodeAllMemoryStates() throws {
+        for (raw, expected): (String, MemoryState) in [
+            ("normal", .normal),
+            ("warn", .warn),
+            ("urgent", .urgent),
+            ("critical", .critical),
+            ("terminal", .terminal),
+        ] {
+            let json = """
+                {
+                    "crash": { "error": { "type": "signal" } },
+                    "system": {
+                        "app_memory": {
+                            "memory_level": "\(raw)",
+                            "memory_pressure": "\(raw)"
+                        }
+                    },
+                    "report": { "id": "test" }
+                }
+                """
+            let report = try CrashReport.decode(from: json)
+            XCTAssertEqual(report.system?.appMemory?.memoryLevel, expected, "memory_level \(raw)")
+            XCTAssertEqual(report.system?.appMemory?.memoryPressure, expected, "memory_pressure \(raw)")
+        }
+    }
+
+    func testDecodeUnknownMemoryState() throws {
+        let json = """
+            {
+                "crash": { "error": { "type": "signal" } },
+                "system": {
+                    "app_memory": {
+                        "memory_level": "future_state"
+                    }
+                },
+                "report": { "id": "test" }
+            }
+            """
+
+        let report = try CrashReport.decode(from: json)
+        XCTAssertEqual(report.system?.appMemory?.memoryLevel, .unknown("future_state"))
+        XCTAssertEqual(report.system?.appMemory?.memoryLevel?.isUnknown, true)
+    }
+
+    func testDecodeAppMemoryAppTransitionStateIsTyped() throws {
+        // AppMemoryInfo.appTransitionState used to be String?; verifying it now decodes
+        // into the typed AppTransitionState enum, matching ApplicationStats.appTransitionState.
+        let json = """
+            {
+                "crash": { "error": { "type": "signal" } },
+                "system": {
+                    "app_memory": {
+                        "app_transition_state": "active"
+                    }
+                },
+                "report": { "id": "test" }
+            }
+            """
+
+        let report = try CrashReport.decode(from: json)
+        XCTAssertEqual(report.system?.appMemory?.appTransitionState, .active)
+    }
+
     func testDecodeIsCleanExitAbsent() throws {
         let json = """
             {


### PR DESCRIPTION
Audit pass over the 9 public enums in the Report module against their C counterparts.

### KSCrashExcType_Profile

Profile reports emit "profile" in the report's type field, and Swift's CrashErrorType.profile mirrors that, but `KSCrashReportFields.h` had no `KSCrashExcType_Profile` constant, so ObjC consumers using the typed ExceptionType enum couldn't reference it. Adding the constant brings the C and ObjC surface in line with both the wire format and the Swift mirror.

### MemoryState and typed transitions in AppMemoryInfo

AppMemoryInfo stored three fields as raw String? despite all three having typed-enum equivalents. memoryLevel and memoryPressure mirror the C KSCrashAppMemoryState (normal, warn, urgent, critical, terminal). appTransitionState was already typed as AppTransitionState on the sibling ApplicationStats struct, so two structs in the same module disagreed on the same field's type.

Adds a MemoryState enum following the Report module's RawRepresentable plus unknown(String) pattern, and retypes the three fields.