### PR TITLE
README: note that master tracks stable, develop is active work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 
+> **Heads up (May 2026):** `master` now tracks the latest stable release only (currently `2.5.1`).
+> Next-release work lives on [`develop`](https://github.com/kstenerud/KSCrash/tree/develop),
+> and the in-flight 2.6 line is on [`release/2.6.0`](https://github.com/kstenerud/KSCrash/tree/release/2.6.0)
+> (latest beta: [`2.6.0-beta.2`](https://github.com/kstenerud/KSCrash/releases/tag/2.6.0-beta.2)).
+> New PRs should target `develop`.
+
 ![Untitled](https://github.com/user-attachments/assets/9478bde6-78ae-4d59-b8ab-dc6db4137b9f)
 
 [![Run Unit Tests](https://github.com/kstenerud/KSCrash/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/kstenerud/KSCrash/actions/workflows/unit-tests.yml)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 
-> **Heads up (May 2026):** `master` now tracks the latest stable release only (currently `2.5.1`).
-> Next-release work lives on [`develop`](https://github.com/kstenerud/KSCrash/tree/develop),
-> and the in-flight 2.6 line is on [`release/2.6.0`](https://github.com/kstenerud/KSCrash/tree/release/2.6.0)
-> (latest beta: [`2.6.0-beta.2`](https://github.com/kstenerud/KSCrash/releases/tag/2.6.0-beta.2)).
-> New PRs should target `develop`.
+> [!NOTE]
+> **Branch layout (May 2026)**
+>
+> - [`master`](https://github.com/kstenerud/KSCrash): latest stable release, currently `2.5.1`
+> - [`develop`](https://github.com/kstenerud/KSCrash/tree/develop): next-release work, **target this for new PRs**
+> - [`release/2.6.0`](https://github.com/kstenerud/KSCrash/tree/release/2.6.0): in-flight 2.6 line, latest beta is [`2.6.0-beta.2`](https://github.com/kstenerud/KSCrash/releases/tag/2.6.0-beta.2)
 
 ![Untitled](https://github.com/user-attachments/assets/9478bde6-78ae-4d59-b8ab-dc6db4137b9f)
 


### PR DESCRIPTION
Adds a short note at the very top of the README so anyone landing on the repo immediately sees that `master` now tracks the latest stable release only (2.5.1 today), that next-release work is on `develop`, and that the in-flight 2.6 beta line is on `release/2.6.0`. Pointer to `2.6.0-beta.2` so people know the latest published artifact. Closes a confusion loop where the master branch looks "stale" compared to release/2.6.0.