### PR TITLE
Monitor: bound the array store in endHandlingException

### DIFF
--- a/Sources/KSCrashRecordingCore/KSCrashMonitor.c
+++ b/Sources/KSCrashRecordingCore/KSCrashMonitor.c
@@ -129,7 +129,12 @@ static int beginHandlingException(thread_t handlerThread)
 
 static void endHandlingException(int threadIndex)
 {
-    atomic_store(&g_state.threadsHandlingExceptions[threadIndex], 0);
+    // Mirror the bounds check in beginHandlingException: an index past the array
+    // was never stored into in the first place, so there's nothing to clear and
+    // attempting it would write OOB.
+    if (threadIndex >= 0 && threadIndex < MAX_SIMULTANEOUS_EXCEPTIONS) {
+        atomic_store(&g_state.threadsHandlingExceptions[threadIndex], 0);
+    }
 
     int expectedIndex = g_state.handlingExceptionIndex;
     if (expectedIndex == 0) {


### PR DESCRIPTION
beginHandlingException increments handlingExceptionIndex unconditionally and only stores into threadsHandlingExceptions[i] when i is below MAX_SIMULTANEOUS_EXCEPTIONS. The end-side cleanup didn't have the matching guard: endHandlingException would atomic_store at threadsHandlingExceptions[threadIndex] regardless of bounds, so an index returned past the cap (which can only happen if 200+ exceptions are in-flight simultaneously) writes OOB. Bounds-check the store, no-op for every normal case.