### PR TITLE
fix: use binary image cache for system binary CPU metadata

### DIFF
--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
@@ -453,10 +453,7 @@ static void initialize(void)
     safeStrlcpy(sd->cpuArchitecture, getCurrentCPUArch(), sizeof(sd->cpuArchitecture));
     sd->cpuType = kssysctl_int32ForName("hw.cputype");
     sd->cpuSubType = kssysctl_int32ForName("hw.cpusubtype");
-    if (header != NULL) {
-        sd->binaryCPUType = header->cputype;
-        sd->binaryCPUSubType = header->cpusubtype;
-    }
+
     safeNSStringCopy(sd->timezone, [NSTimeZone localTimeZone].abbreviation, sizeof(sd->timezone));
     safeNSStringCopy(sd->processName, [NSProcessInfo processInfo].processName, sizeof(sd->processName));
     sd->processID = [NSProcessInfo processInfo].processIdentifier;
@@ -466,6 +463,9 @@ static void initialize(void)
     sd->memorySize = kssysctl_uint64ForName("hw.memsize");
 
     if (header != NULL) {
+        sd->binaryCPUType = header->cputype;
+        sd->binaryCPUSubType = header->cpusubtype;
+
         const char *binaryArch = getCPUArchForCPUType(header->cputype, header->cpusubtype);
         safeStrlcpy(sd->binaryArchitecture, binaryArch != NULL ? binaryArch : "", sizeof(sd->binaryArchitecture));
     }

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
@@ -57,7 +57,6 @@
 #import <UIKit/UIKit.h>
 #endif
 #include <fcntl.h>
-#include <mach-o/dyld.h>
 #include <mach/mach.h>
 #include <stdatomic.h>
 
@@ -392,7 +391,7 @@ static void initialize(void)
     // Populate all static fields into local pointer before publishing.
     NSBundle *mainBundle = [NSBundle mainBundle];
     NSDictionary *infoDict = [mainBundle infoDictionary];
-    const struct mach_header *header = _dyld_get_image_header(0);
+    const struct mach_header *header = ksbic_getAppHeader();
 
 #if KSCRASH_HAS_UIDEVICE
     safeNSStringCopy(sd->systemName, [UIDevice currentDevice].systemName, sizeof(sd->systemName));
@@ -454,8 +453,10 @@ static void initialize(void)
     safeStrlcpy(sd->cpuArchitecture, getCurrentCPUArch(), sizeof(sd->cpuArchitecture));
     sd->cpuType = kssysctl_int32ForName("hw.cputype");
     sd->cpuSubType = kssysctl_int32ForName("hw.cpusubtype");
-    sd->binaryCPUType = header->cputype;
-    sd->binaryCPUSubType = header->cpusubtype;
+    if (header != NULL) {
+        sd->binaryCPUType = header->cputype;
+        sd->binaryCPUSubType = header->cpusubtype;
+    }
     safeNSStringCopy(sd->timezone, [NSTimeZone localTimeZone].abbreviation, sizeof(sd->timezone));
     safeNSStringCopy(sd->processName, [NSProcessInfo processInfo].processName, sizeof(sd->processName));
     sd->processID = [NSProcessInfo processInfo].processIdentifier;
@@ -464,8 +465,10 @@ static void initialize(void)
     safeStrlcpy(sd->buildType, getBuildType(), sizeof(sd->buildType));
     sd->memorySize = kssysctl_uint64ForName("hw.memsize");
 
-    const char *binaryArch = getCPUArchForCPUType(header->cputype, header->cpusubtype);
-    safeStrlcpy(sd->binaryArchitecture, binaryArch != NULL ? binaryArch : "", sizeof(sd->binaryArchitecture));
+    if (header != NULL) {
+        const char *binaryArch = getCPUArchForCPUType(header->cputype, header->cpusubtype);
+        safeStrlcpy(sd->binaryArchitecture, binaryArch != NULL ? binaryArch : "", sizeof(sd->binaryArchitecture));
+    }
 
 #ifdef __clang_version__
     safeStrlcpy(sd->clangVersion, __clang_version__, sizeof(sd->clangVersion));

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_System_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_System_Tests.m
@@ -26,9 +26,11 @@
 
 #import <XCTest/XCTest.h>
 
+#import "KSBinaryImageCache.h"
 #import "KSCrashMonitorContext.h"
 #import "KSCrashMonitor_System.h"
 #import "KSCrashReportFields.h"
+#import "KSDynamicLinker.h"
 #import "KSFileUtils.h"
 #import "KSJSONCodecObjC.h"
 #import "KSSysCtl.h"
@@ -63,6 +65,7 @@ static bool stubRunSidecarPath(const char *monitorId, char *pathBuffer, size_t p
                                                attributes:nil
                                                     error:nil];
     strlcpy(g_sidecarPath, self.tempDir.fileSystemRepresentation, sizeof(g_sidecarPath));
+    ksdl_init();
 }
 
 - (void)tearDown
@@ -72,6 +75,7 @@ static bool stubRunSidecarPath(const char *monitorId, char *pathBuffer, size_t p
 
     [[NSFileManager defaultManager] removeItemAtPath:self.tempDir error:nil];
     g_sidecarPath[0] = '\0';
+    ksdl_init();
     [super tearDown];
 }
 
@@ -111,6 +115,56 @@ static bool stubRunSidecarPath(const char *monitorId, char *pathBuffer, size_t p
     XCTAssertGreaterThan(sc.processID, 0, @"processID should be non-zero");
 
     api->setEnabled(false, NULL);
+}
+
+- (void)testBinaryCPUMetadataUsesBinaryImageCacheHeader
+{
+    const struct mach_header *header = ksbic_getAppHeader();
+    XCTAssertNotEqual(header, NULL, @"App header should be available from the binary image cache");
+
+    KSCrashMonitorAPI *api = kscm_system_getAPI();
+    KSCrash_ExceptionHandlerCallbacks callbacks = { .getRunSidecarPath = stubRunSidecarPath };
+    api->init(&callbacks, NULL);
+    api->setEnabled(true, NULL);
+
+    NSString *sidecarFile = [self.tempDir stringByAppendingPathComponent:@"System.ksscr"];
+    KSCrash_SystemData sc = {};
+    int fd = open(sidecarFile.fileSystemRepresentation, O_RDONLY);
+    XCTAssertNotEqual(fd, -1);
+    XCTAssertTrue(ksfu_readBytesFromFD(fd, (char *)&sc, (int)sizeof(sc)));
+    close(fd);
+
+    XCTAssertEqual(sc.binaryCPUType, header->cputype);
+    XCTAssertEqual(sc.binaryCPUSubType, header->cpusubtype);
+    XCTAssertTrue(sc.binaryArchitecture[0] != '\0', @"binaryArchitecture should be populated");
+
+    api->setEnabled(false, NULL);
+}
+
+- (void)testBinaryCPUMetadataMissingWhenBinaryImageCacheUnavailable
+{
+    ksdl_resetCache();
+    XCTAssertEqual(ksbic_getAppHeader(), NULL,
+                   @"App header should be unavailable before the binary image cache is initialized");
+
+    KSCrashMonitorAPI *api = kscm_system_getAPI();
+    KSCrash_ExceptionHandlerCallbacks callbacks = { .getRunSidecarPath = stubRunSidecarPath };
+    api->init(&callbacks, NULL);
+    api->setEnabled(true, NULL);
+
+    NSString *sidecarFile = [self.tempDir stringByAppendingPathComponent:@"System.ksscr"];
+    KSCrash_SystemData sc = {};
+    int fd = open(sidecarFile.fileSystemRepresentation, O_RDONLY);
+    XCTAssertNotEqual(fd, -1);
+    XCTAssertTrue(ksfu_readBytesFromFD(fd, (char *)&sc, (int)sizeof(sc)));
+    close(fd);
+
+    XCTAssertEqual(sc.binaryCPUType, 0);
+    XCTAssertEqual(sc.binaryCPUSubType, 0);
+    XCTAssertEqual(sc.binaryArchitecture[0], '\0');
+
+    api->setEnabled(false, NULL);
+    ksdl_init();
 }
 
 - (void)testOSVersionMatchesPlatform

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_System_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_System_Tests.m
@@ -164,7 +164,6 @@ static bool stubRunSidecarPath(const char *monitorId, char *pathBuffer, size_t p
     XCTAssertEqual(sc.binaryArchitecture[0], '\0');
 
     api->setEnabled(false, NULL);
-    ksdl_init();
 }
 
 - (void)testOSVersionMatchesPlatform


### PR DESCRIPTION
KSCrash initializes `KSDynamicLinker`/`KSBinaryImageCache` before enabling monitors during `kscrash_install()`, so the system monitor can use the cached app Mach header when collecting binary CPU metadata.

This PR replaces the remaining direct `_dyld_get_image_header(0)` lookup in the system monitor with `ksbic_getAppHeader()`. If the cached app header is unavailable, leave binary CPU type/subtype/architecture unset instead of falling back to `dyld`.

Added system monitor tests for both populated binary CPU metadata and missing-cache behavior.

While this is not strictly upstreaming a fix, it came up during my diff analysis, since reducing `dyld` locks during setup is a high-priority item given recurring blocking issues in the wild (related to https://github.com/kstenerud/KSCrash/issues/431 and https://github.com/getsentry/sentry-cocoa/pull/6181, but we had others).