### PR TITLE
Fix C++ monitor handling of ObjC exception subclasses

### DIFF
--- a/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
+++ b/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
@@ -43,6 +43,12 @@ class Report
 };
 }  // namespace sample_namespace
 
+@interface KSCrashTriggersList_TestNSExceptionSubclass : NSException
+@end
+
+@implementation KSCrashTriggersList_TestNSExceptionSubclass
+@end
+
 static void trigger_ns(void)
 {
     NSException *exc = [NSException exceptionWithName:NSGenericException reason:@"Something broke" userInfo:nil];
@@ -108,6 +114,13 @@ NSString *const KSCrashNSExceptionStacktraceFuncName = @"exceptionWithStacktrace
     [exc raise];
 }
 
++ (void)trigger_nsException_nsExceptionSubclass
+{
+    [[KSCrashTriggersList_TestNSExceptionSubclass exceptionWithName:@"TestNSExceptionSubclass"
+                                                             reason:@"Subclass Test"
+                                                           userInfo:nil] raise];
+}
+
 + (void)trigger_nsException_nsArrayOutOfBounds
 {
     NSArray *array = @[ @1, @2, @3 ];
@@ -130,6 +143,11 @@ NSString *const KSCrashNSExceptionStacktraceFuncName = @"exceptionWithStacktrace
 + (void)trigger_cpp_runtimeExceptionBackgroundThread
 {
     trigger_cpp_backgroundThread();
+}
+
++ (void)trigger_cpp_objcObjectException
+{
+    @throw @"Objective-C object exception";
 }
 
 + (void)trigger_mach_badAccess

--- a/Samples/Common/Sources/CrashTriggers/include/KSCrashTriggersList.h
+++ b/Samples/Common/Sources/CrashTriggers/include/KSCrashTriggersList.h
@@ -43,10 +43,12 @@ extern NSString *const KSCrashNSExceptionStacktraceFuncName;
 
 #define __ALL_TRIGGERS                                                                                 \
     __PROCESS_TRIGGER(nsException, genericNSException, @"Generic NSException")                         \
+    __PROCESS_TRIGGER(nsException, nsExceptionSubclass, @"NSException Subclass")                       \
     __PROCESS_TRIGGER(nsException, nsArrayOutOfBounds, @"NSArray out-of-bounds")                       \
     __PROCESS_TRIGGER(nsException, user, @"User reported NSException")                                 \
     __PROCESS_TRIGGER(cpp, runtimeException, @"Runtime Exception")                                     \
     __PROCESS_TRIGGER(cpp, runtimeExceptionBackgroundThread, @"Runtime Exception (Background Thread)") \
+    __PROCESS_TRIGGER(cpp, objcObjectException, @"Objective-C Object Exception")                       \
     __PROCESS_TRIGGER(mach, badAccess, @"EXC_BAD_ACCESS (SIGSEGV)")                                    \
     __PROCESS_TRIGGER(mach, badAccessDeadbeef, @"EXC_BAD_ACCESS (0xDEADBEEF)")                         \
     __PROCESS_TRIGGER(mach, busError, @"EXC_BAD_ACCESS (SIGBUS)")                                      \

--- a/Samples/Tests/IntegrationTests.swift
+++ b/Samples/Tests/IntegrationTests.swift
@@ -57,6 +57,22 @@ final class NSExceptionTests: IntegrationTestBase {
         XCTAssertEqual(state.terminationReason, .crash)
     }
 
+    func testNSExceptionSubclass() throws {
+        try launchAndCrash(.nsException_nsExceptionSubclass)
+
+        let rawReport = try readCrashReport()
+        try rawReport.validate()
+        XCTAssertEqual(rawReport.crash.error.type, .nsexception)
+        XCTAssertEqual(rawReport.crash.error.reason, "Subclass Test")
+        XCTAssertEqual(rawReport.crash.error.nsexception?.name, "TestNSExceptionSubclass")
+        XCTAssertNil(rawReport.crash.error.cppException)
+        XCTAssertNotNil(rawReport.crash.lastExceptionBacktrace)
+
+        let appleReport = try launchAndReportCrash()
+        XCTAssertTrue(appleReport.contains("TestNSExceptionSubclass"))
+        XCTAssertTrue(appleReport.contains("Subclass Test"))
+    }
+
     func testDontRecordAllThreads() throws {
         try launchAndCrash(
             .nsException_genericNSException,
@@ -158,6 +174,19 @@ final class CppTests: IntegrationTestBase {
         let state = try readState()
         XCTAssertTrue(state.crashedLastLaunch)
         XCTAssertEqual(state.terminationReason, .crash)
+    }
+
+    func testObjectiveCObjectExceptionFallsBackToCPPMonitor() throws {
+        // NSSetUncaughtExceptionHandler is only called for NSException objects, so arbitrary Objective-C object throws
+        // should still be reported by the C++ monitor instead of being skipped as NSExceptions.
+        try launchAndCrash(.cpp_objcObjectException)
+
+        let rawReport = try readCrashReport()
+        try rawReport.validate()
+        XCTAssertEqual(rawReport.crash.error.type, .cppException)
+        XCTAssertNotNil(rawReport.crash.error.cppException?.name)
+        XCTAssertNil(rawReport.crash.error.nsexception)
+        XCTAssertNotNil(rawReport.crash.lastExceptionBacktrace)
     }
 
     func testRuntimeExceptionBackgroundThread() throws {

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException+Private.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException+Private.h
@@ -27,11 +27,13 @@
 
 #ifdef __cplusplus
 
+#include <string.h>
 #include <typeinfo>
 
 #include "KSSystemCapabilities.h"
 
 #if KSCRASH_HAS_OBJC
+#include <objc/runtime.h>
 #if defined(__has_include)
 #if __has_include(<ptrauth.h>)
 #include <ptrauth.h>
@@ -63,8 +65,8 @@ static inline const void *kscm_cppexception_stripCxxVTablePointer(const void *po
 }
 #endif  // KSCRASH_HAS_OBJC
 
-// Check if a C++ exception type_info represents an Objective-C exception.
-static inline bool kscm_cppexception_isObjCException(const std::type_info *tinfo)
+// Check if a C++ exception type_info represents an Objective-C exception object.
+static inline bool kscm_cppexception_isObjCExceptionType(const std::type_info *tinfo)
 {
 #if KSCRASH_HAS_OBJC
     if (tinfo == nullptr) {
@@ -78,6 +80,47 @@ static inline bool kscm_cppexception_isObjCException(const std::type_info *tinfo
     // On arm64e, vtable pointers are signed with pointer authentication codes (PAC). Strip the signatures before
     // comparing so the raw objc_ehtype_vtable address can match the signed pointer stored in tinfo.
     return kscm_cppexception_stripCxxVTablePointer(tinfoVTable) == kscm_cppexception_stripCxxVTablePointer(objcVTable);
+#else
+    (void)tinfo;
+    return false;
+#endif
+}
+
+// objc_typeinfo mirrors the ObjC runtime's custom type_info subclass. The first two fields are std::type_info's
+// vtable and name pointer; the ObjC runtime adds the thrown object's Class after those fields.
+struct kscm_cppexception_objc_typeinfo {
+    const void *vtable;
+    const char *name;
+    Class cls;
+};
+
+static inline Class kscm_cppexception_objcClassFromTypeInfo(const std::type_info *tinfo)
+{
+#if KSCRASH_HAS_OBJC
+    if (!kscm_cppexception_isObjCExceptionType(tinfo)) {
+        return Nil;
+    }
+    return reinterpret_cast<const kscm_cppexception_objc_typeinfo *>(tinfo)->cls;
+#else
+    (void)tinfo;
+    return Nil;
+#endif
+}
+
+// Check if a C++ exception type_info represents an NSException or subclass. The NSException monitor only handles
+// NSException objects; arbitrary Objective-C object throws (for example @throw @"...") should remain with the C++
+// monitor instead of being skipped here.
+static inline bool kscm_cppexception_isNSException(const std::type_info *tinfo)
+{
+#if KSCRASH_HAS_OBJC
+    for (Class currentClass = kscm_cppexception_objcClassFromTypeInfo(tinfo); currentClass != Nil;
+         currentClass = class_getSuperclass(currentClass)) {
+        const char *className = class_getName(currentClass);
+        if (className != nullptr && strcmp(className, "NSException") == 0) {
+            return true;
+        }
+    }
+    return false;
 #else
     (void)tinfo;
     return false;

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException+Private.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException+Private.h
@@ -1,6 +1,8 @@
 //
 //  KSCrashMonitor_CPPException+Private.h
 //
+//  Created by Mischan Toosarani-Hausberger on 2024-05-26.
+//
 //  Copyright (c) 2012 Karl Stenerud. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -79,7 +81,7 @@ static inline bool kscm_cppexception_isObjCExceptionType(const std::type_info *t
     const void *objcVTable = reinterpret_cast<const void *>(objc_ehtype_vtable + 2);
 
     // On arm64e, vtable pointers are signed with pointer authentication codes (PAC). Strip the signatures before
-    // comparing so the raw objc_ehtype_vtable address can match the signed pointer stored in tinfo.
+    // comparing so that the raw objc_ehtype_vtable address matches the signed pointer stored in tinfo.
     return kscm_cppexception_stripCxxVTablePointer(tinfoVTable) == kscm_cppexception_stripCxxVTablePointer(objcVTable);
 #else
     (void)tinfo;

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException+Private.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException+Private.h
@@ -28,6 +28,7 @@
 #ifdef __cplusplus
 
 #include <string.h>
+
 #include <typeinfo>
 
 #include "KSSystemCapabilities.h"

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException+Private.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException+Private.h
@@ -1,0 +1,89 @@
+//
+//  KSCrashMonitor_CPPException+Private.h
+//
+//  Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef HDR_KSCrashMonitor_CPPException_Private_h
+#define HDR_KSCrashMonitor_CPPException_Private_h
+
+#ifdef __cplusplus
+
+#include <typeinfo>
+
+#include "KSSystemCapabilities.h"
+
+#if KSCRASH_HAS_OBJC
+#if defined(__has_include)
+#if __has_include(<ptrauth.h>)
+#include <ptrauth.h>
+#define KSCRASH_CPP_EXCEPTION_HAS_PTRAUTH 1
+#endif
+#endif
+#ifndef KSCRASH_CPP_EXCEPTION_HAS_PTRAUTH
+#define KSCRASH_CPP_EXCEPTION_HAS_PTRAUTH 0
+#endif
+
+// The ObjC runtime uses a custom C++ type_info subclass (objc_typeinfo) for all Objective-C exceptions. Its vtable
+// pointer is set to objc_ehtype_vtable + 2 (the +2 skips the Itanium C++ ABI vtable prefix: offset-to-top and RTTI
+// pointer).
+//
+// objc_typeinfo struct definition:
+// https://github.com/apple-oss-distributions/objc4/blob/fb265098/runtime/objc-exception.mm#L313-L320
+//
+// objc_ehtype_vtable is exported from libobjc on Apple platforms and declared in Apple's internal objc-abi.h:
+// https://github.com/apple-oss-distributions/objc4/blob/fb265098/runtime/objc-abi.h#L377-L380
+extern "C" const void *const objc_ehtype_vtable[];
+
+static inline const void *kscm_cppexception_stripCxxVTablePointer(const void *pointer)
+{
+#if KSCRASH_CPP_EXCEPTION_HAS_PTRAUTH
+    return ptrauth_strip(pointer, ptrauth_key_cxx_vtable_pointer);
+#else
+    return pointer;
+#endif
+}
+#endif  // KSCRASH_HAS_OBJC
+
+// Check if a C++ exception type_info represents an Objective-C exception.
+static inline bool kscm_cppexception_isObjCException(const std::type_info *tinfo)
+{
+#if KSCRASH_HAS_OBJC
+    if (tinfo == nullptr) {
+        return false;
+    }
+
+    // The first pointer-sized field in any type_info object is the vtable pointer.
+    const void *tinfoVTable = *reinterpret_cast<const void *const *>(tinfo);
+    const void *objcVTable = reinterpret_cast<const void *>(objc_ehtype_vtable + 2);
+
+    // On arm64e, vtable pointers are signed with pointer authentication codes (PAC). Strip the signatures before
+    // comparing so the raw objc_ehtype_vtable address can match the signed pointer stored in tinfo.
+    return kscm_cppexception_stripCxxVTablePointer(tinfoVTable) == kscm_cppexception_stripCxxVTablePointer(objcVTable);
+#else
+    (void)tinfo;
+    return false;
+#endif
+}
+
+#endif  // __cplusplus
+
+#endif  // HDR_KSCrashMonitor_CPPException_Private_h

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
@@ -96,7 +96,7 @@ static bool isEnabled(__unused void *context) { return g_state.isEnabled && g_st
 static KS_NOINLINE void captureStackTrace(void *, std::type_info *tinfo,
                                           void (*)(void *)) KS_KEEP_FUNCTION_IN_STACKTRACE
 {
-    if (kscm_cppexception_isObjCException(tinfo)) {
+    if (kscm_cppexception_isObjCExceptionType(tinfo)) {
         return;
     }
     if (g_captureNextStackTrace) {
@@ -145,13 +145,15 @@ static void CPPExceptionTerminate(void)
     std::type_info *tinfo = __cxxabiv1::__cxa_current_exception_type();
     // nullptr when std::terminate() is invoked without an active exception
     // (explicit call, noexcept violation after exception is consumed, etc.).
-    const char *name = tinfo != nullptr ? cpp_demangleSymbol(tinfo->name()) : NULL;
-    if (kscm_cppexception_isObjCException(tinfo)) {
-        KSLOG_DEBUG("Detected Objective-C exception. Letting the current NSException handler deal with it.");
+    if (kscm_cppexception_isNSException(tinfo)) {
+        // Let NSException and subclasses flow to objc_terminate()/NSSetUncaughtExceptionHandler. Arbitrary Objective-C
+        // object throws are not handled by NSSetUncaughtExceptionHandler, so the C++ monitor still reports those.
+        KSLOG_DEBUG("Detected NSException. Letting the current NSException handler deal with it.");
         goto skip_handling;
     }
 
     if (isEnabled(NULL)) {
+        const char *name = tinfo != nullptr ? cpp_demangleSymbol(tinfo->name()) : NULL;
         thread_t thisThread = (thread_t)ksthread_self();
         // This requires async-safety because the environment is suspended.
         KSCrash_MonitorContext *crashContext = g_state.callbacks.notify(

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
@@ -27,6 +27,7 @@
 #include "KSCompilerDefines.h"
 #include "KSCrashMonitorContext.h"
 #include "KSCrashMonitorHelper.h"
+#include "KSCrashMonitor_CPPException+Private.h"
 #include "KSID.h"
 #include "KSMachineContext.h"
 #include "KSStackCursor_SelfThread.h"
@@ -95,7 +96,7 @@ static bool isEnabled(__unused void *context) { return g_state.isEnabled && g_st
 static KS_NOINLINE void captureStackTrace(void *, std::type_info *tinfo,
                                           void (*)(void *)) KS_KEEP_FUNCTION_IN_STACKTRACE
 {
-    if (tinfo != nullptr && strcmp(tinfo->name(), "NSException") == 0) {
+    if (kscm_cppexception_isObjCException(tinfo)) {
         return;
     }
     if (g_captureNextStackTrace) {
@@ -145,8 +146,8 @@ static void CPPExceptionTerminate(void)
     // nullptr when std::terminate() is invoked without an active exception
     // (explicit call, noexcept violation after exception is consumed, etc.).
     const char *name = tinfo != nullptr ? cpp_demangleSymbol(tinfo->name()) : NULL;
-    if (name != NULL && strcmp(name, "NSException") == 0) {
-        KSLOG_DEBUG("Detected NSException. Letting the current NSException handler deal with it.");
+    if (kscm_cppexception_isObjCException(tinfo)) {
+        KSLOG_DEBUG("Detected Objective-C exception. Letting the current NSException handler deal with it.");
         goto skip_handling;
     }
 

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_CPPException_ObjCException_Tests.mm
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_CPPException_ObjCException_Tests.mm
@@ -83,7 +83,8 @@ static bool legacyNameCheckMatchesNSException(const std::type_info *tinfo)
         std::type_info *tinfo = currentExceptionType();
         XCTAssertFalse(legacyNameCheckMatchesNSException(tinfo));
         XCTAssertTrue(kscm_cppexception_isObjCExceptionType(tinfo));
-        XCTAssertEqual(kscm_cppexception_objcClassFromTypeInfo(tinfo), KSCrashMonitor_CPPException_TestNSExceptionSubclass.class);
+        XCTAssertEqual(kscm_cppexception_objcClassFromTypeInfo(tinfo),
+                       KSCrashMonitor_CPPException_TestNSExceptionSubclass.class);
         XCTAssertTrue(kscm_cppexception_isNSException(tinfo));
     }
 }
@@ -96,7 +97,8 @@ static bool legacyNameCheckMatchesNSException(const std::type_info *tinfo)
         std::type_info *tinfo = currentExceptionType();
         XCTAssertFalse(legacyNameCheckMatchesNSException(tinfo));
         XCTAssertTrue(kscm_cppexception_isObjCExceptionType(tinfo));
-        XCTAssertEqual(kscm_cppexception_objcClassFromTypeInfo(tinfo), object_getClass(@"Objective-C object exception"));
+        XCTAssertEqual(kscm_cppexception_objcClassFromTypeInfo(tinfo),
+                       object_getClass(@"Objective-C object exception"));
         XCTAssertFalse(kscm_cppexception_isNSException(tinfo));
     }
 }

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_CPPException_ObjCException_Tests.mm
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_CPPException_ObjCException_Tests.mm
@@ -60,18 +60,20 @@ static bool legacyNameCheckMatchesNSException(const std::type_info *tinfo)
     return tinfo != nullptr && strcmp(tinfo->name(), "NSException") == 0;
 }
 
-- (void)testObjectiveCExceptionDetection_NSException_MatchesLegacyAndVTableCheck
+- (void)testObjectiveCExceptionDetection_NSException_MatchesLegacyAndNSExceptionCheck
 {
     @try {
         [NSException raise:NSInvalidArgumentException format:@"Invalid argument"];
     } @catch (...) {
         std::type_info *tinfo = currentExceptionType();
         XCTAssertTrue(legacyNameCheckMatchesNSException(tinfo));
-        XCTAssertTrue(kscm_cppexception_isObjCException(tinfo));
+        XCTAssertTrue(kscm_cppexception_isObjCExceptionType(tinfo));
+        XCTAssertEqual(kscm_cppexception_objcClassFromTypeInfo(tinfo), NSException.class);
+        XCTAssertTrue(kscm_cppexception_isNSException(tinfo));
     }
 }
 
-- (void)testObjectiveCExceptionDetection_NSExceptionSubclass_OnlyMatchesVTableCheck
+- (void)testObjectiveCExceptionDetection_NSExceptionSubclass_OnlyMatchesNSExceptionCheck
 {
     @try {
         [[KSCrashMonitor_CPPException_TestNSExceptionSubclass exceptionWithName:@"TestException"
@@ -80,18 +82,22 @@ static bool legacyNameCheckMatchesNSException(const std::type_info *tinfo)
     } @catch (...) {
         std::type_info *tinfo = currentExceptionType();
         XCTAssertFalse(legacyNameCheckMatchesNSException(tinfo));
-        XCTAssertTrue(kscm_cppexception_isObjCException(tinfo));
+        XCTAssertTrue(kscm_cppexception_isObjCExceptionType(tinfo));
+        XCTAssertEqual(kscm_cppexception_objcClassFromTypeInfo(tinfo), KSCrashMonitor_CPPException_TestNSExceptionSubclass.class);
+        XCTAssertTrue(kscm_cppexception_isNSException(tinfo));
     }
 }
 
-- (void)testObjectiveCExceptionDetection_ArbitraryObjectiveCObject_OnlyMatchesVTableCheck
+- (void)testObjectiveCExceptionDetection_ArbitraryObjectiveCObject_DoesNotMatchNSExceptionCheck
 {
     @try {
         @throw @"Objective-C object exception";
     } @catch (...) {
         std::type_info *tinfo = currentExceptionType();
         XCTAssertFalse(legacyNameCheckMatchesNSException(tinfo));
-        XCTAssertTrue(kscm_cppexception_isObjCException(tinfo));
+        XCTAssertTrue(kscm_cppexception_isObjCExceptionType(tinfo));
+        XCTAssertEqual(kscm_cppexception_objcClassFromTypeInfo(tinfo), object_getClass(@"Objective-C object exception"));
+        XCTAssertFalse(kscm_cppexception_isNSException(tinfo));
     }
 }
 
@@ -102,7 +108,9 @@ static bool legacyNameCheckMatchesNSException(const std::type_info *tinfo)
     } catch (...) {
         std::type_info *tinfo = currentExceptionType();
         XCTAssertFalse(legacyNameCheckMatchesNSException(tinfo));
-        XCTAssertFalse(kscm_cppexception_isObjCException(tinfo));
+        XCTAssertFalse(kscm_cppexception_isObjCExceptionType(tinfo));
+        XCTAssertEqual(kscm_cppexception_objcClassFromTypeInfo(tinfo), Nil);
+        XCTAssertFalse(kscm_cppexception_isNSException(tinfo));
     }
 }
 

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_CPPException_ObjCException_Tests.mm
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_CPPException_ObjCException_Tests.mm
@@ -1,6 +1,8 @@
 //
 //  KSCrashMonitor_CPPException_ObjCException_Tests.mm
 //
+//  Created by Mischan Toosarani-Hausberger on 2024-05-26.
+//
 //  Copyright (c) 2012 Karl Stenerud. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_CPPException_ObjCException_Tests.mm
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_CPPException_ObjCException_Tests.mm
@@ -1,0 +1,109 @@
+//
+//  KSCrashMonitor_CPPException_ObjCException_Tests.mm
+//
+//  Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// clang-format off
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-macro-identifier"
+#import <XCTest/XCTest.h>
+#pragma clang diagnostic pop
+// clang-format on
+
+#import "KSCrashMonitor_CPPException+Private.h"
+
+#include <cxxabi.h>
+#include <string.h>
+#include <stdexcept>
+#include <typeinfo>
+
+@interface KSCrashMonitor_CPPException_TestNSExceptionSubclass : NSException
+@end
+
+@implementation KSCrashMonitor_CPPException_TestNSExceptionSubclass
+@end
+
+@interface KSCrashMonitor_CPPException_ObjCException_Tests : XCTestCase
+@end
+
+@implementation KSCrashMonitor_CPPException_ObjCException_Tests
+
+// These tests inspect the active exception's ABI type_info. This is the same discriminator the C++ monitor receives
+// from __cxa_throw and __cxa_current_exception_type; the tests avoid invoking terminate() or mutating global monitor
+// state.
+static std::type_info *currentExceptionType(void) { return __cxxabiv1::__cxa_current_exception_type(); }
+
+// Historically, the C++ exception monitor compared type_info->name() to "NSException". That only covers plain
+// NSException because Objective-C exceptions expose the thrown object's dynamic class name there (for example an
+// NSException subclass or NSString).
+static bool legacyNameCheckMatchesNSException(const std::type_info *tinfo)
+{
+    return tinfo != nullptr && strcmp(tinfo->name(), "NSException") == 0;
+}
+
+- (void)testObjectiveCExceptionDetection_NSException_MatchesLegacyAndVTableCheck
+{
+    @try {
+        [NSException raise:NSInvalidArgumentException format:@"Invalid argument"];
+    } @catch (...) {
+        std::type_info *tinfo = currentExceptionType();
+        XCTAssertTrue(legacyNameCheckMatchesNSException(tinfo));
+        XCTAssertTrue(kscm_cppexception_isObjCException(tinfo));
+    }
+}
+
+- (void)testObjectiveCExceptionDetection_NSExceptionSubclass_OnlyMatchesVTableCheck
+{
+    @try {
+        [[KSCrashMonitor_CPPException_TestNSExceptionSubclass exceptionWithName:@"TestException"
+                                                                         reason:@"Test"
+                                                                       userInfo:nil] raise];
+    } @catch (...) {
+        std::type_info *tinfo = currentExceptionType();
+        XCTAssertFalse(legacyNameCheckMatchesNSException(tinfo));
+        XCTAssertTrue(kscm_cppexception_isObjCException(tinfo));
+    }
+}
+
+- (void)testObjectiveCExceptionDetection_ArbitraryObjectiveCObject_OnlyMatchesVTableCheck
+{
+    @try {
+        @throw @"Objective-C object exception";
+    } @catch (...) {
+        std::type_info *tinfo = currentExceptionType();
+        XCTAssertFalse(legacyNameCheckMatchesNSException(tinfo));
+        XCTAssertTrue(kscm_cppexception_isObjCException(tinfo));
+    }
+}
+
+- (void)testObjectiveCExceptionDetection_CPPException_MatchesNeitherCheck
+{
+    try {
+        throw std::runtime_error("C++ exception");
+    } catch (...) {
+        std::type_info *tinfo = currentExceptionType();
+        XCTAssertFalse(legacyNameCheckMatchesNSException(tinfo));
+        XCTAssertFalse(kscm_cppexception_isObjCException(tinfo));
+    }
+}
+
+@end


### PR DESCRIPTION
The C++ exception monitor skipped Objective-C exceptions by checking whether `type_info->name()` equals `"NSException"`.

That works only for plain `NSException`, but not for `NSException` subclasses or arbitrary Objective-C objects thrown with `@throw`. Those exceptions still use Objective-C exception machinery, but their `type_info->name()` is the dynamic Objective-C class name.

This PR changes the check to identify arbitrary Objective-C exceptions by comparing the exception `type_info` vtable against the Objective-C runtime exception `type_info` vtable. On `arm64e`, the comparison strips pointer authentication bits before comparing.

### Testing

Added focused Objective-C++ coverage that compares the old name-based check with the new helper for a couple of representative cases. It only tests the check, not the entire monitor, to keep things simple.

The new test file is Objective-C++ (`.mm`) because the test needs to inspect the C++ ABI `type_info` for the active exception via `__cxa_current_exception_type()`, and also uses `std::type_info` and C++ exception syntax for the negative control, which we can't access from plain Objective-C.