### PR TITLE
Fix run-sidecar cleanup deleting live sidecars past 512 reports

### DIFF
--- a/Sources/KSCrashRecording/KSCrashReportStoreC.m
+++ b/Sources/KSCrashRecording/KSCrashReportStoreC.m
@@ -350,14 +350,13 @@ static NSDictionary *stitchRunSidecarsIntoReport(NSDictionary *report,
 
 // UUID: 8-4-4-4-12 hex digits with hyphens = 36 chars
 #define KSCRS_UUID_STRING_LENGTH 36
-#define KSCRS_MAX_REPORT_COUNT 512
 
 /** Remove run sidecar directories that have no matching reports.
  *
  * Scans the RunSidecars directory and collects the set of active run_ids
  * from existing reports by JSON-decoding report["report"]["run_id"].
  * Any run sidecar directory whose name isn't in the active set is deleted.
- * Runs once at initialization.
+ * Runs after report sending and via the explicit cleanup entry point.
  */
 static void cleanupOrphanedRunSidecars(const KSCrashReportStoreCConfiguration *const config)
 {
@@ -367,13 +366,28 @@ static void cleanupOrphanedRunSidecars(const KSCrashReportStoreCConfiguration *c
 
     const char *currentRunID = kscrash_getRunID();
 
-    int64_t reportIDs[KSCRS_MAX_REPORT_COUNT];
-    int reportCount = getReportIDs(reportIDs, KSCRS_MAX_REPORT_COUNT, config);
+    // Declared up front so the single `done:` cleanup path frees them regardless
+    // of which early exit is taken.
+    int64_t *reportIDs = NULL;
+    char (*activeRunIds)[KSCRS_UUID_STRING_LENGTH + 1] = NULL;
+
+    // Enumerate every report, not a fixed cap. A run sidecar is an orphan only
+    // when no surviving report references it, so under-counting reports here
+    // would delete sidecars still in use (e.g. when maxReportCount exceeds the
+    // buffer size). Sizing to the actual count mirrors pruneReports.
+    int reportCount = getReportCount(config);
+    if (reportCount > 0) {
+        reportIDs = calloc((size_t)reportCount, sizeof(*reportIDs));
+        if (reportIDs == NULL) {
+            goto done;
+        }
+        reportCount = getReportIDs(reportIDs, reportCount, config);
+    }
 
     int capacity = reportCount + 1;  // +1 for current run
-    char (*activeRunIds)[KSCRS_UUID_STRING_LENGTH + 1] = calloc((size_t)capacity, sizeof(*activeRunIds));
+    activeRunIds = calloc((size_t)capacity, sizeof(*activeRunIds));
     if (activeRunIds == NULL) {
-        return;
+        goto done;
     }
     int activeCount = 0;
 
@@ -417,7 +431,9 @@ static void cleanupOrphanedRunSidecars(const KSCrashReportStoreCConfiguration *c
         closedir(dir);
     }
 
+done:
     free(activeRunIds);
+    free(reportIDs);
 }
 
 static void deleteReportWithID(int64_t reportID, const KSCrashReportStoreCConfiguration *const config)

--- a/Tests/KSCrashRecordingTests/KSCrashReportStoreC_RunSidecar_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashReportStoreC_RunSidecar_Tests.m
@@ -238,6 +238,31 @@ static CFDictionaryRef testStitchReport(CFDictionaryRef reportDict, const char *
     XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:orphanDir]);
 }
 
+// Regression: cleanup used to enumerate reports into a fixed 512-slot buffer, so
+// with more reports than that the unenumerated tail had its still-referenced run
+// sidecars deleted as orphans. Every sidecar with a matching report must survive.
+- (void)testCleanupKeepsRunSidecarsBeyondFixedReportCap
+{
+    [self prepareStoreWithRunSidecars:@"testCleanupBeyondCap"];
+
+    const int reportCount = 600;  // comfortably over the old 512 cap
+    NSMutableArray<NSString *> *runDirs = [NSMutableArray arrayWithCapacity:reportCount];
+    for (int i = 0; i < reportCount; i++) {
+        NSString *runId = [[NSUUID UUID] UUIDString];
+        [self writeReportWithRunId:runId];
+        [self writeRunSidecar:@"System" runId:runId contents:@"system data"];
+        [runDirs addObject:[[NSString stringWithUTF8String:_storeConfig.runSidecarsPath]
+                               stringByAppendingPathComponent:runId]];
+    }
+
+    kscrs_cleanupOrphanedRunSidecars(&_storeConfig);
+
+    NSFileManager *fm = [NSFileManager defaultManager];
+    for (NSString *runDir in runDirs) {
+        XCTAssertTrue([fm fileExistsAtPath:runDir], @"Run sidecar wrongly deleted: %@", runDir);
+    }
+}
+
 - (void)testDeleteReportWithNoRunSidecarsPathDoesNotCrash
 {
     [self prepareStoreWithRunSidecars:@"testDeleteNoRunSidecars"];


### PR DESCRIPTION
Run sidecars are cleaned up after sending reports by collecting the run_ids still referenced by reports on disk and deleting any sidecar directory not in that set. The enumeration read report IDs into a fixed 512-entry stack buffer, so once more than 512 reports were present the reports past the cap were never scanned, their run_ids were missing from the active set, and their still-referenced sidecars were deleted as orphans. The default maxReportCount is 5, so this only surfaced when an app raised the limit above 512, but when it did the result was silent loss of sidecar data needed to stitch later reports.

This sizes the buffer to the actual report count, the way pruneReports already does, with a single goto-done cleanup so a future resource added to the function can not be missed on an early exit. Adds a regression test that writes 600 reports with matching sidecars and confirms cleanup keeps all of them.

Brings #848, merged into `release/2.6.0`, over to `develop`.