### PR TITLE
Link the C++ runtime explicitly in test targets that use it

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -186,6 +186,16 @@ let warningFlags = [
     //"-Wnullable-to-nonnull-conversion",
 ]
 
+// Test targets that pull in the C++ standard library (via .mm/.cpp using std:: and
+// throw) must link the C++ runtime explicitly. Xcode 27's SwiftPM stopped auto-linking
+// it into test bundles, so std:: and __cxa_* symbols would otherwise be undefined at
+// link time. Harmless on toolchains that already link it (duplicate libraries are
+// allowed via -no_warn_duplicate_libraries).
+let cxxTestLinkerSettings: [LinkerSetting] = [
+    .linkedLibrary("c++"),
+    .linkedLibrary("c++abi"),
+]
+
 let package = Package(
     name: "KSCrash",
     platforms: [
@@ -282,7 +292,8 @@ let package = Package(
                 .headerSearchPath("../../Sources/\(Targets.recording)/Monitors"),
                 .headerSearchPath("../../Sources/\(Targets.recordingCore)/include"),  // For internal Unwind/ headers
                 .unsafeFlags(warningFlags),
-            ]
+            ],
+            linkerSettings: cxxTestLinkerSettings
         ),
 
         .target(
@@ -350,7 +361,8 @@ let package = Package(
             ],
             cSettings: [
                 .unsafeFlags(warningFlags)
-            ]
+            ],
+            linkerSettings: cxxTestLinkerSettings
         ),
         .testTarget(
             name: Targets.recordingCoreSwift.tests,
@@ -532,7 +544,8 @@ let package = Package(
             cSettings: [
                 .headerSearchPath("../../Sources/\(Targets.recording)"),
                 .headerSearchPath("../../Sources/\(Targets.recording)/Monitors"),
-            ]
+            ],
+            linkerSettings: cxxTestLinkerSettings
         ),
 
         .testTarget(


### PR DESCRIPTION
The test targets that pull in the C++ standard library (`KSCrashRecordingCoreTests`, `KSCrashRecordingTests`, `KSCrashBenchmarksObjC`, via `.mm` files that use `std::` and `throw`) relied on SwiftPM auto-linking libc++/libc++abi into their test bundles. Xcode 27's SwiftPM no longer does that, so `std::` and `__cxa_*` symbols come up undefined at link time and the test bundle fails to build. CI on Xcode 26 isn't affected today, but this breaks local builds on the Xcode 27 beta and would break CI once it moves to Xcode 27.

This declares `c++` and `c++abi` explicitly on those targets via a shared `cxxTestLinkerSettings`. It's harmless where the runtime is already linked (duplicate libraries are allowed), verified building cleanly under both Xcode 26.5 and the Xcode 27 beta, and it matches the existing `linkedLibrary` usage in the package.