### PR TITLE
ci: skip Public API Diff for PRs targeting develop

### DIFF
--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -2,6 +2,11 @@ name: Public API Diff
 
 on:
   pull_request:
+    # develop is the integration line for the next major (3.0). Breaking
+    # changes are expected there, so the digester gate would be noise.
+    # When 3.0 ships, re-enable by deleting this exclusion.
+    branches-ignore:
+      - develop
     paths:
       - "Sources/**"
       - "Package.swift"


### PR DESCRIPTION
While `develop` is the 3.0 integration line, every source-breaking change shows up as an api-check failure against the latest stable (`2.5.1`), which isn't useful since we want those changes there. Skips the Public API Diff workflow for PRs whose base is `develop`. The check still runs for PRs targeting `master`, `release/*`, and any other branch, and for direct pushes to `master`. When 3.0 ships and `develop` rebases into stable, delete the `branches-ignore` block.