### PR TITLE
Fix the Thread Sanitizer CI job failures

### DIFF
--- a/Sources/KSCrashRecording/KSThreadCache.c
+++ b/Sources/KSCrashRecording/KSThreadCache.c
@@ -180,7 +180,10 @@ static void updateCache(void)
 
 static void *monitorThreadCache(__unused void *const userData)
 {
-    static int quickPollCount = 4;
+    // Each monitor thread owns its quick-poll countdown. Keep it a local: more
+    // than one monitor thread can run at once (kstc_init after kstc_reset), and
+    // they must not share this counter.
+    int quickPollCount = 4;
     usleep(1);
 
     for (;;) {

--- a/Tests/KSCrashBenchmarks/KSBenchmarkTestCase.swift
+++ b/Tests/KSCrashBenchmarks/KSBenchmarkTestCase.swift
@@ -24,7 +24,36 @@
 // THE SOFTWARE.
 //
 
+import Darwin
 import XCTest
+
+// True when the process is running under a sanitizer (ASan/TSan/UBSan). Used to
+// skip these benchmarks: measuring performance under a sanitizer is meaningless,
+// and under TSan XCTest's measure() intermittently SEGVs in objc_release during
+// measurement teardown.
+//
+// The dlsym probe is deliberate. Each tidier-looking option fails here:
+//   - `#if KSCRASH_HAS_SANITIZER`: that is a C preprocessor macro, and Swift's
+//     `#if` only reads `-D` build conditions, not C macros, so it is silently
+//     always false (this was the original, broken guard).
+//   - A shared helper in a module (KSCrashTestTools, KSCrashSwiftCore): these
+//     benchmark sources are also compiled by the Tuist on-device build
+//     (Benchmarks/Project.swift), which can only depend on shipping products, not
+//     internal test/utility targets, so any such import breaks that build.
+//   - A `-D SANITIZER` build flag + `#if`: only skips when the build passes the
+//     flag, so a local `swift test --sanitize` that omits it silently runs the
+//     benchmarks and crashes.
+// A sanitizer runtime exports a well-known init symbol once loaded, so a dlsym
+// against RTLD_DEFAULT detects it however the build was invoked, with zero
+// dependencies.
+private func isRunningUnderSanitizer() -> Bool {
+    // RTLD_DEFAULT (search every loaded image) is not exported to Swift, so spell
+    // out its pseudo-handle value.
+    let rtldDefault = UnsafeMutableRawPointer(bitPattern: -2)
+    return ["__asan_init", "__tsan_init", "__ubsan_handle_add_overflow"].contains { symbol in
+        symbol.withCString { dlsym(rtldDefault, $0) != nil }
+    }
+}
 
 /// Base class for all KSCrash benchmark tests.
 ///
@@ -44,5 +73,12 @@ class KSBenchmarkTestCase: XCTestCase {
             options.iterationCount = 5
         #endif
         return options
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // Benchmarks measure performance, which is meaningless under a sanitizer,
+        // and XCTest's measure() intermittently crashes in objc_release under TSan.
+        try XCTSkipIf(isRunningUnderSanitizer(), "Benchmarks do not run under sanitizers")
     }
 }

--- a/Tests/KSCrashBenchmarksCold/KSCxaThrowColdBenchmarks.swift
+++ b/Tests/KSCrashBenchmarksCold/KSCxaThrowColdBenchmarks.swift
@@ -24,11 +24,26 @@
 // THE SOFTWARE.
 //
 
+import Darwin
 import KSCrashRecordingCore
 import XCTest
 
 // Dummy handler for benchmarking - does nothing
 private let dummyHandler: cxa_throw_type = { _, _, _ in }
+
+// True when the process is running under a sanitizer (ASan/TSan/UBSan), used to
+// skip this benchmark (it conflicts with a sanitizer and SEGVs under TSan).
+// Copied from KSBenchmarkTestCase because this cold benchmark is a separate SPM
+// target and can't share code with it; see there for why the sanitizer is probed
+// with dlsym rather than a C-macro `#if`, a shared module, or a build flag.
+private func isRunningUnderSanitizer() -> Bool {
+    // RTLD_DEFAULT (search every loaded image) is not exported to Swift, so spell
+    // out its pseudo-handle value.
+    let rtldDefault = UnsafeMutableRawPointer(bitPattern: -2)
+    return ["__asan_init", "__tsan_init", "__ubsan_handle_add_overflow"].contains { symbol in
+        symbol.withCString { dlsym(rtldDefault, $0) != nil }
+    }
+}
 
 /// This test target runs in its own process to ensure true cold measurement.
 /// No other tests run before this, guaranteeing:
@@ -41,11 +56,8 @@ class KSCxaThrowColdBenchmarks: XCTestCase {
     /// This test runs in an isolated process to ensure truly cold state.
     /// Uses iterationCount=1 with a counter trick: warmup iteration does nothing,
     /// measured iteration runs the actual cold installation.
-    func testBenchmarkSwapInstallationCold() {
-        #if KSCRASH_HAS_SANITIZER
-            print("Skipping benchmark - sanitizers are enabled")
-            return
-        #endif
+    func testBenchmarkSwapInstallationCold() throws {
+        try XCTSkipIf(isRunningUnderSanitizer(), "Sanitizers conflict with __cxa_throw swapper")
 
         var iteration = 0
 


### PR DESCRIPTION
The Thread Sanitizer job was failing for a few independent reasons, none of them tied to any particular PR. This clears all of them.

The cold `__cxa_throw` swap benchmark is meant to skip when a sanitizer is enabled, like the ObjC benchmark and the swapper tests do. Its guard used `#if KSCRASH_HAS_SANITIZER`, but that is a C preprocessor macro and Swift's `#if` only reads `-D` compilation conditions, so the guard was always false. Under TSan the benchmark ran anyway and crashed with a SEGV inside XCTest's `measure()` teardown. It now detects the sanitizer at runtime by `dlsym`-ing for a sanitizer runtime's init symbol, with no module dependency, since these benchmark sources are also compiled by the Tuist on-device build (`Benchmarks/Project.swift`), which can only depend on shipping products, not internal test targets.

The same `measure()`-under-TSan crash also hit the Swift profiler benchmarks, which had no sanitizer guard at all, so those now skip through the shared `KSBenchmarkTestCase` base class using the same runtime check.

Finally, `KSThreadCache` had a real data race. `quickPollCount` was a function-static in the monitor loop, so it was shared across threads. In production there is a single monitor thread, but `kstc_reset` followed by `kstc_init` in tests leaves the old detached thread running while a new one starts, and both touched the same static. It is now a plain local so each monitor thread gets its own counter.