### PR TITLE
fix: Honor SIG_IGN when installing signal monitor

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,7 +4,10 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - 'Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.c'
       - 'Samples/Tests/**'
+      - 'Samples/Common/Sources/CrashCallback/**'
+      - 'Samples/Common/Sources/CrashTriggers/**'
       - 'Samples/Common/Sources/IntegrationTestsHelper/**'
       - '.github/workflows/integration-tests.yml'
   push:

--- a/Samples/Common/Sources/CrashCallback/CrashCallback.m
+++ b/Samples/Common/Sources/CrashCallback/CrashCallback.m
@@ -6,6 +6,8 @@
 //
 
 #import "CrashCallback.h"
+#import <errno.h>
+#import <signal.h>
 #import <stdio.h>
 #import "KSCrashC.h"
 
@@ -46,4 +48,15 @@ void integrationTestDidWriteReportCallback(const KSCrash_ExceptionHandlingPlan *
 
 void setIntegrationTestDidWriteReportCallback(void (^ _Nonnull implementation)(const KSCrash_ExceptionHandlingPlan *const _Nonnull plan, int64_t reportID)) {
     g_integrationTestDidWriteReportCallback = implementation;
+}
+
+int integrationTestIgnoreSIGPIPE(void)
+{
+    struct sigaction action = { { 0 } };
+    action.sa_handler = SIG_IGN;
+    sigemptyset(&action.sa_mask);
+    if (sigaction(SIGPIPE, &action, NULL) != 0) {
+        return errno;
+    }
+    return 0;
 }

--- a/Samples/Common/Sources/CrashCallback/include/CrashCallback.h
+++ b/Samples/Common/Sources/CrashCallback/include/CrashCallback.h
@@ -29,6 +29,8 @@ void integrationTestDidWriteReportCallback(const KSCrash_ExceptionHandlingPlan *
 
 void setIntegrationTestDidWriteReportCallback(void (^ _Nonnull implementation)(const KSCrash_ExceptionHandlingPlan *const _Nonnull plan, int64_t reportID));
 
+int integrationTestIgnoreSIGPIPE(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
+++ b/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
@@ -208,6 +208,11 @@ NSString *const KSCrashNSExceptionStacktraceFuncName = @"exceptionWithStacktrace
     abort();  // This will raise a SIGABRT signal
 }
 
++ (void)trigger_signal_sigpipe
+{
+    raise(SIGPIPE);
+}
+
 + (void)trigger_user_nonfatal
 {
     trigger_user_nonfatal();

--- a/Samples/Common/Sources/CrashTriggers/include/KSCrashTriggersList.h
+++ b/Samples/Common/Sources/CrashTriggers/include/KSCrashTriggersList.h
@@ -56,6 +56,7 @@ extern NSString *const KSCrashNSExceptionStacktraceFuncName;
     __PROCESS_TRIGGER(mach, busError, @"EXC_BAD_ACCESS (SIGBUS)")                                      \
     __PROCESS_TRIGGER(mach, illegalInstruction, @"EXC_BAD_INSTRUCTION")                                \
     __PROCESS_TRIGGER(signal, abort, @"Abort")                                                         \
+    __PROCESS_TRIGGER(signal, sigpipe, @"SIGPIPE")                                                     \
     __PROCESS_TRIGGER(user, nonfatal, @"Nonfatal")                                                     \
     __PROCESS_TRIGGER(user, fatal, @"Fatal")                                                           \
     __PROCESS_TRIGGER(multiple, mach_mach, @"Mach + Mach")                                             \

--- a/Samples/Common/Sources/IntegrationTestsHelper/InstallConfig.swift
+++ b/Samples/Common/Sources/IntegrationTestsHelper/InstallConfig.swift
@@ -35,6 +35,7 @@ public struct InstallConfig: Codable {
     public var isWatchdogEnabled: Bool?
     public var isHangReportingEnabled: Bool?
     public var isCompactBinaryImagesEnabled: Bool?
+    public var ignoreSIGPIPEBeforeInstall: Bool?
 
     public init(installPath: String) {
         self.installPath = installPath
@@ -43,6 +44,13 @@ public struct InstallConfig: Codable {
 
 extension InstallConfig {
     func install() throws {
+        if ignoreSIGPIPEBeforeInstall == true {
+            let error = integrationTestIgnoreSIGPIPE()
+            guard error == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: error) ?? .EINVAL)
+            }
+        }
+
         let config = CrashInstallConfiguration()
         config.installPath = installPath
         if let isCxaThrowEnabled {

--- a/Samples/Common/Sources/IntegrationTestsHelper/IntegrationTestRunner.swift
+++ b/Samples/Common/Sources/IntegrationTestsHelper/IntegrationTestRunner.swift
@@ -32,11 +32,18 @@ public final class IntegrationTestRunner {
         var delay: TimeInterval?
         var stateSavePath: String?
         var runEarly: Bool?
+        var completionMarkerPath: String?
 
-        public init(delay: TimeInterval? = nil, stateSavePath: String? = nil, runEarly: Bool? = nil) {
+        public init(
+            delay: TimeInterval? = nil,
+            stateSavePath: String? = nil,
+            runEarly: Bool? = nil,
+            completionMarkerPath: String? = nil
+        ) {
             self.delay = delay
             self.stateSavePath = stateSavePath
             self.runEarly = runEarly
+            self.completionMarkerPath = completionMarkerPath
         }
     }
 
@@ -100,6 +107,9 @@ public final class IntegrationTestRunner {
             }
             if let report = script.report {
                 report.report()
+            }
+            if let completionMarkerPath = script.config?.completionMarkerPath {
+                try! Data().write(to: URL(fileURLWithPath: completionMarkerPath))
             }
         }
     }

--- a/Samples/Tests/Core/IntegrationTestBase.swift
+++ b/Samples/Tests/Core/IntegrationTestBase.swift
@@ -39,6 +39,7 @@ class IntegrationTestBase: XCTestCase {
     private(set) var installUrl: URL!
     private(set) var appleReportsUrl: URL!
     private(set) var stateUrl: URL!
+    private(set) var actionCompletedUrl: URL!
 
     var appLaunchTimeout: TimeInterval = 10.0
     var appTerminateTimeout: TimeInterval = 5.0
@@ -64,6 +65,14 @@ class IntegrationTestBase: XCTestCase {
         )
     }
 
+    private var runConfigWithCompletionMarker: IntegrationTestRunner.RunConfig {
+        .init(
+            delay: actionDelay,
+            stateSavePath: stateUrl.path,
+            completionMarkerPath: actionCompletedUrl.path
+        )
+    }
+
     override func setUpWithError() throws {
         try super.setUpWithError()
 
@@ -75,6 +84,7 @@ class IntegrationTestBase: XCTestCase {
             .appendingPathComponent(UUID().uuidString)
         appleReportsUrl = installUrl.appendingPathComponent("__TEST_REPORTS__")
         stateUrl = installUrl.appendingPathComponent("__test_state__.json")
+        actionCompletedUrl = installUrl.appendingPathComponent("__test_action_completed__")
 
         try FileManager.default.createDirectory(at: appleReportsUrl, withIntermediateDirectories: true)
         log.info("KSCrash install path: \(installUrl.path)")
@@ -131,6 +141,21 @@ class IntegrationTestBase: XCTestCase {
             XCTAssert(app.wait(for: .notRunning, timeout: actionDelay + appCrashTimeout), "App crash is expected")
         #endif
         logFile(name: "Data/ConsoleLog.txt", path: installUrl.path.appending("/Data/ConsoleLog.txt"))
+    }
+
+    private func waitForFile(at url: URL, timeout: TimeInterval) throws {
+        enum Error: Swift.Error {
+            case fileNotFound
+        }
+
+        let fileExpectation = XCTNSPredicateExpectation(
+            predicate: .init { _, _ in FileManager.default.fileExists(atPath: url.path) },
+            object: nil
+        )
+        wait(for: [fileExpectation], timeout: timeout)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw Error.fileNotFound
+        }
     }
 
     private func waitForFile(in dir: URL, timeout: TimeInterval? = nil) throws -> URL {
@@ -247,6 +272,22 @@ class IntegrationTestBase: XCTestCase {
 
         launchAppAndRunScript()
         waitForCrash()
+    }
+
+    func launchAndRunTrigger(_ triggerId: CrashTriggerId, installOverride: ((inout InstallConfig) throws -> Void)? = nil)
+        throws
+    {
+        var installConfig = InstallConfig(installPath: installUrl.path)
+        try installOverride?(&installConfig)
+        try? FileManager.default.removeItem(at: actionCompletedUrl)
+        app.launchEnvironment[IntegrationTestRunner.envKey] = try IntegrationTestRunner.script(
+            crash: .init(triggerId: triggerId),
+            install: installConfig,
+            config: runConfigWithCompletionMarker
+        )
+
+        launchAppAndRunScript()
+        try waitForFile(at: actionCompletedUrl, timeout: actionDelay + appCrashTimeout)
     }
 
     func launchAndMakeUserReport(

--- a/Samples/Tests/Core/IntegrationTestBase.swift
+++ b/Samples/Tests/Core/IntegrationTestBase.swift
@@ -287,7 +287,7 @@ class IntegrationTestBase: XCTestCase {
         )
 
         launchAppAndRunScript()
-        try waitForFile(at: actionCompletedUrl, timeout: actionDelay + appCrashTimeout)
+        try waitForFile(at: actionCompletedUrl, timeout: appLaunchTimeout + actionDelay + appCrashTimeout)
     }
 
     func launchAndMakeUserReport(

--- a/Samples/Tests/IntegrationTests.swift
+++ b/Samples/Tests/IntegrationTests.swift
@@ -296,6 +296,16 @@ final class CppTests: IntegrationTestBase {
             XCTAssertEqual(state.terminationReason, .crash)
         }
 
+        func testIgnoredSIGPIPEDoesNotProduceCrashReport() throws {
+            // KSCrash must not turn an application/runtime-ignored signal into a reported crash.
+            try launchAndRunTrigger(.signal_sigpipe) { configuration in
+                configuration.ignoreSIGPIPEBeforeInstall = true
+            }
+
+            XCTAssertNotEqual(app.state, .notRunning)
+            XCTAssertFalse(try hasCrashReport())
+        }
+
         func testTermination() throws {
             // SIGTERM is caught to record a clean exit but no crash report is written
             try launchAndInstall()

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.c
@@ -147,6 +147,9 @@ static void logSigactionError(int sigNum, int error)
 static void restoreHandlersUpTo(const int *fatalSignals, int fatalSignalsCount)
 {
     for (int i = 0; i < fatalSignalsCount; i++) {
+        if (g_state.previousSignalHandlers[i].sa_handler == SIG_IGN) {
+                continue;
+        }
         sigaction(fatalSignals[i], &g_state.previousSignalHandlers[i], NULL);
     }
 }

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.c
@@ -133,6 +133,24 @@ exit_immediately:
     raise(sigNum);
 }
 
+static void logSigactionError(int sigNum, int error)
+{
+    char sigNameBuff[30];
+    const char *sigName = kssignal_signalName(sigNum);
+    if (sigName == NULL) {
+        snprintf(sigNameBuff, sizeof(sigNameBuff), "%d", sigNum);
+        sigName = sigNameBuff;
+    }
+    KSLOG_ERROR("sigaction (%s): %s", sigName, strerror(error));
+}
+
+static void restoreHandlersUpTo(const int *fatalSignals, int fatalSignalsCount)
+{
+    for (int i = 0; i < fatalSignalsCount; i++) {
+        sigaction(fatalSignals[i], &g_state.previousSignalHandlers[i], NULL);
+    }
+}
+
 // ============================================================================
 #pragma mark - API -
 // ============================================================================
@@ -178,19 +196,9 @@ static void install(void)
     action.sa_sigaction = &handleSignal;
 
     for (int i = 0; i < fatalSignalsCount; i++) {
-        KSLOG_DEBUG("Assigning handler for signal %d", fatalSignals[i]);
-        if (sigaction(fatalSignals[i], &action, &g_state.previousSignalHandlers[i]) != 0) {
-            char sigNameBuff[30];
-            const char *sigName = kssignal_signalName(fatalSignals[i]);
-            if (sigName == NULL) {
-                snprintf(sigNameBuff, sizeof(sigNameBuff), "%d", fatalSignals[i]);
-                sigName = sigNameBuff;
-            }
-            KSLOG_ERROR("sigaction (%s): %s", sigName, strerror(errno));
-            // Try to reverse the damage
-            for (i--; i >= 0; i--) {
-                sigaction(fatalSignals[i], &g_state.previousSignalHandlers[i], NULL);
-            }
+        if (sigaction(fatalSignals[i], NULL, &g_state.previousSignalHandlers[i]) != 0) {
+            logSigactionError(fatalSignals[i], errno);
+            restoreHandlersUpTo(fatalSignals, i);
             goto failed;
         }
 
@@ -199,7 +207,14 @@ static void install(void)
         // turn an ignored signal (for example SIGPIPE) into a reported fatal
         // crash even though the process would normally continue running.
         if (g_state.previousSignalHandlers[i].sa_handler == SIG_IGN) {
-            sigaction(fatalSignals[i], &g_state.previousSignalHandlers[i], NULL);
+            continue;
+        }
+
+        KSLOG_DEBUG("Assigning handler for signal %d", fatalSignals[i]);
+        if (sigaction(fatalSignals[i], &action, NULL) != 0) {
+            logSigactionError(fatalSignals[i], errno);
+            restoreHandlersUpTo(fatalSignals, i);
+            goto failed;
         }
     }
     KSLOG_DEBUG("Signal handlers installed.");
@@ -222,10 +237,7 @@ static void restoreHandlers(void)
     const int *fatalSignals = kssignal_fatalSignals();
     int fatalSignalsCount = kssignal_numFatalSignals();
 
-    for (int i = 0; i < fatalSignalsCount; i++) {
-        KSLOG_DEBUG("Restoring original handler for signal %d", fatalSignals[i]);
-        sigaction(fatalSignals[i], &g_state.previousSignalHandlers[i], NULL);
-    }
+    restoreHandlersUpTo(fatalSignals, fatalSignalsCount);
 }
 
 static const char *monitorId(__unused void *context) { return "Signal"; }

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.c
@@ -193,6 +193,14 @@ static void install(void)
             }
             goto failed;
         }
+
+        // If the application or runtime explicitly ignored this signal before
+        // KSCrash was installed, preserve that behavior. Otherwise KSCrash would
+        // turn an ignored signal (for example SIGPIPE) into a reported fatal
+        // crash even though the process would normally continue running.
+        if (g_state.previousSignalHandlers[i].sa_handler == SIG_IGN) {
+            sigaction(fatalSignals[i], &g_state.previousSignalHandlers[i], NULL);
+        }
     }
     KSLOG_DEBUG("Signal handlers installed.");
     return;

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.c
@@ -148,7 +148,7 @@ static void restoreHandlersUpTo(const int *fatalSignals, int fatalSignalsCount)
 {
     for (int i = 0; i < fatalSignalsCount; i++) {
         if (g_state.previousSignalHandlers[i].sa_handler == SIG_IGN) {
-                continue;
+            continue;
         }
         sigaction(fatalSignals[i], &g_state.previousSignalHandlers[i], NULL);
     }

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_Signal_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_Signal_Tests.m
@@ -26,6 +26,8 @@
 
 #import <XCTest/XCTest.h>
 
+#include <signal.h>
+
 #import "KSCrashMonitorContext.h"
 #import "KSCrashMonitor_Signal.h"
 #import "KSSystemCapabilities.h"
@@ -60,6 +62,32 @@
     XCTAssertFalse(api->isEnabled(NULL));
     api->setEnabled(false, NULL);
     XCTAssertFalse(api->isEnabled(NULL));
+}
+
+- (void)testPreservesIgnoredSignalHandlers
+{
+    KSCrashMonitorAPI *api = kscm_signal_getAPI();
+    api->setEnabled(false, NULL);
+
+    struct sigaction originalAction;
+    XCTAssertEqual(sigaction(SIGPIPE, NULL, &originalAction), 0);
+
+    struct sigaction ignoredAction = { { 0 } };
+    ignoredAction.sa_handler = SIG_IGN;
+    sigemptyset(&ignoredAction.sa_mask);
+    XCTAssertEqual(sigaction(SIGPIPE, &ignoredAction, NULL), 0);
+
+    @try {
+        api->setEnabled(true, NULL);
+        XCTAssertTrue(api->isEnabled(NULL));
+
+        struct sigaction currentAction;
+        XCTAssertEqual(sigaction(SIGPIPE, NULL, &currentAction), 0);
+        XCTAssertEqual(currentAction.sa_handler, SIG_IGN);
+    } @finally {
+        api->setEnabled(false, NULL);
+        sigaction(SIGPIPE, &originalAction, NULL);
+    }
 }
 
 #else

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_Signal_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_Signal_Tests.m
@@ -26,8 +26,6 @@
 
 #import <XCTest/XCTest.h>
 
-#include <signal.h>
-
 #import "KSCrashMonitorContext.h"
 #import "KSCrashMonitor_Signal.h"
 #import "KSSystemCapabilities.h"
@@ -62,32 +60,6 @@
     XCTAssertFalse(api->isEnabled(NULL));
     api->setEnabled(false, NULL);
     XCTAssertFalse(api->isEnabled(NULL));
-}
-
-- (void)testPreservesIgnoredSignalHandlers
-{
-    KSCrashMonitorAPI *api = kscm_signal_getAPI();
-    api->setEnabled(false, NULL);
-
-    struct sigaction originalAction;
-    XCTAssertEqual(sigaction(SIGPIPE, NULL, &originalAction), 0);
-
-    struct sigaction ignoredAction = { { 0 } };
-    ignoredAction.sa_handler = SIG_IGN;
-    sigemptyset(&ignoredAction.sa_mask);
-    XCTAssertEqual(sigaction(SIGPIPE, &ignoredAction, NULL), 0);
-
-    @try {
-        api->setEnabled(true, NULL);
-        XCTAssertTrue(api->isEnabled(NULL));
-
-        struct sigaction currentAction;
-        XCTAssertEqual(sigaction(SIGPIPE, NULL, &currentAction), 0);
-        XCTAssertEqual(currentAction.sa_handler, SIG_IGN);
-    } @finally {
-        api->setEnabled(false, NULL);
-        sigaction(SIGPIPE, &originalAction, NULL);
-    }
 }
 
 #else


### PR DESCRIPTION
This PR ensures the signal monitor preserves signal handlers explicitly set to `SIG_IGN` before KSCrash installs.

Previously, KSCrash installed its signal handler for every fatal signal and stored the previous handler, but did not check whether the previous handler was `SIG_IGN`. For signals such as `SIGPIPE`, some applications or runtimes intentionally ignore the signal. In that case, KSCrash could intercept the signal, write a fatal crash report, restore the ignored handler, and re-raise it, allowing the process to continue while still producing a crash report.

With this change, if the previous handler for a signal was `SIG_IGN`, KSCrash immediately restores it, leaving that signal ignored.

I am not sure whether this behavior aligns with KSCrash signal-handling principles, but downstream in SentryCrash, a customer added it some time ago (https://github.com/getsentry/sentry-cocoa/pull/1489), and it is likely a sensible environmental hint to act on. I also added the behavior to our e2e SDK coverage (https://github.com/getsentry/sentry-cocoa/pull/8328).