### PR TITLE
Diagnose crashes on the Objective-C nonatomic-property race sentinel

### DIFF
--- a/Sources/KSCrashFilters/KSCrashDoctor.m
+++ b/Sources/KSCrashFilters/KSCrashDoctor.m
@@ -171,6 +171,14 @@ typedef enum { CPUFamilyUnknown, CPUFamilyArm, CPUFamilyX86, CPUFamilyX86_64 } C
     return CPUFamilyUnknown;
 }
 
+- (BOOL)is32BitReport:(NSDictionary *)report
+{
+    // 64-bit arch names (arm64, arm64e, x86_64) all contain "64". Treat an unknown
+    // or missing arch as not-32-bit so the ambiguous 0xbad0 sentinel is not matched.
+    NSString *cpuArch = [[self systemReport:report] objectForKey:KSCrashField_CPUArch];
+    return cpuArch != nil && [cpuArch rangeOfString:@"64"].location == NSNotFound;
+}
+
 - (nullable NSString *)registerNameForFamily:(CPUFamily)family paramIndex:(int)index
 {
     switch (family) {
@@ -544,7 +552,10 @@ typedef enum { CPUFamilyUnknown, CPUFamilyArm, CPUFamilyX86, CPUFamilyX86_64 } C
             if (address == 0) {
                 return [self appendOriginatingCall:@"Attempted to dereference null pointer." callName:lastFunctionName];
             }
-            if (address == kKSNonatomicRaceSentinel || address == kKSNonatomicRaceSentinel32) {
+            // The 64-bit sentinel is unmistakable. The 32-bit half (0xbad0) is a plausible
+            // real garbage pointer on 64-bit, so only trust it on a 32-bit report.
+            if (address == kKSNonatomicRaceSentinel ||
+                (address == kKSNonatomicRaceSentinel32 && [self is32BitReport:report])) {
                 return [self
                     appendOriginatingCall:@"Crashed on the Objective-C nonatomic-property race sentinel. A nonatomic "
                                           @"property was read on one thread while being written on another "

--- a/Sources/KSCrashFilters/KSCrashDoctor.m
+++ b/Sources/KSCrashFilters/KSCrashDoctor.m
@@ -11,6 +11,13 @@
 
 #import <mach/exception_types.h>
 
+/// Sentinel that synthesized nonatomic Objective-C setters briefly store mid-store;
+/// a concurrent unsafe read of the property faults on it, so a crash on this address
+/// signals a thread-safety bug on a nonatomic property (Apple ObjC runtime, rdar://148109501).
+/// 64-bit devices fault on the full value; 32-bit watchOS uses its low half, 0xbad0.
+static const unsigned long long kKSNonatomicRaceSentinel = 0x400000000000bad0ULL;
+static const unsigned long long kKSNonatomicRaceSentinel32 = 0xbad0ULL;
+
 typedef enum { CPUFamilyUnknown, CPUFamilyArm, CPUFamilyX86, CPUFamilyX86_64 } CPUFamily;
 
 @interface KSCrashDoctorParam : NSObject
@@ -533,13 +540,20 @@ typedef enum { CPUFamilyUnknown, CPUFamilyArm, CPUFamilyX86, CPUFamilyX86_64 } C
         }
 
         if ([self isInvalidAddress:errorReport]) {
-            uintptr_t address = (uintptr_t)[[errorReport objectForKey:KSCrashField_Address] unsignedLongLongValue];
+            unsigned long long address = [[errorReport objectForKey:KSCrashField_Address] unsignedLongLongValue];
             if (address == 0) {
                 return [self appendOriginatingCall:@"Attempted to dereference null pointer." callName:lastFunctionName];
             }
+            if (address == kKSNonatomicRaceSentinel || address == kKSNonatomicRaceSentinel32) {
+                return [self
+                    appendOriginatingCall:@"Crashed on the Objective-C nonatomic-property race sentinel. A nonatomic "
+                                          @"property was read on one thread while being written on another "
+                                          @"(thread-safety bug)."
+                                 callName:lastFunctionName];
+            }
             return
                 [self appendOriginatingCall:[NSString stringWithFormat:@"Attempted to dereference garbage pointer %p.",
-                                                                       (void *)address]
+                                                                       (void *)(uintptr_t)address]
                                    callName:lastFunctionName];
         }
 

--- a/Tests/KSCrashFiltersTests/KSCrashReportFilterDoctor_Tests.m
+++ b/Tests/KSCrashFiltersTests/KSCrashReportFilterDoctor_Tests.m
@@ -54,6 +54,10 @@
     XCTAssertEqualObjects(diagnostic, @"App hung for 3.99 seconds. Terminated by watchdog.");
 }
 
+static NSString *const kSentinelDiagnosis =
+    @"Crashed on the Objective-C nonatomic-property race sentinel. A nonatomic property was read "
+    @"on one thread while being written on another (thread-safety bug).";
+
 - (void)testNonatomicPropertyRaceSentinel
 {
     // EXC_BAD_ACCESS on 0x400000000000bad0, the sentinel a synthesized nonatomic
@@ -61,9 +65,26 @@
     KSCrashReportDictionary *report = [self _crashReportAsJSON:@"nonatomic_race"];
     KSCrashReportDictionary *resultReport = [self _filteredReport:report];
     NSString *diagnostic = resultReport.value[KSCrashField_Crash][KSCrashField_Diagnosis];
-    XCTAssertEqualObjects(diagnostic,
-                          @"Crashed on the Objective-C nonatomic-property race sentinel. A nonatomic property was read "
-                          @"on one thread while being written on another (thread-safety bug).");
+    XCTAssertEqualObjects(diagnostic, kSentinelDiagnosis);
+}
+
+- (void)testNonatomicPropertyRaceSentinel32Bit
+{
+    // On 32-bit watchOS the sentinel is its low half, 0xbad0 (cpu_arch armv7k).
+    KSCrashReportDictionary *report = [self _crashReportAsJSON:@"nonatomic_race_32bit"];
+    KSCrashReportDictionary *resultReport = [self _filteredReport:report];
+    NSString *diagnostic = resultReport.value[KSCrashField_Crash][KSCrashField_Diagnosis];
+    XCTAssertEqualObjects(diagnostic, kSentinelDiagnosis);
+}
+
+- (void)testGarbagePointerAt0xbad0On64BitIsNotSentinel
+{
+    // 0xbad0 is a plausible real garbage pointer on 64-bit, so it must not be
+    // mistaken for the 32-bit sentinel there.
+    KSCrashReportDictionary *report = [self _crashReportAsJSON:@"bad_access_0xbad0_64bit"];
+    KSCrashReportDictionary *resultReport = [self _filteredReport:report];
+    NSString *diagnostic = resultReport.value[KSCrashField_Crash][KSCrashField_Diagnosis];
+    XCTAssertEqualObjects(diagnostic, @"Attempted to dereference garbage pointer 0xbad0.");
 }
 
 @end

--- a/Tests/KSCrashFiltersTests/KSCrashReportFilterDoctor_Tests.m
+++ b/Tests/KSCrashFiltersTests/KSCrashReportFilterDoctor_Tests.m
@@ -54,4 +54,16 @@
     XCTAssertEqualObjects(diagnostic, @"App hung for 3.99 seconds. Terminated by watchdog.");
 }
 
+- (void)testNonatomicPropertyRaceSentinel
+{
+    // EXC_BAD_ACCESS on 0x400000000000bad0, the sentinel a synthesized nonatomic
+    // ObjC setter briefly stores mid-store (Apple ObjC runtime, rdar://148109501).
+    KSCrashReportDictionary *report = [self _crashReportAsJSON:@"nonatomic_race"];
+    KSCrashReportDictionary *resultReport = [self _filteredReport:report];
+    NSString *diagnostic = resultReport.value[KSCrashField_Crash][KSCrashField_Diagnosis];
+    XCTAssertEqualObjects(diagnostic,
+                          @"Crashed on the Objective-C nonatomic-property race sentinel. A nonatomic property was read "
+                          @"on one thread while being written on another (thread-safety bug).");
+}
+
 @end

--- a/Tests/KSCrashFiltersTests/Resources/bad_access_0xbad0_64bit.json
+++ b/Tests/KSCrashFiltersTests/Resources/bad_access_0xbad0_64bit.json
@@ -1,0 +1,32 @@
+{
+    "report": {
+        "version": "3.1.0",
+        "id": "5C3E1B8A-0000-0000-0000-000000000064",
+        "process_name": "Crash-Tester",
+        "type": "standard"
+    },
+    "system": {
+        "cpu_arch": "arm64"
+    },
+    "crash": {
+        "error": {
+            "type": "mach",
+            "mach": {
+                "exception_name": "EXC_BAD_ACCESS",
+                "code_name": "KERN_INVALID_ADDRESS"
+            },
+            "signal": {
+                "name": "SIGSEGV"
+            },
+            "address": 47824
+        },
+        "threads": [
+            {
+                "crashed": true,
+                "backtrace": {
+                    "contents": []
+                }
+            }
+        ]
+    }
+}

--- a/Tests/KSCrashFiltersTests/Resources/nonatomic_race.json
+++ b/Tests/KSCrashFiltersTests/Resources/nonatomic_race.json
@@ -1,0 +1,29 @@
+{
+    "report": {
+        "version": "3.1.0",
+        "id": "5C3E1B8A-0000-0000-0000-000000000000",
+        "process_name": "Crash-Tester",
+        "type": "standard"
+    },
+    "crash": {
+        "error": {
+            "type": "mach",
+            "mach": {
+                "exception_name": "EXC_BAD_ACCESS",
+                "code_name": "KERN_INVALID_ADDRESS"
+            },
+            "signal": {
+                "name": "SIGSEGV"
+            },
+            "address": 4611686018427435728
+        },
+        "threads": [
+            {
+                "crashed": true,
+                "backtrace": {
+                    "contents": []
+                }
+            }
+        ]
+    }
+}

--- a/Tests/KSCrashFiltersTests/Resources/nonatomic_race_32bit.json
+++ b/Tests/KSCrashFiltersTests/Resources/nonatomic_race_32bit.json
@@ -1,0 +1,32 @@
+{
+    "report": {
+        "version": "3.1.0",
+        "id": "5C3E1B8A-0000-0000-0000-000000000032",
+        "process_name": "Crash-Tester",
+        "type": "standard"
+    },
+    "system": {
+        "cpu_arch": "armv7k"
+    },
+    "crash": {
+        "error": {
+            "type": "mach",
+            "mach": {
+                "exception_name": "EXC_BAD_ACCESS",
+                "code_name": "KERN_INVALID_ADDRESS"
+            },
+            "signal": {
+                "name": "SIGSEGV"
+            },
+            "address": 47824
+        },
+        "threads": [
+            {
+                "crashed": true,
+                "backtrace": {
+                    "contents": []
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Apple's Objective-C runtime in Xcode 26 added a debugging aid: a synthesized nonatomic setter now briefly stores the sentinel value `0x400000000000bad0` (`0xbad0` on 32-bit watchOS) while it swaps the ivar, so a thread that reads the property without synchronization can fault on that sentinel. A crash on that address is a strong signal of a thread-safety bug on a nonatomic property. See https://developer.apple.com/documentation/xcode-release-notes/xcode-26-release-notes#Objective-C-Runtime.

This teaches `KSCrashDoctor` to recognize that address. When a bad-access crash faults on the sentinel, the diagnosis now reads "Crashed on the Objective-C nonatomic-property race sentinel. A nonatomic property was read on one thread while being written on another (thread-safety bug)." instead of the generic "garbage pointer" message. It reuses the existing `diagnosis` field, so nothing else in the pipeline changes.