### PR TITLE
Skip dyld shared cache images in the __cxa_throw swapper

### DIFF
--- a/Sources/KSCrashRecordingCore/KSCxaThrowSwapper.c
+++ b/Sources/KSCrashRecordingCore/KSCxaThrowSwapper.c
@@ -385,10 +385,25 @@ static bool process_segment_direct(const segment_command_t *segment, intptr_t sl
     return false;
 }
 
+// MH_DYLIB_IN_CACHE marks images resident in the dyld shared cache; older SDK
+// headers may not define it.
+#ifndef MH_DYLIB_IN_CACHE
+#define MH_DYLIB_IN_CACHE 0x80000000
+#endif
+
 static void rebind_symbols_for_image(const struct mach_header *header, intptr_t slide)
 {
     // Skip if handler is NULL (we're in reset state)
     if (atomic_load_explicit(&g_cxa_throw_handler, memory_order_acquire) == NULL) {
+        return;
+    }
+
+    // Skip images in the dyld shared cache: their __DATA_CONST is a shared,
+    // OS-managed read-only mapping. Rewriting it is tolerated on older systems
+    // but corrupts the mapping on newer ones (observed faulting the ObjC
+    // runtime's map_images on iOS 26.5), so only the app and its own
+    // (non-cache) dylibs are rebound.
+    if ((header->flags & MH_DYLIB_IN_CACHE) != 0) {
         return;
     }
 


### PR DESCRIPTION
Rewriting the __cxa_throw binding in a shared cache image's __DATA_CONST corrupts that read-only mapping on iOS 26.5 and faults the ObjC runtime in map_images during a later dlopen (seen via VideoToolbox and Metal decoder loads), reported as EXC_BAD_ACCESS in map_images_nolock. Older systems tolerated the mprotect rewrite; 26.5 does not. The same binary launches on 26.3.1 and crashes on 26.5.

This skips images with MH_DYLIB_IN_CACHE set, so only the app and its own non-cache dylibs are rebound. Uncaught C++ exceptions from system frameworks are still captured by the std::terminate handler, so only the throw-site swap for cache images is given up.