### PR TITLE
Record debugger-attached state in system info

### DIFF
--- a/Sources/KSCrashRecording/KSCrash.m
+++ b/Sources/KSCrashRecording/KSCrash.m
@@ -263,6 +263,7 @@ static void onNSExceptionHandlingEnabled(NSUncaughtExceptionHandler *uncaughtExc
         COPY_SYS_STR(osVersion, "osVersion");
         dict[@"isJailbroken"] = @(sd.isJailbroken);
         dict[@"procTranslated"] = @(sd.procTranslated);
+        dict[@"isBeingDebugged"] = @(sd.isBeingDebugged);
         COPY_SYS_TIMESTAMP(appStartTimestamp, "appStartTime");
         COPY_SYS_STR(executablePath, "executablePath");
         COPY_SYS_STR(executableName, "executableName");

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.h
@@ -98,7 +98,14 @@ typedef struct {
     uint64_t usableMemory;
     uint64_t processStartWallClockNs;  // unix epoch nanoseconds at sidecar creation
     uint64_t processStartMonotonicNs;  // CLOCK_MONOTONIC_RAW nanoseconds at sidecar creation
-    uint8_t isBeingDebugged;           // a debugger was attached (P_TRACED) at sidecar creation
+
+    // --- v2 additions ---
+    //
+    // Added in KSCrash_System_CurrentVersion=2. New fields must only be APPENDED
+    // (never reordered or inserted above) so an older v1 sidecar (shorter) reads
+    // into this struct with the trailing fields left zero-filled;
+    // kscm_system_getSystemDataForPath tolerates the short read to enable that.
+    uint8_t isBeingDebugged;  // a debugger was attached (P_TRACED) at sidecar creation
 } KSCrash_SystemData;
 
 _Static_assert(sizeof(KSCrash_SystemData) == 2992, "KSCrash_SystemData size changed — update sidecar version");

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.h
@@ -47,7 +47,7 @@ extern "C" {
 
 #define KSSYS_MAGIC ((int32_t)0x6B737973)  // 'ksys'
 
-static const uint8_t KSCrash_System_CurrentVersion = 1;
+static const uint8_t KSCrash_System_CurrentVersion = 2;
 
 /** mmap'd struct written once at init and flushed to disk by the kernel.
  *  No pointers — all data is inline so it survives across launches.
@@ -98,9 +98,10 @@ typedef struct {
     uint64_t usableMemory;
     uint64_t processStartWallClockNs;  // unix epoch nanoseconds at sidecar creation
     uint64_t processStartMonotonicNs;  // CLOCK_MONOTONIC_RAW nanoseconds at sidecar creation
+    uint8_t isBeingDebugged;           // a debugger was attached (P_TRACED) at sidecar creation
 } KSCrash_SystemData;
 
-_Static_assert(sizeof(KSCrash_SystemData) == 2984, "KSCrash_SystemData size changed — update sidecar version");
+_Static_assert(sizeof(KSCrash_SystemData) == 2992, "KSCrash_SystemData size changed — update sidecar version");
 
 // ============================================================================
 #pragma mark - API -

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
@@ -60,6 +60,7 @@
 #include <fcntl.h>
 #include <mach/mach.h>
 #include <stdatomic.h>
+#include <sys/stat.h>
 
 static KSCrash_SystemData *g_systemData = NULL;
 static KSSpinLock g_systemDataLock = KSSPINLOCK_INIT;
@@ -577,7 +578,19 @@ bool kscm_system_getSystemDataForPath(const char *path, KSCrash_SystemData *outD
     if (fd == -1) return false;
 
     KSCrash_SystemData data = { 0 };
-    bool readOK = ksfu_readBytesFromFD(fd, (char *)&data, (int)sizeof(data));
+    // Tolerate short reads: a sidecar written by an older (version < current)
+    // build is smaller than the current struct. Read what's on disk and leave
+    // the trailing newer fields zero-filled — the version check below still
+    // gates the file, and stitch consumers gate newer fields per-version.
+    // Mirrors kslifecycle_readData(). Reading exactly sizeof(data) would
+    // EOF-fail on an older sidecar and drop the previous run's system data.
+    struct stat st;
+    if (fstat(fd, &st) != 0) {
+        close(fd);
+        return false;
+    }
+    size_t bytesToRead = (size_t)st.st_size < sizeof(data) ? (size_t)st.st_size : sizeof(data);
+    bool readOK = (bytesToRead > 0) && ksfu_readBytesFromFD(fd, (char *)&data, (int)bytesToRead);
     close(fd);
 
     if (!readOK || data.magic != KSSYS_MAGIC || data.version == 0 || data.version > KSCrash_System_CurrentVersion) {

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_System.m
@@ -42,6 +42,7 @@
 #import "KSCrashMonitorContext.h"
 #include "KSCrashMonitorHelper.h"
 #import "KSDate.h"
+#import "KSDebug.h"
 #import "KSFileUtils.h"
 #import "KSJailbreak.h"
 #import "KSSpinLock.h"
@@ -434,6 +435,7 @@ static void initialize(void)
     }
     sd->isJailbroken = isJailbroken();
     sd->procTranslated = procTranslated();
+    sd->isBeingDebugged = ksdebug_isBeingTraced();
 
     sd->appStartTimestamp = (int64_t)ksdate_seconds();
 

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_SystemStitch.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_SystemStitch.m
@@ -83,6 +83,7 @@ CFDictionaryRef kscm_system_createStitchedReport(CFDictionaryRef reportDict, con
     setStringIfNonEmpty(systemDict, KSCrashField_OSVersion, sc.osVersion);
     systemDict[KSCrashField_Jailbroken] = sc.isJailbroken ? @YES : @NO;
     systemDict[KSCrashField_ProcTranslated] = sc.procTranslated ? @YES : @NO;
+    systemDict[KSCrashField_IsBeingDebugged] = sc.isBeingDebugged ? @YES : @NO;
     setTimestamp(systemDict, KSCrashField_AppStartTime, sc.appStartTimestamp);
     systemDict[KSCrashField_ProcessStartWallClockNs] = @(sc.processStartWallClockNs);
     systemDict[KSCrashField_ProcessStartMonotonicNs] = @(sc.processStartMonotonicNs);

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_SystemStitch.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_SystemStitch.m
@@ -83,7 +83,12 @@ CFDictionaryRef kscm_system_createStitchedReport(CFDictionaryRef reportDict, con
     setStringIfNonEmpty(systemDict, KSCrashField_OSVersion, sc.osVersion);
     systemDict[KSCrashField_Jailbroken] = sc.isJailbroken ? @YES : @NO;
     systemDict[KSCrashField_ProcTranslated] = sc.procTranslated ? @YES : @NO;
-    systemDict[KSCrashField_IsBeingDebugged] = sc.isBeingDebugged ? @YES : @NO;
+    // Only emit for sidecars that actually recorded it (version >= 2). For an
+    // older sidecar the field is zero-filled, and emitting `false` would read as
+    // "definitely not debugged" rather than "unknown".
+    if (sc.version >= 2) {
+        systemDict[KSCrashField_IsBeingDebugged] = sc.isBeingDebugged ? @YES : @NO;
+    }
     setTimestamp(systemDict, KSCrashField_AppStartTime, sc.appStartTimestamp);
     systemDict[KSCrashField_ProcessStartWallClockNs] = @(sc.processStartWallClockNs);
     systemDict[KSCrashField_ProcessStartMonotonicNs] = @(sc.processStartMonotonicNs);

--- a/Sources/KSCrashRecording/include/KSCrashReportFields.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportFields.h
@@ -245,6 +245,7 @@ KSCRF_DEFINE_CONSTANT(KSCrashField, Executable, executable, "CFBundleExecutable"
 KSCRF_DEFINE_CONSTANT(KSCrashField, ExecutablePath, executablePath, "CFBundleExecutablePath")
 KSCRF_DEFINE_CONSTANT(KSCrashField, Jailbroken, jailbroken, "jailbroken")
 KSCRF_DEFINE_CONSTANT(KSCrashField, ProcTranslated, procTranslated, "proc_translated")
+KSCRF_DEFINE_CONSTANT(KSCrashField, IsBeingDebugged, isBeingDebugged, "is_being_debugged")
 KSCRF_DEFINE_CONSTANT(KSCrashField, KernelVersion, kernelVersion, "kernel_version")
 KSCRF_DEFINE_CONSTANT(KSCrashField, Machine, machine, "machine")
 KSCRF_DEFINE_CONSTANT(KSCrashField, Model, model, "model")

--- a/Sources/KSCrashReportModel/Models/SystemInfo.swift
+++ b/Sources/KSCrashReportModel/Models/SystemInfo.swift
@@ -140,6 +140,9 @@ public struct SystemInfo: Codable, Sendable, Equatable {
     /// Whether the process is running under Rosetta translation.
     public let procTranslated: Bool?
 
+    /// Whether a debugger was attached to the process.
+    public let isBeingDebugged: Bool?
+
     /// Darwin kernel version string.
     public let kernelVersion: String?
 
@@ -250,6 +253,7 @@ public struct SystemInfo: Codable, Sendable, Equatable {
         deviceAppHash: String? = nil,
         jailbroken: Bool? = nil,
         procTranslated: Bool? = nil,
+        isBeingDebugged: Bool? = nil,
         kernelVersion: String? = nil,
         machine: String? = nil,
         memory: MemoryInfo? = nil,
@@ -300,6 +304,7 @@ public struct SystemInfo: Codable, Sendable, Equatable {
         self.deviceAppHash = deviceAppHash
         self.jailbroken = jailbroken
         self.procTranslated = procTranslated
+        self.isBeingDebugged = isBeingDebugged
         self.kernelVersion = kernelVersion
         self.machine = machine
         self.memory = memory
@@ -352,6 +357,7 @@ public struct SystemInfo: Codable, Sendable, Equatable {
         case deviceAppHash = "device_app_hash"
         case jailbroken
         case procTranslated = "proc_translated"
+        case isBeingDebugged = "is_being_debugged"
         case kernelVersion = "kernel_version"
         case machine
         case memory
@@ -411,6 +417,7 @@ public struct SystemInfo: Codable, Sendable, Equatable {
         deviceAppHash = try c.decodeIfPresent(String.self, forKey: .deviceAppHash)
         jailbroken = try c.decodeIfPresent(Bool.self, forKey: .jailbroken)
         procTranslated = try c.decodeIfPresent(Bool.self, forKey: .procTranslated)
+        isBeingDebugged = try c.decodeIfPresent(Bool.self, forKey: .isBeingDebugged)
         kernelVersion = try c.decodeIfPresent(String.self, forKey: .kernelVersion)
         machine = try c.decodeIfPresent(String.self, forKey: .machine)
         memory = try c.decodeIfPresent(MemoryInfo.self, forKey: .memory)
@@ -474,6 +481,7 @@ public struct SystemInfo: Codable, Sendable, Equatable {
         try c.encodeIfPresent(deviceAppHash, forKey: .deviceAppHash)
         try c.encodeIfPresent(jailbroken, forKey: .jailbroken)
         try c.encodeIfPresent(procTranslated, forKey: .procTranslated)
+        try c.encodeIfPresent(isBeingDebugged, forKey: .isBeingDebugged)
         try c.encodeIfPresent(kernelVersion, forKey: .kernelVersion)
         try c.encodeIfPresent(machine, forKey: .machine)
         try c.encodeIfPresent(memory, forKey: .memory)

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_System_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_System_Tests.m
@@ -295,4 +295,28 @@ static bool stubRunSidecarPath(const char *monitorId, char *pathBuffer, size_t p
     XCTAssertTrue(result == nil, @"createStitchedReport should return NULL for invalid magic");
 }
 
+- (void)testGetSystemDataForPath_v1Sidecar_toleratesShortReadAndZeroFills
+{
+    // A sidecar written by a v1 build ends before the appended isBeingDebugged
+    // field. The reader must tolerate the short file (not EOF-fail) and leave
+    // the new field zero-filled, rather than dropping the previous run's data.
+    KSCrash_SystemData sc = {};
+    sc.magic = KSSYS_MAGIC;
+    sc.version = 1;  // pretend this is a v1 sidecar
+    strlcpy(sc.systemName, "iOS", sizeof(sc.systemName));
+    sc.isBeingDebugged = 1;  // trailing byte we deliberately do NOT write
+
+    NSData *full = [NSData dataWithBytes:&sc length:sizeof(sc)];
+    NSData *v1 = [full subdataWithRange:NSMakeRange(0, offsetof(KSCrash_SystemData, isBeingDebugged))];
+    NSString *sidecarFile = [self.tempDir stringByAppendingPathComponent:@"System-v1.ksscr"];
+    XCTAssertTrue([v1 writeToFile:sidecarFile atomically:YES]);
+
+    KSCrash_SystemData out = {};
+    XCTAssertTrue(kscm_system_getSystemDataForPath(sidecarFile.fileSystemRepresentation, &out));
+    XCTAssertEqual(out.version, 1);
+    XCTAssertEqualObjects(@(out.systemName), @"iOS");
+    // isBeingDebugged wasn't in the v1 file → zero-filled, not the struct's garbage.
+    XCTAssertEqual(out.isBeingDebugged, 0);
+}
+
 @end


### PR DESCRIPTION
Adds an isBeingDebugged flag to the system data, sampled from ksdebug_isBeingTraced() (P_TRACED) at sidecar creation and threaded through the system stitch into the report's system section, the SystemInfo report model, and the -systemInfo accessor.

This lets a consumer tell a run that was being debugged apart from a normal one. A debugger SIGKILL (an Xcode stop) is uncatchable and leaves no signal report, so a next launch termination heuristic can otherwise misread it as a crash. With the flag on the report, that case can be filtered out.

The flag is appended at the end of KSCrash_SystemData so older sidecars keep their field offsets. KSCrash_System_CurrentVersion goes to 2 and the size assert updates to match.