### PR TITLE
Store: stop hijacking the stitch config from KSCrashReportStore.init

### DIFF
--- a/Sources/KSCrashCore/include/KSCrashNamespace.h
+++ b/Sources/KSCrashCore/include/KSCrashNamespace.h
@@ -345,6 +345,7 @@
 #define kscrs_readReport KSCRASH_NS(kscrs_readReport)
 #define kscrs_readReportAtPath KSCRASH_NS(kscrs_readReportAtPath)
 #define kscrs_readReportByPathAndID KSCRASH_NS(kscrs_readReportByPathAndID)
+#define kscrs_setStitchConfig KSCRASH_NS(kscrs_setStitchConfig)
 #define ksct_swap KSCRASH_NS(ksct_swap)
 #define ksct_swapReset KSCRASH_NS(ksct_swapReset)
 #define kscu_arm64_decode KSCRASH_NS(kscu_arm64_decode)

--- a/Sources/KSCrashRecording/KSCrashC.c
+++ b/Sources/KSCrashRecording/KSCrashC.c
@@ -465,6 +465,11 @@ KSCrashInstallErrorCode kscrash_install(const char *appName, const char *const i
     }
 
     kscrs_initialize(&g_reportStoreConfig);
+    // Register the install's config as the source of paths for the no-config
+    // readers (readReportAtPath, readReportByPathAndID, finalizeReport). Only
+    // the install does this; constructing a KSCrashReportStore no longer
+    // hijacks the stitch path.
+    kscrs_setStitchConfig(&g_reportStoreConfig);
     kscm_setReportSidecarFilePathProvider(getReportSidecarFilePathCallback);
     kscm_setReportSidecarPathProvider(getReportSidecarPathCallback);
     kscm_setRunSidecarPathProvider(getRunSidecarPathCallback);

--- a/Sources/KSCrashRecording/KSCrashC.c
+++ b/Sources/KSCrashRecording/KSCrashC.c
@@ -464,7 +464,10 @@ KSCrashInstallErrorCode kscrash_install(const char *appName, const char *const i
         g_reportStoreConfig.runSidecarsPath = strdup(path);
     }
 
-    kscrs_initialize(&g_reportStoreConfig);
+    KSCrashInstallErrorCode storeInitResult = kscrs_initialize(&g_reportStoreConfig);
+    if (storeInitResult != KSCrashInstallErrorNone) {
+        return storeInitResult;
+    }
     // Register the install's config as the source of paths for the no-config
     // readers (readReportAtPath, readReportByPathAndID, finalizeReport). Only
     // the install does this; constructing a KSCrashReportStore no longer

--- a/Sources/KSCrashRecording/KSCrashReportStoreC+Private.h
+++ b/Sources/KSCrashRecording/KSCrashReportStoreC+Private.h
@@ -100,6 +100,19 @@ bool kscrs_getRunSidecarFilePathForRunID(const char *monitorId, const char *runI
                                          size_t pathBufferLength,
                                          const KSCrashReportStoreCConfiguration *const configuration);
 
+/** Sets the configuration used by the no-config readers
+ *  (kscrs_readReportAtPath, kscrs_readReportByPathAndID, kscrs_finalizeReport)
+ *  for sidecar stitching.
+ *
+ *  Typically called once by kscrash_install. Tests that need stitching to work
+ *  without going through kscrash_install can call this directly. Pass NULL to
+ *  clear (e.g. in tearDown so cross-test state does not leak).
+ *
+ *  The configuration is deep-copied; the caller does not need to keep the
+ *  passed pointer alive after this call returns.
+ */
+void kscrs_setStitchConfig(const KSCrashReportStoreCConfiguration *configuration);
+
 /** Read a report by path and ID, applying fixup and all stitch callbacks.
  *
  * Like kscrs_readReportAtPath but also stitches per-report sidecars

--- a/Sources/KSCrashRecording/KSCrashReportStoreC.m
+++ b/Sources/KSCrashRecording/KSCrashReportStoreC.m
@@ -55,9 +55,27 @@ static _Atomic(uint32_t) g_nextUniqueIDLow;
 static int64_t g_nextUniqueIDHigh;
 static pthread_mutex_t g_mutex = PTHREAD_MUTEX_INITIALIZER;
 
-// Saved during kscrs_initialize so kscrs_readReportAtPath can stitch sidecars.
-static bool g_hasStoredConfig = false;
-static KSCrashReportStoreCConfiguration g_storedConfig;
+// The stitch config used by the no-config readers (readReportAtPath,
+// readReportByPathAndID, finalizeReport). Set explicitly via
+// kscrs_setStitchConfig — typically by kscrash_install. Constructing a
+// KSCrashReportStore does NOT touch this; only the install (or a test that
+// opts in) decides whose paths the stitching uses.
+static bool g_hasStitchConfig = false;
+static KSCrashReportStoreCConfiguration g_stitchConfig;
+
+void kscrs_setStitchConfig(const KSCrashReportStoreCConfiguration *const configuration)
+{
+    pthread_mutex_lock(&g_mutex);
+    if (g_hasStitchConfig) {
+        KSCrashReportStoreCConfiguration_Release(&g_stitchConfig);
+        g_hasStitchConfig = false;
+    }
+    if (configuration != NULL) {
+        g_stitchConfig = KSCrashReportStoreCConfiguration_Copy((KSCrashReportStoreCConfiguration *)configuration);
+        g_hasStitchConfig = true;
+    }
+    pthread_mutex_unlock(&g_mutex);
+}
 
 static int compareInt64(const void *a, const void *b)
 {
@@ -463,12 +481,6 @@ KSCrashInstallErrorCode kscrs_initialize(const KSCrashReportStoreCConfiguration 
         }
         pruneReports(configuration);
         initializeIDs();
-
-        if (g_hasStoredConfig) {
-            KSCrashReportStoreCConfiguration_Release(&g_storedConfig);
-        }
-        g_storedConfig = KSCrashReportStoreCConfiguration_Copy((KSCrashReportStoreCConfiguration *)configuration);
-        g_hasStoredConfig = true;
     }
     pthread_mutex_unlock(&g_mutex);
     return result;
@@ -571,7 +583,7 @@ static char *readReportAtPath(const char *path, int64_t reportID, const KSCrashR
 char *kscrs_readReportAtPath(const char *path)
 {
     pthread_mutex_lock(&g_mutex);
-    const KSCrashReportStoreCConfiguration *config = g_hasStoredConfig ? &g_storedConfig : NULL;
+    const KSCrashReportStoreCConfiguration *config = g_hasStitchConfig ? &g_stitchConfig : NULL;
     char *result = readReportAtPath(path, 0, config);
     pthread_mutex_unlock(&g_mutex);
     return result;
@@ -580,7 +592,7 @@ char *kscrs_readReportAtPath(const char *path)
 char *kscrs_readReportByPathAndID(const char *path, int64_t reportID)
 {
     pthread_mutex_lock(&g_mutex);
-    const KSCrashReportStoreCConfiguration *config = g_hasStoredConfig ? &g_storedConfig : NULL;
+    const KSCrashReportStoreCConfiguration *config = g_hasStitchConfig ? &g_stitchConfig : NULL;
     char *result = readReportAtPath(path, reportID, config);
     pthread_mutex_unlock(&g_mutex);
     return result;
@@ -597,7 +609,7 @@ bool kscrs_finalizeReport(const char *reportPath, int64_t reportID)
     // window where the write-back resurrects a deleted report.
     pthread_mutex_lock(&g_mutex);
 
-    if (!g_hasStoredConfig) {
+    if (!g_hasStitchConfig) {
         pthread_mutex_unlock(&g_mutex);
         return false;
     }
@@ -631,8 +643,8 @@ bool kscrs_finalizeReport(const char *reportPath, int64_t reportID)
         // Fixup
         NSDictionary *report = kscrf_fixupReportDict(dict);
         bool stitchFailed = false;
-        report = stitchRunSidecarsIntoReport(report, &g_storedConfig, &stitchFailed);
-        report = stitchReportSidecarsIntoReport(report, reportID, &g_storedConfig, &stitchFailed);
+        report = stitchRunSidecarsIntoReport(report, &g_stitchConfig, &stitchFailed);
+        report = stitchReportSidecarsIntoReport(report, reportID, &g_stitchConfig, &stitchFailed);
         if (stitchFailed) {
             KSLOG_ERROR(@"Stitching failed for report %lld, skipping finalization to allow retry on next read",
                         (long long)reportID);

--- a/Sources/KSCrashRecording/KSCrashReportStoreC.m
+++ b/Sources/KSCrashRecording/KSCrashReportStoreC.m
@@ -71,7 +71,7 @@ void kscrs_setStitchConfig(const KSCrashReportStoreCConfiguration *const configu
         g_hasStitchConfig = false;
     }
     if (configuration != NULL) {
-        g_stitchConfig = KSCrashReportStoreCConfiguration_Copy((KSCrashReportStoreCConfiguration *)configuration);
+        g_stitchConfig = KSCrashReportStoreCConfiguration_Copy(configuration);
         g_hasStitchConfig = true;
     }
     pthread_mutex_unlock(&g_mutex);

--- a/Sources/KSCrashRecording/include/KSCrashCConfiguration.h
+++ b/Sources/KSCrashRecording/include/KSCrashCConfiguration.h
@@ -96,7 +96,7 @@ static inline KSCrashReportStoreCConfiguration KSCrashReportStoreCConfiguration_
 }
 
 static inline KSCrashReportStoreCConfiguration KSCrashReportStoreCConfiguration_Copy(
-    KSCrashReportStoreCConfiguration *configuration)
+    const KSCrashReportStoreCConfiguration *configuration)
 {
     return (KSCrashReportStoreCConfiguration) {
         .appName = configuration->appName ? strdup(configuration->appName) : NULL,

--- a/Tests/KSCrashRecordingTests/KSCrashReportFinalizer_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashReportFinalizer_Tests.m
@@ -26,8 +26,10 @@
 
 #import "FileBasedTestCase.h"
 
+#import "KSCrashConfiguration.h"
 #import "KSCrashMonitor.h"
 #import "KSCrashReportFields.h"
+#import "KSCrashReportStore.h"
 #import "KSCrashReportStoreC+Private.h"
 #import "KSCrashReportStoreC.h"
 #import "KSJSONCodecObjC.h"
@@ -101,6 +103,7 @@ static CFDictionaryRef noopStitchReport(CFDictionaryRef reportDict, __unused con
 
 - (void)tearDown
 {
+    kscrs_setStitchConfig(NULL);
     kscm_removeMonitor(&_testMonitorAPI);
     kscm_removeMonitor(&_failingMonitorAPI);
     kscm_removeMonitor(&_noopMonitorAPI);
@@ -118,6 +121,7 @@ static CFDictionaryRef noopStitchReport(CFDictionaryRef reportDict, __unused con
     _storeConfig.runSidecarsPath = runSidecarsPath.UTF8String;
     _storeConfig.maxReportCount = 10;
     kscrs_initialize(&_storeConfig);
+    kscrs_setStitchConfig(&_storeConfig);
 }
 
 - (int64_t)writeReportWithRunId:(NSString *)runId
@@ -262,6 +266,43 @@ static CFDictionaryRef noopStitchReport(CFDictionaryRef reportDict, __unused con
 
     NSDictionary *report = [self readReportJSON:path];
     XCTAssertEqualObjects(report[@"finalizer_test_stitch"], @"stitched_report_data");
+}
+
+- (void)testConstructingReportStoreDoesNotHijackStitchConfig
+{
+    // Regression: prior to the fix, KSCrashReportStore.init called
+    // kscrs_initialize, which had the side effect of replacing the global
+    // stitch config with the Store's config. Constructing a Store after
+    // install made finalize/read look up sidecars in the Store's paths
+    // instead of the install's. This test pins the new contract: only
+    // kscrs_setStitchConfig sets the stitch config; constructing a Store
+    // does not.
+    [self prepareStore:@"testHijackA"];  // sets stitch config to _storeConfig (paths under testHijackA)
+    [self registerTestMonitor];
+
+    NSString *runId = [[NSUUID UUID] UUIDString];
+    int64_t reportID = [self writeReportWithRunId:runId];
+    [self writeReportSidecar:@"FinalizerTestMonitor" reportID:reportID contents:@"data_from_store_A"];
+    NSString *path = [self reportPathForID:reportID];
+
+    // Construct an unrelated KSCrashReportStore with a different reports path.
+    // Its init calls kscrs_initialize on its own config; we expect the stitch
+    // config (set above by prepareStore) to remain unchanged.
+    KSCrashReportStoreConfiguration *otherConfig = [KSCrashReportStoreConfiguration new];
+    otherConfig.appName = @"otherapp";
+    otherConfig.reportsPath = [self.tempPath stringByAppendingPathComponent:@"testHijackB"];
+    KSCrashReportStore *otherStore = [KSCrashReportStore storeWithConfiguration:otherConfig error:nil];
+    XCTAssertNotNil(otherStore);
+
+    // If construction had hijacked the stitch config, finalize would now look
+    // for sidecars under testHijackB's paths and fail to find the one written
+    // under testHijackA. With the fix, the stitch config still points at
+    // testHijackA and the sidecar is found.
+    bool result = kscrs_finalizeReport(path.UTF8String, reportID);
+    XCTAssertTrue(result);
+
+    NSDictionary *report = [self readReportJSON:path];
+    XCTAssertEqualObjects(report[@"finalizer_test_stitch"], @"data_from_store_A");
 }
 
 #pragma mark - Sidecar Cleanup

--- a/Tests/KSCrashRecordingTests/KSCrashReportStoreC_RunSidecar_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashReportStoreC_RunSidecar_Tests.m
@@ -72,6 +72,12 @@ static CFDictionaryRef testStitchReport(CFDictionaryRef reportDict, const char *
     memset(&_storeConfig, 0, sizeof(_storeConfig));
 }
 
+- (void)tearDown
+{
+    kscrs_setStitchConfig(NULL);
+    [super tearDown];
+}
+
 - (void)prepareStoreWithRunSidecars:(NSString *)name
 {
     NSString *reportsPath = [self.tempPath stringByAppendingPathComponent:name];
@@ -83,6 +89,7 @@ static CFDictionaryRef testStitchReport(CFDictionaryRef reportDict, const char *
     _storeConfig.runSidecarsPath = runSidecarsPath.UTF8String;
     _storeConfig.maxReportCount = 10;
     kscrs_initialize(&_storeConfig);
+    kscrs_setStitchConfig(&_storeConfig);
 }
 
 - (int64_t)writeReportWithRunId:(NSString *)runId

--- a/Tests/KSCrashRecordingTests/KSCrashReportStoreC_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashReportStoreC_Tests.m
@@ -64,6 +64,12 @@
     self.appName = @"myapp";
 }
 
+- (void)tearDown
+{
+    kscrs_setStitchConfig(NULL);
+    [super tearDown];
+}
+
 - (void)prepareReportStoreWithPathEnd:(NSString *)pathEnd
 {
     [self prepareReportStoreWithPathEnd:pathEnd maxReportCount:5];
@@ -76,6 +82,7 @@
     _storeConfig.reportsPath = self.reportStorePath.UTF8String;
     _storeConfig.maxReportCount = maxReportCount;
     kscrs_initialize(&_storeConfig);
+    kscrs_setStitchConfig(&_storeConfig);
 }
 
 - (void)prepareReportStoreWithSidecarsWithPathEnd:(NSString *)pathEnd
@@ -87,6 +94,7 @@
     _storeConfig.reportSidecarsPath = sidecarsPath.UTF8String;
     _storeConfig.maxReportCount = 5;
     kscrs_initialize(&_storeConfig);
+    kscrs_setStitchConfig(&_storeConfig);
 }
 
 - (NSArray *)getReportIDs
@@ -657,6 +665,7 @@
     _storeConfig.runSidecarsPath = runSidecarsPath.UTF8String;
     _storeConfig.maxReportCount = 5;
     kscrs_initialize(&_storeConfig);
+    kscrs_setStitchConfig(&_storeConfig);
 
     NSString *json = @"{\"report\":\"not a dict\",\"crash\":{}}";
     int64_t reportID = kscrs_addUserReport(json.UTF8String, (int)json.length, &_storeConfig);


### PR DESCRIPTION
kscrs_initialize had a side effect: every call replaced the global config used by the no-config readers (readReportAtPath, readReportByPathAndID, finalizeReport) for sidecar stitching. Since KSCrashReportStore.init calls kscrs_initialize on its own config, simply constructing a Store after install would silently take over the install's stitch path with the Store's config. Reads then looked up sidecars in the wrong directories.

Split the two concerns. kscrs_initialize keeps doing its setup work (mkdir, prune, init IDs) and no longer touches the stitch config. A new kscrs_setStitchConfig sets it explicitly. kscrash_install calls both; KSCrashReportStore.init only calls kscrs_initialize.