### PR TITLE
ci: only run Public API Diff against stable bases (master + release/*)

### DIFF
--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -2,11 +2,14 @@ name: Public API Diff
 
 on:
   pull_request:
-    # develop is the integration line for the next major (3.0). Breaking
-    # changes are expected there, so the digester gate would be noise.
-    # When 3.0 ships, re-enable by deleting this exclusion.
-    branches-ignore:
-      - develop
+    # Only gate PRs that will land on a stable base (master + release/*).
+    # develop is the 3.0 integration line where breaking changes are expected,
+    # and PRs stacked on develop (e.g. ac/run-summary -> ac/remove-installations-base)
+    # would slip past a develop-only exclusion. Listing stable bases explicitly
+    # covers both. When 3.0 ships and develop merges into master, add develop here.
+    branches:
+      - master
+      - "release/**"
     paths:
       - "Sources/**"
       - "Package.swift"


### PR DESCRIPTION
Follow-up to #843. The `branches-ignore: develop` rule only excluded PRs whose base was `develop` exactly, so PRs stacked on develop (like #827, which targets `ac/remove-installations-base`) still ran the digester and failed against `2.5.1`. Switches to an allowlist of stable bases (`master`, `release/**`), which is the actual intent: only gate PRs that will land on a line where source-breaking is forbidden. When 3.0 ships, add `develop` (or whatever its successor is) back to the list.