### PR TITLE
Use effective monitor mask when registering monitors

### DIFF
--- a/Sources/KSCrashRecording/KSCrashC.c
+++ b/Sources/KSCrashRecording/KSCrashC.c
@@ -107,7 +107,6 @@ static atomic_bool g_installed = false;
 static bool g_shouldAddConsoleLogToReport = false;
 static bool g_shouldPrintPreviousLog = false;
 static char g_consoleLogPath[KSFU_MAX_PATH_LENGTH];
-static KSCrashMonitorType g_monitoring = KSCrashMonitorTypeProductionSafeMinimal;
 static char g_lastCrashReportFilePath[KSFU_MAX_PATH_LENGTH];
 static KSCrashReportStoreCConfiguration g_reportStoreConfig;
 // TODO: Remove in 3.0
@@ -305,12 +304,12 @@ static void setMonitors(KSCrashMonitorType monitorTypes)
     // Infrastructure monitors (System, Lifecycle, UserInfo, Resource) are
     // always enabled. They collect context that every report depends on
     // and are not crash detectors, so there is no reason to disable them.
-    g_monitoring = monitorTypes | KSCrashMonitorTypeRequired;
+    const KSCrashMonitorType effectiveMonitorTypes = monitorTypes | KSCrashMonitorTypeRequired;
 
     for (size_t i = 0; i < g_monitorMappingCount; i++) {
         KSCrashMonitorAPI *api = g_monitorMappings[i].getAPI();
         if (api != NULL) {
-            if (monitorTypes & g_monitorMappings[i].type) {
+            if (effectiveMonitorTypes & g_monitorMappings[i].type) {
                 kscm_addMonitor(api);
             } else {
                 kscm_removeMonitor(api);
@@ -652,6 +651,9 @@ bool kscrash_testcode_deriveReportsSiblingDir(const char *reportsPath, const cha
 {
     return deriveReportsSiblingDir(reportsPath, installPath, subdir, out, outSize);
 }
+
+__attribute__((unused))  // For tests. Declared as extern in TestCase
+void kscrash_testcode_setMonitors(KSCrashMonitorType monitorTypes) { setMonitors(monitorTypes); }
 
 __attribute__((unused))  // For tests. Declared as extern in TestCase
 void kscrash_testcode_setLastRunID(const char *runID)

--- a/Sources/KSCrashRecording/KSCrashC.c
+++ b/Sources/KSCrashRecording/KSCrashC.c
@@ -653,7 +653,10 @@ bool kscrash_testcode_deriveReportsSiblingDir(const char *reportsPath, const cha
 }
 
 __attribute__((unused))  // For tests. Declared as extern in TestCase
-void kscrash_testcode_setMonitors(KSCrashMonitorType monitorTypes) { setMonitors(monitorTypes); }
+void kscrash_testcode_setMonitors(KSCrashMonitorType monitorTypes)
+{
+    setMonitors(monitorTypes);
+}
 
 __attribute__((unused))  // For tests. Declared as extern in TestCase
 void kscrash_testcode_setLastRunID(const char *runID)

--- a/Tests/KSCrashRecordingTests/KSCrashMonitorSelection_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitorSelection_Tests.m
@@ -1,0 +1,62 @@
+//
+//  KSCrashMonitorSelection_Tests.m
+//
+//  Created by Mischan Toosarani-Hausberger on 2026-07-09.
+//
+//  Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "KSCrashMonitor.h"
+#import "KSCrashMonitorType.h"
+
+extern void kscm_testcode_resetState(void);
+extern void kscrash_testcode_setMonitors(KSCrashMonitorType monitorTypes);
+
+@interface KSCrashMonitorSelection_Tests : XCTestCase
+@end
+
+@implementation KSCrashMonitorSelection_Tests
+
+- (void)setUp
+{
+    [super setUp];
+    kscm_testcode_resetState();
+}
+
+- (void)testCustomMonitorMaskRegistersRequiredInfrastructureMonitors
+{
+    kscrash_testcode_setMonitors(KSCrashMonitorTypeUserReported);
+
+    XCTAssertNotEqual(kscm_getMonitor("UserReported"), NULL);
+    XCTAssertNotEqual(kscm_getMonitor("System"), NULL);
+    XCTAssertNotEqual(kscm_getMonitor("Lifecycle"), NULL);
+    XCTAssertNotEqual(kscm_getMonitor("UserInfo"), NULL);
+    XCTAssertNotEqual(kscm_getMonitor("Resource"), NULL);
+
+    XCTAssertEqual(kscm_getMonitor("Signal"), NULL);
+    XCTAssertEqual(kscm_getMonitor("MachException"), NULL);
+    XCTAssertEqual(kscm_getMonitor("NSException"), NULL);
+    XCTAssertEqual(kscm_getMonitor("Zombie"), NULL);
+}
+
+@end


### PR DESCRIPTION
This is both a fix and a question for something that popped up during experimentation with monitors: when `setMonitors()` sets the monitors from the configuration, it ORs in required infrastructure monitors

https://github.com/kstenerud/KSCrash/blob/c3557af43e616131de46a1ed54558f5f7cfc47c8/Sources/KSCrashRecording/KSCrashC.c#L305-L308

however, that static global `g_monitoring` was already initialized with a value (which is never read before being overwritten in `setMonitors()`) 

https://github.com/kstenerud/KSCrash/blob/c3557af43e616131de46a1ed54558f5f7cfc47c8/Sources/KSCrashRecording/KSCrashC.c#L110

and then it is never used again, but instead `setMonitors()` uses the passed-in configuration parameter `monitorTypes` to decide whether a monitor should be added or removed

https://github.com/kstenerud/KSCrash/blob/62039fc55f3f673fefb3644099f646ae3c30fc5e/Sources/KSCrashRecording/KSCrashC.c#L233-L237

This means that passing in any non-default monitor flags could potentially uninstall required infrastructure monitors (I added a test that went red before I wrote the fix).

My assumption for this fix is:

* the initialization of the static global `g_monitoring` is no longer required, since no one reads that value and `KSCrashCConfiguration_Default()` initializes the monitor configuration to `KSCrashMonitorTypeProductionSafeMinimal` anyway
* `g_monitoring` itself might no longer be needed as a static global and can be replaced with a local inside `setMonitors()`
* the add/remove decision inside `setMonitors()` should be based on the monitor type flags in that variable and _not_ the incoming parameter `monitorTypes`

Does that make sense, or am I missing essential context? I am rather careful here because that seems like core behavior, and maybe you wanted to extend the use of the global later.