### PR TITLE
Record debugger-attached state in the run summary

### DIFF
--- a/Sources/KSCrashRecording/KSCrashRunContext.m
+++ b/Sources/KSCrashRecording/KSCrashRunContext.m
@@ -590,6 +590,7 @@ static KSCrashRunSummary *buildSummary(const KSCrashRunContext *ctx, const char 
                                                       users:users
                                                 startedAtMs:startedAtMs
                                                   endedAtMs:endedAtMs
+                                            isBeingDebugged:sys->isBeingDebugged != 0
                                                     outcome:outcome
                                                   durations:durations
                                                    sessions:sessions

--- a/Sources/KSCrashRecording/KSCrashRunSummary.m
+++ b/Sources/KSCrashRecording/KSCrashRunSummary.m
@@ -454,12 +454,12 @@ static KSCrashRunSummaryHostKind hostKindFromWireString(NSString *value)
     if (userIDValue != nil && userIDValue != (id)kCFNull) {
         if (![userIDValue isKindOfClass:[NSString class]]) {
             if (error != NULL) {
-                *error = [NSError
-                    errorWithDomain:NSCocoaErrorDomain
-                               code:NSFileReadCorruptFileError
-                           userInfo:@{
-                               NSLocalizedDescriptionKey : @"Run summary JSON has a wrong-typed optional field."
-                           }];
+                *error =
+                    [NSError errorWithDomain:NSCocoaErrorDomain
+                                        code:NSFileReadCorruptFileError
+                                    userInfo:@{
+                                        NSLocalizedDescriptionKey : @"Run summary JSON has a wrong-typed user_id field."
+                                    }];
             }
             return nil;
         }
@@ -474,12 +474,12 @@ static KSCrashRunSummaryHostKind hostKindFromWireString(NSString *value)
     if (isBeingDebuggedValue != nil && isBeingDebuggedValue != (id)kCFNull) {
         if (!isJSONBoolean(isBeingDebuggedValue)) {
             if (error != NULL) {
-                *error = [NSError
-                    errorWithDomain:NSCocoaErrorDomain
-                               code:NSFileReadCorruptFileError
-                           userInfo:@{
-                               NSLocalizedDescriptionKey : @"Run summary JSON has a wrong-typed optional field."
-                           }];
+                *error = [NSError errorWithDomain:NSCocoaErrorDomain
+                                             code:NSFileReadCorruptFileError
+                                         userInfo:@{
+                                             NSLocalizedDescriptionKey :
+                                                 @"Run summary JSON has a wrong-typed is_being_debugged field."
+                                         }];
             }
             return nil;
         }

--- a/Sources/KSCrashRecording/KSCrashRunSummary.m
+++ b/Sources/KSCrashRecording/KSCrashRunSummary.m
@@ -154,6 +154,7 @@
                                 users:(KSCrashRunSummaryUsers *)users
                           startedAtMs:(int64_t)startedAtMs
                             endedAtMs:(int64_t)endedAtMs
+                      isBeingDebugged:(BOOL)isBeingDebugged
                               outcome:(KSCrashRunSummaryOutcome *)outcome
                             durations:(KSCrashRunSummaryDurations *)durations
                              sessions:(KSCrashRunSummarySessions *)sessions
@@ -170,6 +171,7 @@
         _users = users;
         _startedAtMs = startedAtMs;
         _endedAtMs = endedAtMs;
+        _isBeingDebugged = isBeingDebugged;
         _outcome = outcome;
         _durations = durations;
         _sessions = sessions;
@@ -213,6 +215,7 @@ static NSString *hostKindWireString(KSCrashRunSummaryHostKind kind)
     };
     dict[@"started_at_ms"] = @(self.startedAtMs);
     dict[@"ended_at_ms"] = @(self.endedAtMs);
+    dict[@"is_being_debugged"] = self.isBeingDebugged ? @YES : @NO;
     dict[@"outcome"] = @{
         @"termination_reason" : @(kstermination_reasonToString(self.outcome.terminationReason)),
         // @YES / @NO wrap CFBoolean so KSJSONCodec emits JSON booleans; a
@@ -463,6 +466,26 @@ static KSCrashRunSummaryHostKind hostKindFromWireString(NSString *value)
         userID = (NSString *)userIDValue;
     }
 
+    // is_being_debugged was added after the first shipped summaries, so a
+    // payload written by an older SDK lacks the key; that decodes as NO
+    // rather than failing. A present non-boolean still fails the decode.
+    id isBeingDebuggedValue = dict[@"is_being_debugged"];
+    BOOL isBeingDebugged = NO;
+    if (isBeingDebuggedValue != nil && isBeingDebuggedValue != (id)kCFNull) {
+        if (!isJSONBoolean(isBeingDebuggedValue)) {
+            if (error != NULL) {
+                *error = [NSError
+                    errorWithDomain:NSCocoaErrorDomain
+                               code:NSFileReadCorruptFileError
+                           userInfo:@{
+                               NSLocalizedDescriptionKey : @"Run summary JSON has a wrong-typed optional field."
+                           }];
+            }
+            return nil;
+        }
+        isBeingDebugged = [(NSNumber *)isBeingDebuggedValue boolValue];
+    }
+
     KSCrashRunSummaryOutcome *outcome = [[KSCrashRunSummaryOutcome alloc]
         initWithTerminationReason:kstermination_reasonFromString(reasonString.UTF8String)
                     cleanShutdown:cleanShutdown
@@ -495,6 +518,7 @@ static KSCrashRunSummaryHostKind hostKindFromWireString(NSString *value)
                                                       users:users
                                                 startedAtMs:startedAtMs
                                                   endedAtMs:endedAtMs
+                                            isBeingDebugged:isBeingDebugged
                                                     outcome:outcome
                                                   durations:durations
                                                    sessions:sessions

--- a/Sources/KSCrashRecording/include/KSCrashRunSummary.h
+++ b/Sources/KSCrashRecording/include/KSCrashRunSummary.h
@@ -246,6 +246,11 @@ __attribute__((objc_subclassing_restricted))
 /** Unix epoch milliseconds (wall clock). */
 @property(nonatomic, readonly) int64_t endedAtMs;
 
+/** Whether a debugger was attached (P_TRACED) to the run, sampled at process
+ *  start. NO when the run's sidecar predates the field.
+ */
+@property(nonatomic, readonly) BOOL isBeingDebugged;
+
 @property(nonatomic, readonly, strong) KSCrashRunSummaryOutcome *outcome;
 @property(nonatomic, readonly, strong) KSCrashRunSummaryDurations *durations;
 @property(nonatomic, readonly, strong) KSCrashRunSummarySessions *sessions;
@@ -264,6 +269,7 @@ __attribute__((objc_subclassing_restricted))
                                 users:(KSCrashRunSummaryUsers *)users
                           startedAtMs:(int64_t)startedAtMs
                             endedAtMs:(int64_t)endedAtMs
+                      isBeingDebugged:(BOOL)isBeingDebugged
                               outcome:(KSCrashRunSummaryOutcome *)outcome
                             durations:(KSCrashRunSummaryDurations *)durations
                              sessions:(KSCrashRunSummarySessions *)sessions

--- a/Tests/KSCrashFiltersTests/KSCrashRunFilter_Tests.m
+++ b/Tests/KSCrashFiltersTests/KSCrashRunFilter_Tests.m
@@ -82,6 +82,7 @@
                                                       users:users
                                                 startedAtMs:0
                                                   endedAtMs:100
+                                            isBeingDebugged:NO
                                                     outcome:outcome
                                                   durations:durations
                                                    sessions:sessions

--- a/Tests/KSCrashRecordingTests/KSCrashReportStore_RunSummary_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashReportStore_RunSummary_Tests.m
@@ -113,6 +113,7 @@
                                                       users:users
                                                 startedAtMs:0
                                                   endedAtMs:100
+                                            isBeingDebugged:NO
                                                     outcome:outcome
                                                   durations:durations
                                                    sessions:sessions

--- a/Tests/KSCrashRecordingTests/KSCrashRunContext_Summary_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashRunContext_Summary_Tests.m
@@ -84,6 +84,7 @@ static void populateContext(KSCrashRunContext *ctx)
     strlcpy(ctx->system.deviceAppHash, "0123456789abcdef0123456789abcdef", sizeof(ctx->system.deviceAppHash));
     ctx->system.procTranslated = 0;
     ctx->system.isJailbroken = 0;
+    ctx->system.isBeingDebugged = 0;
 }
 
 @interface KSCrashRunContext_Summary_Tests : XCTestCase
@@ -126,6 +127,7 @@ static void populateContext(KSCrashRunContext *ctx)
 
     XCTAssertEqual(summary.startedAtMs, 1744000000000LL);
     XCTAssertEqual(summary.endedAtMs, 1744000180000LL);
+    XCTAssertFalse(summary.isBeingDebugged);
 
     XCTAssertEqual(summary.outcome.terminationReason, KSTerminationReasonCrash);
     XCTAssertFalse(summary.outcome.cleanShutdown);
@@ -175,6 +177,19 @@ static void populateContext(KSCrashRunContext *ctx)
     KSCrashRunSummary *summary = ksruncontext_testcode_buildSummary(&ctx, NULL);
 
     XCTAssertEqual(summary.app.hostKind, KSCrashRunSummaryHostKindExtension);
+}
+
+// Like hostKind, the flag comes from the *previous* run's stored sidecar
+// byte, not from the current process's debugger state.
+- (void)test_buildSummary_isBeingDebuggedComesFromSidecar
+{
+    KSCrashRunContext ctx;
+    populateContext(&ctx);
+    ctx.system.isBeingDebugged = 1;
+
+    KSCrashRunSummary *summary = ksruncontext_testcode_buildSummary(&ctx, NULL);
+
+    XCTAssertTrue(summary.isBeingDebugged);
 }
 
 - (void)test_buildSummary_extendsActiveWithOpenTailSlice

--- a/Tests/KSCrashRecordingTests/KSCrashRunSummary_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashRunSummary_Tests.m
@@ -172,6 +172,7 @@
                                                    users:users
                                              startedAtMs:1744000000000
                                                endedAtMs:1744000180000
+                                         isBeingDebugged:YES
                                                  outcome:outcome
                                                durations:durations
                                                 sessions:sessions
@@ -186,6 +187,7 @@
     XCTAssertEqualObjects(summary.userID, @"bob");
     XCTAssertEqual(summary.startedAtMs, 1744000000000);
     XCTAssertEqual(summary.endedAtMs, 1744000180000);
+    XCTAssertTrue(summary.isBeingDebugged);
     XCTAssertIdentical(summary.outcome, outcome);
     XCTAssertIdentical(summary.durations, durations);
     XCTAssertIdentical(summary.sessions, sessions);
@@ -226,6 +228,7 @@
                                                                             users:users
                                                                       startedAtMs:0
                                                                         endedAtMs:0
+                                                                  isBeingDebugged:NO
                                                                           outcome:outcome
                                                                         durations:durations
                                                                          sessions:sessions
@@ -251,6 +254,7 @@
         @"users" : @ { @"perceptible_count" : @0, @"imperceptible_count" : @0 },
         @"started_at_ms" : @0,
         @"ended_at_ms" : @0,
+        @"is_being_debugged" : @NO,
         @"outcome" : @ {
             @"termination_reason" : @"clean",
             @"clean_shutdown" : @YES,
@@ -344,6 +348,42 @@
     XCTAssertNil(summary.userID);
 }
 
+- (void)test_decoder_readsIsBeingDebugged
+{
+    NSMutableDictionary *dict = [self fullyValidWireDict];
+    dict[@"is_being_debugged"] = @YES;
+    KSCrashRunSummary *summary = [KSCrashRunSummary summaryFromJSONData:[self jsonDataFromDict:dict] error:nil];
+    XCTAssertNotNil(summary);
+    XCTAssertTrue(summary.isBeingDebugged);
+}
+
+- (void)test_decoder_toleratesMissingIsBeingDebugged
+{
+    NSMutableDictionary *dict = [self fullyValidWireDict];
+    // Payloads written before the field existed lack the key; unknown decodes
+    // as NO rather than failing.
+    [dict removeObjectForKey:@"is_being_debugged"];
+    KSCrashRunSummary *summary = [KSCrashRunSummary summaryFromJSONData:[self jsonDataFromDict:dict] error:nil];
+    XCTAssertNotNil(summary);
+    XCTAssertFalse(summary.isBeingDebugged);
+}
+
+- (void)test_encoder_roundTripsIsBeingDebugged
+{
+    NSMutableDictionary *dict = [self fullyValidWireDict];
+    dict[@"is_being_debugged"] = @YES;
+    KSCrashRunSummary *summary = [KSCrashRunSummary summaryFromJSONData:[self jsonDataFromDict:dict] error:nil];
+
+    NSData *encoded = summary.jsonData;
+    XCTAssertNotNil(encoded);
+    NSDictionary *json = [NSJSONSerialization JSONObjectWithData:encoded options:0 error:nil];
+    XCTAssertEqualObjects(json[@"is_being_debugged"], @YES);
+
+    KSCrashRunSummary *decoded = [KSCrashRunSummary summaryFromJSONData:encoded error:nil];
+    XCTAssertNotNil(decoded);
+    XCTAssertTrue(decoded.isBeingDebugged);
+}
+
 - (void)test_decoder_rejectsNonDictionaryRoot
 {
     NSData *rootArray = [NSJSONSerialization dataWithJSONObject:@[ @"not a dict" ] options:0 error:nil];
@@ -422,6 +462,12 @@
     NSMutableDictionary *device = [dict[@"device"] mutableCopy];
     device[@"is_translated"] = @1;
     dict[@"device"] = device;
+    XCTAssertNil([KSCrashRunSummary summaryFromJSONData:[self jsonDataFromDict:dict] error:nil]);
+
+    // is_being_debugged is optional, but a present non-boolean is a schema
+    // violation and rejects the whole summary, same as user_id.
+    dict = [self fullyValidWireDict];
+    dict[@"is_being_debugged"] = @1;
     XCTAssertNil([KSCrashRunSummary summaryFromJSONData:[self jsonDataFromDict:dict] error:nil]);
 }
 

--- a/Tests/KSCrashReportModelTests/RunSummaryCodableTests.swift
+++ b/Tests/KSCrashReportModelTests/RunSummaryCodableTests.swift
@@ -35,6 +35,7 @@ final class RunSummaryCodableTests: XCTestCase {
         userID: String? = "bob",
         perceptibleUserCount: Int = 2,
         imperceptibleUserCount: Int = 1,
+        isBeingDebugged: Bool = false,
         terminationReason: KSCrashRecording.TerminationReason = .clean,
         hostKind: RunSummary.HostKind = .app
     ) -> RunSummary {
@@ -70,6 +71,7 @@ final class RunSummaryCodableTests: XCTestCase {
             users: users,
             startedAtMs: 1_744_000_000_000,
             endedAtMs: 1_744_000_180_000,
+            isBeingDebugged: isBeingDebugged,
             outcome: outcome,
             durations: durations,
             sessions: sessions,
@@ -98,6 +100,7 @@ final class RunSummaryCodableTests: XCTestCase {
         XCTAssertEqual(decoded.users.imperceptibleCount, original.users.imperceptibleCount)
         XCTAssertEqual(decoded.startedAtMs, original.startedAtMs)
         XCTAssertEqual(decoded.endedAtMs, original.endedAtMs)
+        XCTAssertEqual(decoded.isBeingDebugged, original.isBeingDebugged)
         XCTAssertEqual(decoded.outcome.terminationReason, original.outcome.terminationReason)
         XCTAssertEqual(decoded.outcome.cleanShutdown, original.outcome.cleanShutdown)
         XCTAssertEqual(decoded.outcome.fatalReported, original.outcome.fatalReported)
@@ -128,6 +131,13 @@ final class RunSummaryCodableTests: XCTestCase {
         XCTAssertNil(decoded.userID)
     }
 
+    func test_roundtrip_isBeingDebugged() throws {
+        let original = makeSummary(isBeingDebugged: true)
+        let data = try XCTUnwrap(original.jsonData())
+        let decoded = try RunSummary.decode(from: data)
+        XCTAssertTrue(decoded.isBeingDebugged)
+    }
+
     // MARK: - Wire format
 
     func test_wireFormat_usesSnakeCaseKeys() throws {
@@ -142,6 +152,7 @@ final class RunSummaryCodableTests: XCTestCase {
         XCTAssertNotNil(json["users"])
         XCTAssertNotNil(json["started_at_ms"])
         XCTAssertNotNil(json["ended_at_ms"])
+        XCTAssertNotNil(json["is_being_debugged"])
         XCTAssertNotNil(json["durations_ms"])
 
         let outcome = try XCTUnwrap(json["outcome"] as? [String: Any])


### PR DESCRIPTION
#862 added an `is_being_debugged` flag to the crash report's system section so a consumer can tell a debugged run apart from a normal one. This adds the same flag to the run summary: `KSCrashRunSummary` gains an `isBeingDebugged` property sourced from the previous run's System sidecar, and the wire format emits `is_being_debugged` alongside the other top-level fields.

The flag is a plain boolean, and false doubles as unknown: a v1 System sidecar zero-fills the field, and a summary payload written by an older SDK lacks the wire key, which the decoder reads as false instead of failing. The change is additive, so `schema_version` stays at 1.