### PR TITLE
Agent instructions: source-breaking is measured against the most recent release

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -60,6 +60,10 @@ KSCrash is a layered crash reporting framework:
 
 Public modules (API surface): KSCrashRecording, KSCrashFilters, KSCrashSinks, KSCrashInstallations, KSCrashDiscSpaceMonitor, KSCrashBootTimeMonitor, KSCrashDemangleFilter, Monitors (Swift), Report (Swift), KSCrashProfiler (Swift). Public headers: `Sources/[ModuleName]/include/*.h`.
 
+## Source-Breaking Changes
+
+A change is source-breaking **only if it breaks code that compiled against the most recent tagged release** (`git describe --tags --abbrev=0`), not against master. Symbols, types, or shapes that do not exist at the release tag cannot be source-breaking, no matter how they evolve on master. Always verify against the release tag before acting on a review comment, automated flag, or memory note that calls something source-breaking. See `.claude/rules/api-stability.md` for the full rule and the list of changes that warrant flagging.
+
 ## Verbose Logging
 
 KSLogger uses compile-time log levels for async-signal-safety:

--- a/.claude/rules/api-stability.md
+++ b/.claude/rules/api-stability.md
@@ -15,7 +15,17 @@ The public API surface consists of: **KSCrashRecording**, **KSCrashFilters**, **
 
 ## API Stability
 
-KSCrash prioritizes API stability. A change is **breaking** only if it breaks code that compiled against the last tagged release (e.g., 2.5.1), not against unreleased work on master. The following changes to public headers need strong justification plus migration guidance:
+KSCrash prioritizes API stability. A change is **breaking** only if it breaks code that compiled against the **most recent tagged release**, not against unreleased work on master.
+
+**This is the only baseline that matters.** Apply it when authoring changes, when reviewing PRs, and when evaluating any review comment that claims "this is source-breaking."
+
+- Find the current release with `git describe --tags --abbrev=0` (or check the GitHub releases page).
+- Compare the affected public header at that tag (`git show <tag>:Sources/.../Header.h`) against the PR's version.
+- If the API in the PR is identical to, or strictly additive over, the API at the release tag, **the change is not source-breaking**, regardless of what unreleased work on master has done in between.
+- A symbol or type that does not exist at the release tag is not part of the released surface, so changing or removing it on master cannot be source-breaking.
+- A reviewer comment, automated tool, or memory note that flags a change as source-breaking must be verified against the release tag before being acted on. If the verification disagrees with the comment, the comment is wrong.
+
+The following changes to public headers need strong justification plus migration guidance **when they would break code compiled against the most recent release**:
 
 - **Method parameter changes**: Any addition, removal, type change, or reordering. ObjC has no default parameters, so even adding a nullable parameter breaks all call sites.
 - **Callback/function pointer signature changes**: Parameter or return type changes.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,17 @@
 
 When performing code reviews on this repository, follow these instructions to identify API breaking changes in the KSCrash crash reporting library.
 
+## What "Breaking" Means in This Repo
+
+A change is breaking **only if it breaks code that compiled against the most recent tagged release**, not against unreleased work on master. This is the only baseline that matters when reviewing.
+
+- Compare the affected public header at the most recent tag (`git describe --tags --abbrev=0`, then `git show <tag>:Sources/.../Header.h`) against the PR's version.
+- If the API in the PR is identical to or strictly additive over the API at the release tag, the change is **not breaking** for the purposes of this review, no matter what unreleased work on master has done in between.
+- A symbol, type, property, or signature that did not exist at the release tag is not part of the released surface. Changing or removing it on master cannot be breaking.
+- Do not flag a change as breaking without performing this comparison. If a reviewer comment, prior memory, or pattern-match suggests a change is breaking but the verification disagrees, the change is not breaking.
+
+The patterns below describe the changes that warrant scrutiny **when they would break code compiled against the most recent release**.
+
 ## Scope of Review
 
 Only review changes to public API surfaces. The public modules are: KSCrashRecording, KSCrashFilters, KSCrashSinks, KSCrashInstallations, KSCrashDiscSpaceMonitor, KSCrashBootTimeMonitor, and KSCrashDemangleFilter. Only examine files in `Sources/[ModuleName]/include/*.h` directories as these contain the public headers.
@@ -228,6 +239,8 @@ Adding optional methods to protocols is safe:
 
 ## Review Process
 
-For each PR, examine modified public headers and flag any of the breaking change patterns above. Ask yourself: Would existing user code fail to compile after this change? If yes, it's breaking. The KSCrash library prioritizes API stability, so breaking changes need strong justification and migration guidance.
+For each PR, examine modified public headers and flag any of the breaking change patterns above. The question to ask is: **would code that compiled against the most recent release fail to compile after this change?** Verify against the release tag (`git show <tag>:<header>`); do not rely on the master state alone or on a pattern match. If the API at the release tag did not contain the symbol or shape in question, the change cannot be breaking.
+
+The KSCrash library prioritizes API stability, so breaking changes (measured this way) need strong justification and migration guidance.
 
 Pay special attention to callback API changes as this library has a history of major callback signature evolution for async-safety and policy awareness.


### PR DESCRIPTION
A reminder kept popping up across the dev-tooling files: claims of "this is source-breaking" need to be measured against the most recent tagged release, not against unreleased master. A symbol or shape that didn't exist at the release tag is not part of the released surface and can't be source-breaking, no matter how it has evolved on master.

Adds that rule explicitly to .claude/CLAUDE.md, .claude/rules/api-stability.md, and .github/copilot-instructions.md so it controls the framing for both human reviewers and automated tools, and so it can be cited when verifying or pushing back on any source-breaking comment.