### PR TITLE
Reject embedded JSON that cannot be written instead of writing part of it

### DIFF
--- a/.github/data/benchmark-tests.json
+++ b/.github/data/benchmark-tests.json
@@ -106,6 +106,10 @@
     { "name": "EncodeArrays", "category": "json", "description": "Encode arrays (50 items)", "notes": "Backtrace addresses" },
     { "name": "EncodeHexData", "category": "json", "description": "Encode hex data (10x256B)", "notes": "Memory dumps" },
     { "name": "EncodeTypicalCrashReport", "category": "json", "description": "Full crash report", "notes": "10 threads, 30 frames each" },
+    { "name": "EmbedJSONElement", "category": "json", "description": "Embed JSON element (20 fields)", "notes": "Pre-formatted payload, decoded and re-encoded" },
+    { "name": "EmbedLargeJSONElement", "category": "json", "description": "Embed JSON element (500 fields)", "notes": "Larger pre-formatted payload" },
+    { "name": "CheckJSONElement", "category": "json", "description": "Check JSON element (100x)", "notes": "Validation only, no encoding" },
+    { "name": "EmbedJSONFromFile", "category": "json", "description": "Embed JSON from file (20 fields)", "notes": "Pre-formatted payload read from disk" },
 
     { "name": "ThreadSelf", "category": "thread", "description": "Get current thread", "iterations": 10000 },
     { "name": "GetThreadName", "category": "thread", "description": "Get thread name", "iterations": 1000 },

--- a/Sources/KSCrashCore/include/KSCrashNamespace.h
+++ b/Sources/KSCrashCore/include/KSCrashNamespace.h
@@ -414,6 +414,8 @@
 #define ksjson_beginEncode KSCRASH_NS(ksjson_beginEncode)
 #define ksjson_beginObject KSCRASH_NS(ksjson_beginObject)
 #define ksjson_beginStringElement KSCRASH_NS(ksjson_beginStringElement)
+#define ksjson_checkJSONElement KSCRASH_NS(ksjson_checkJSONElement)
+#define ksjson_checkJSONFile KSCRASH_NS(ksjson_checkJSONFile)
 #define ksjson_decode KSCRASH_NS(ksjson_decode)
 #define ksjson_endContainer KSCRASH_NS(ksjson_endContainer)
 #define ksjson_endDataElement KSCRASH_NS(ksjson_endDataElement)

--- a/Sources/KSCrashRecording/KSCrashReportC.c
+++ b/Sources/KSCrashRecording/KSCrashReportC.c
@@ -1746,6 +1746,14 @@ void kscrashreport_writeStandardReport(KSCrash_MonitorContext *const monitorCont
         // Acquire lock to read userInfo (async-signal-safe bounded spin)
         bool userInfoLocked = ks_spinlock_lock_bounded(&g_userInfoLock);
 
+        // Success with an object payload leaves the user container open
+        // (closeLastContainer=false) for the user-section callback below. Everything else
+        // must not run the callback: a failed decode rebalances everything closed (having
+        // already emitted a complete "user" error element) and a scalar payload is rejected
+        // the same way, so there is nothing to write into; an array payload leaves an array
+        // open, which cannot take the callback's keyed fields (array elements are nameless),
+        // so it is only closed.
+        const int entryLevel = getJsonContext(writer)->containerLevel;
         if (userInfoLocked && g_userInfoJSON != NULL) {
             addJSONElement(writer, KSCrashField_User, g_userInfoJSON, false);
             ksfu_flushBufferedWriter(&bufferedWriter);
@@ -1758,12 +1766,15 @@ void kscrashreport_writeStandardReport(KSCrash_MonitorContext *const monitorCont
             ks_spinlock_unlock(&g_userInfoLock);
         }
 
-        if (g_userSectionWriteCallback != NULL) {
-            ksfu_flushBufferedWriter(&bufferedWriter);
-            KSCrash_ExceptionHandlingPlan plan = ksexc_monitorContextToPlan(monitorContext);
-            g_userSectionWriteCallback(&plan, writer);
+        KSJSONEncodeContext *userJsonContext = getJsonContext(writer);
+        if (userJsonContext->containerLevel > entryLevel) {
+            if (g_userSectionWriteCallback != NULL && userJsonContext->isObject[userJsonContext->containerLevel]) {
+                ksfu_flushBufferedWriter(&bufferedWriter);
+                KSCrash_ExceptionHandlingPlan plan = ksexc_monitorContextToPlan(monitorContext);
+                g_userSectionWriteCallback(&plan, writer);
+            }
+            writer->endContainer(writer);
         }
-        writer->endContainer(writer);
         ksfu_flushBufferedWriter(&bufferedWriter);
 
         writeDebugInfo(writer, KSCrashField_Debug, monitorContext);

--- a/Sources/KSCrashRecording/KSCrashReportC.c
+++ b/Sources/KSCrashRecording/KSCrashReportC.c
@@ -305,35 +305,54 @@ static void addUUIDElement(const KSCrashReportWriter *const writer, const char *
     }
 }
 
+/** Stand in for a payload the codec refused.
+ *
+ * The codec rejects whole, writing nothing, so this error object becomes the element
+ * rather than appearing beside a half-written one. It honors closeLastContainer so that
+ * success and failure hand the caller back the same shape.
+ *
+ * @param source The rejected payload, or the path it came from, recorded verbatim.
+ */
+static void addJSONErrorElement(const KSCrashReportWriter *const writer, const char *const key, const int jsonResult,
+                                const char *const source, bool closeLastContainer)
+{
+    char errorBuff[100];
+    const char *errStr = ksjson_stringForError(jsonResult);
+    size_t prefixLen = sizeof("Invalid JSON data: ") - 1;
+    size_t errLen = strlen(errStr);
+    size_t totalLen = prefixLen + errLen;
+    if (totalLen >= sizeof(errorBuff)) {
+        totalLen = sizeof(errorBuff) - 1;
+        errLen = totalLen - prefixLen;
+    }
+    memcpy(errorBuff, "Invalid JSON data: ", prefixLen);
+    memcpy(errorBuff + prefixLen, errStr, errLen);
+    errorBuff[totalLen] = '\0';
+    ksjson_beginObject(getJsonContext(writer), key);
+    ksjson_addStringElement(getJsonContext(writer), KSCrashField_Error, errorBuff, KSJSON_SIZE_AUTOMATIC);
+    ksjson_addStringElement(getJsonContext(writer), KSCrashField_JSONData, source, KSJSON_SIZE_AUTOMATIC);
+    if (closeLastContainer) {
+        ksjson_endContainer(getJsonContext(writer));
+    }
+}
+
 static void addJSONElement(const KSCrashReportWriter *const writer, const char *const key,
                            const char *const jsonElement, bool closeLastContainer)
 {
     int jsonResult =
         ksjson_addJSONElement(getJsonContext(writer), key, jsonElement, (int)strlen(jsonElement), closeLastContainer);
     if (jsonResult != KSJSON_OK) {
-        char errorBuff[100];
-        const char *errStr = ksjson_stringForError(jsonResult);
-        size_t prefixLen = sizeof("Invalid JSON data: ") - 1;
-        size_t errLen = strlen(errStr);
-        size_t totalLen = prefixLen + errLen;
-        if (totalLen >= sizeof(errorBuff)) {
-            totalLen = sizeof(errorBuff) - 1;
-            errLen = totalLen - prefixLen;
-        }
-        memcpy(errorBuff, "Invalid JSON data: ", prefixLen);
-        memcpy(errorBuff + prefixLen, errStr, errLen);
-        errorBuff[totalLen] = '\0';
-        ksjson_beginObject(getJsonContext(writer), key);
-        ksjson_addStringElement(getJsonContext(writer), KSCrashField_Error, errorBuff, KSJSON_SIZE_AUTOMATIC);
-        ksjson_addStringElement(getJsonContext(writer), KSCrashField_JSONData, jsonElement, KSJSON_SIZE_AUTOMATIC);
-        ksjson_endContainer(getJsonContext(writer));
+        addJSONErrorElement(writer, key, jsonResult, jsonElement, closeLastContainer);
     }
 }
 
 static void addJSONElementFromFile(const KSCrashReportWriter *const writer, const char *const key,
                                    const char *const filePath, bool closeLastContainer)
 {
-    ksjson_addJSONFromFile(getJsonContext(writer), key, filePath, closeLastContainer);
+    int jsonResult = ksjson_addJSONFromFile(getJsonContext(writer), key, filePath, closeLastContainer);
+    if (jsonResult != KSJSON_OK) {
+        addJSONErrorElement(writer, key, jsonResult, filePath, closeLastContainer);
+    }
 }
 
 static void beginObject(const KSCrashReportWriter *const writer, const char *const key)
@@ -1746,13 +1765,6 @@ void kscrashreport_writeStandardReport(KSCrash_MonitorContext *const monitorCont
         // Acquire lock to read userInfo (async-signal-safe bounded spin)
         bool userInfoLocked = ks_spinlock_lock_bounded(&g_userInfoLock);
 
-        // Success with an object payload leaves the user container open
-        // (closeLastContainer=false) for the user-section callback below. Everything else
-        // must not run the callback: a failed decode rebalances everything closed (having
-        // already emitted a complete "user" error element) and a scalar payload is rejected
-        // the same way, so there is nothing to write into; an array payload leaves an array
-        // open, which cannot take the callback's keyed fields (array elements are nameless),
-        // so it is only closed.
         const int entryLevel = getJsonContext(writer)->containerLevel;
         if (userInfoLocked && g_userInfoJSON != NULL) {
             addJSONElement(writer, KSCrashField_User, g_userInfoJSON, false);
@@ -1766,6 +1778,12 @@ void kscrashreport_writeStandardReport(KSCrash_MonitorContext *const monitorCont
             ks_spinlock_unlock(&g_userInfoLock);
         }
 
+        // What "user" turned out to be decides what happens here. An object, whether the
+        // payload's own or the error object standing in for a rejected one, takes the
+        // callback's fields and is closed. An array is closed unwritten, since array
+        // elements are nameless and the callback writes keyed fields. A scalar payload
+        // (legal JSON, "user":"..." ) opened nothing at all, so closing here would close
+        // the report root instead.
         KSJSONEncodeContext *userJsonContext = getJsonContext(writer);
         if (userJsonContext->containerLevel > entryLevel) {
             if (g_userSectionWriteCallback != NULL && userJsonContext->isObject[userJsonContext->containerLevel]) {

--- a/Sources/KSCrashRecordingCore/KSJSONCodec.c
+++ b/Sources/KSCrashRecordingCore/KSJSONCodec.c
@@ -1098,7 +1098,9 @@ static void updateDecoder_readFile(struct JSONFromFileContext *context)
             unlikely_if(bytesRead < fillLength)
             {
                 if (bytesRead < 0) {
-                    KSLOG_ERROR("Error reading file %s: %s", context->sourceFilename, strerror(errno));
+                    // errno numerically, not via strerror: this runs at crash time and
+                    // Apple's strerror calloc()s its return buffer.
+                    KSLOG_ERROR("Error reading file %s: errno %d", context->sourceFilename, errno);
                     bytesRead = 0;
                 }
                 // The read fell short, so the file is done. Pull the end in to the last byte

--- a/Sources/KSCrashRecordingCore/KSJSONCodec.c
+++ b/Sources/KSCrashRecordingCore/KSJSONCodec.c
@@ -1223,7 +1223,9 @@ int ksjson_addJSONFromFile(KSJSONEncodeContext *const encodeContext, const char 
 
     int result = decodeElement(name, &decodeContext);
     close(fd);
-    while (closeLastContainer && encodeContext->containerLevel > containerLevel) {
+    // On failure, always rebalance: a partial decode leaves containers open, and leaving
+    // them dangling would nest everything written afterwards inside this element.
+    while ((closeLastContainer || result != KSJSON_OK) && encodeContext->containerLevel > containerLevel) {
         ksjson_endContainer(encodeContext);
     }
 
@@ -1272,7 +1274,9 @@ int ksjson_addJSONElement(KSJSONEncodeContext *const encodeContext, const char *
     int containerLevel = encodeContext->containerLevel;
 
     int result = decodeElement(name, &decodeContext);
-    while (closeLastContainer && encodeContext->containerLevel > containerLevel) {
+    // On failure, always rebalance: a partial decode leaves containers open, and leaving
+    // them dangling would nest everything written afterwards inside this element.
+    while ((closeLastContainer || result != KSJSON_OK) && encodeContext->containerLevel > containerLevel) {
         ksjson_endContainer(encodeContext);
     }
 

--- a/Sources/KSCrashRecordingCore/KSJSONCodec.c
+++ b/Sources/KSCrashRecordingCore/KSJSONCodec.c
@@ -533,7 +533,12 @@ int ksjson_endEncode(KSJSONEncodeContext *const context)
 
 #define INV 0x11111
 
-typedef struct {
+struct KSJSONDecodeContext;
+
+/** Pull more data into the decode window. See requestMoreData(). */
+typedef int (*KSJSONRefillFunc)(struct KSJSONDecodeContext *context, const char *preserveFrom);
+
+typedef struct KSJSONDecodeContext {
     /** Pointer to current work area in the buffer. */
     const char *bufferPtr;
     /** Pointer to the end of the buffer. */
@@ -546,11 +551,88 @@ typedef struct {
     char *stringBuffer;
     /** Length of the string buffer. */
     int stringBufferLength;
+    /** True when bufferEnd is the end of the data itself rather than the end of a window
+     * onto more of it. A number has no closing delimiter, so this is what separates "the
+     * number ends here" from "read more before deciding". */
+    bool bufferEndIsEOF;
+    /** Pulls more data into the window, or NULL when the data is all in memory. Set by
+     * whoever owns the buffer, since only they know where the rest of it lives. */
+    KSJSONRefillFunc refill;
     /** The callbacks to call while decoding. */
     KSJSONDecodeCallbacks *const callbacks;
     /** Data that was specified when calling ksjson_decode(). */
     void *userData;
 } KSJSONDecodeContext;
+
+/** Ask for more data when an element runs past the end of the window.
+ *
+ * Everything from the current position onward is kept and moved to the front, so an element
+ * straddling a window boundary can be rescanned from its start once the rest arrives.
+ *
+ * @return KSJSON_OK if the window changed at all, which includes learning that the data has
+ *         ended. KSJSON_ERROR_INCOMPLETE if there is nothing more to read.
+ *         KSJSON_ERROR_DATA_TOO_LONG if what must be preserved already fills the window.
+ */
+static int requestMoreData(KSJSONDecodeContext *context)
+{
+    unlikely_if(context->bufferEndIsEOF || context->refill == NULL) { return KSJSON_ERROR_INCOMPLETE; }
+    return context->refill(context, context->bufferPtr);
+}
+
+/** Skip whitespace, pulling in more data whenever the window runs out while doing it.
+ *
+ * Whitespace is the one thing that can consume a whole window without any element being
+ * parsed, so a file with enough leading space would otherwise look truncated before the
+ * decoder ever asked for the rest of it.
+ */
+static void skipWhitespace(KSJSONDecodeContext *context)
+{
+    for (;;) {
+        while (context->bufferPtr < context->bufferEnd && isspace((unsigned char)*context->bufferPtr)) {
+            context->bufferPtr++;
+        }
+        if (context->bufferPtr < context->bufferEnd || requestMoreData(context) != KSJSON_OK) {
+            return;
+        }
+    }
+}
+
+/** Make sure at least `count` bytes are in the window, for elements whose length is known
+ * up front. Anything scanned to an unknown length refills from its own start instead.
+ *
+ * @return false if the data ended before that many bytes were available.
+ */
+static bool ensureBuffered(KSJSONDecodeContext *context, const int count)
+{
+    while (context->bufferEnd - context->bufferPtr < count) {
+        unlikely_if(requestMoreData(context) != KSJSON_OK) { return false; }
+    }
+    return true;
+}
+
+/** Anything that may legally follow a JSON value. A number has no closing delimiter of its
+ * own, so this is the only thing separating "1" from the first half of "1x".
+ */
+static bool isJSONValueDelimiter(const char ch)
+{
+    return isspace((unsigned char)ch) || ch == ',' || ch == ']' || ch == '}';
+}
+
+/** Skip trailing whitespace and require that nothing else follows.
+ *
+ * Without this a payload is only ever as valid as its first element, so "1 2", "truejunk"
+ * and "{}[]" would all pass by decoding the part that parses and ignoring the rest.
+ */
+static int requireEndOfData(KSJSONDecodeContext *context)
+{
+    skipWhitespace(context);
+    unlikely_if(context->bufferPtr < context->bufferEnd)
+    {
+        KSLOG_DEBUG("Trailing data after the top level element");
+        return KSJSON_ERROR_INVALID_CHARACTER;
+    }
+    return KSJSON_OK;
+}
 
 /** Lookup table for converting hex values to integers.
  * INV (0x11111) is used to mark invalid characters so that any attempted
@@ -604,45 +686,7 @@ static int decodeString(KSJSONDecodeContext *context, char *dstBuffer, int dstBu
  */
 static int decodeElement(const char *const name, KSJSONDecodeContext *context);
 
-/** Skip past any whitespace.
- *
- * @param CONTEXT The decoding context.
- */
-#define SKIP_WHITESPACE(CONTEXT)                                                      \
-    while (CONTEXT->bufferPtr < CONTEXT->bufferEnd && isspace(*CONTEXT->bufferPtr)) { \
-        CONTEXT->bufferPtr++;                                                         \
-    }
-
-/** Check if a character is valid for representing part of a floating point
- * number.
- *
- * @param ch The character to test.
- *
- * @return true if the character is valid for floating point.
- */
-static inline bool isFPChar(char ch)
-{
-    switch (ch) {
-        case '0':
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-        case '8':
-        case '9':
-        case '.':
-        case 'e':
-        case 'E':
-        case '+':
-        case '-':
-            return true;
-        default:
-            return false;
-    }
-}
+static int decodeNumber(const char *const name, KSJSONDecodeContext *context, const int sign);
 
 static int writeUTF8(unsigned int character, char **dst)
 {
@@ -689,25 +733,42 @@ static int decodeString(KSJSONDecodeContext *context, char *dstBuffer, int dstBu
         return KSJSON_ERROR_INVALID_CHARACTER;
     }
 
-    const char *src = context->bufferPtr + 1;
+    // The closing quote is at an unknown distance, so when the window runs out before it
+    // turns up, pull more in and scan the whole string again from its opening quote.
+    // Refilling moves the string to the front, so bufferPtr stays valid across the retry.
+    const char *srcEnd = NULL;
     bool fastCopy = true;
-
-    for (; src < context->bufferEnd && *src != '\"'; src++) {
-        unlikely_if(*src == '\\')
-        {
-            fastCopy = false;
-            src++;
+    for (;;) {
+        const char *src = context->bufferPtr + 1;
+        fastCopy = true;
+        for (; src < context->bufferEnd && *src != '\"'; src++) {
+            unlikely_if(*src == '\\')
+            {
+                fastCopy = false;
+                src++;
+            }
         }
+        likely_if(src < context->bufferEnd)
+        {
+            srcEnd = src;
+            break;
+        }
+
+        const int result = requestMoreData(context);
+        unlikely_if(result == KSJSON_ERROR_INCOMPLETE)
+        {
+            KSLOG_DEBUG("Premature end of data");
+            return KSJSON_ERROR_INCOMPLETE;
+        }
+        unlikely_if(result != KSJSON_OK) { return result; }
     }
-    unlikely_if(src >= context->bufferEnd)
-    {
-        KSLOG_DEBUG("Premature end of data");
-        return KSJSON_ERROR_INCOMPLETE;
-    }
-    const char *srcEnd = src;
-    src = context->bufferPtr + 1;
+
+    const char *src = context->bufferPtr + 1;
     int length = (int)(srcEnd - src);
-    if (length >= dstBufferLength) {
+    // With no escapes the source span is exactly what it decodes to, so this is the limit
+    // itself. With escapes the source is longer than the value, and charging the source
+    // would refuse values that do fit, so the unescape loop below measures its own output.
+    if (fastCopy && length >= dstBufferLength) {
         KSLOG_DEBUG("String is too long");
         return KSJSON_ERROR_DATA_TOO_LONG;
     }
@@ -723,8 +784,17 @@ static int decodeString(KSJSONDecodeContext *context, char *dstBuffer, int dstBu
     }
 
     char *dst = dstBuffer;
+    // One byte held back for the terminator, so a write is in bounds while dst < dstEnd.
+    // Room is always compared by subtracting, never by forming dst + width, which could
+    // point past the end of the buffer.
+    char *const dstEnd = dstBuffer + dstBufferLength - 1;
 
     for (; src < srcEnd; src++) {
+        unlikely_if(dstEnd - dst < 1)
+        {
+            KSLOG_DEBUG("String is too long");
+            return KSJSON_ERROR_DATA_TOO_LONG;
+        }
         likely_if(*src != '\\') { *dst++ = *src; }
         else
         {
@@ -800,9 +870,22 @@ static int decodeString(KSJSONDecodeContext *context, char *dstBuffer, int dstBu
                             return KSJSON_ERROR_INVALID_CHARACTER;
                         }
                         // And combine 20 bit result.
-                        accum = ((accum - 0xd800) << 10) | (accum2 - 0xdc00);
+                        // The pair encodes the code point biased down by 0x10000, which is
+                        // why the surrogate range can cover the whole astral plane in 20
+                        // bits. Leaving the bias off turns every emoji into an unrelated
+                        // character in the private use area.
+                        accum = 0x10000 + (((accum - 0xd800) << 10) | (accum2 - 0xdc00));
                     }
 
+                    // Charge the code point what it actually costs. The check at the top of
+                    // the loop only accounted for one byte, and reserving the widest
+                    // encoding for every escape would refuse values that do fit.
+                    const ptrdiff_t utf8Width = accum < 0x80 ? 1 : accum < 0x800 ? 2 : accum < 0x10000 ? 3 : 4;
+                    unlikely_if(dstEnd - dst < utf8Width)
+                    {
+                        KSLOG_DEBUG("String is too long");
+                        return KSJSON_ERROR_DATA_TOO_LONG;
+                    }
                     int result = writeUTF8(accum, &dst);
                     unlikely_if(result != KSJSON_OK) { return result; }
                     src += 4;
@@ -819,9 +902,190 @@ static int decodeString(KSJSONDecodeContext *context, char *dstBuffer, int dstBu
     return KSJSON_OK;
 }
 
+/** How a number token ended. */
+typedef enum {
+    /** A whole number, correctly delimited. */
+    NumberScan_Complete,
+    /** The window ran out mid-token; more data would settle it. */
+    NumberScan_NeedsMoreData,
+    /** The data ran out mid-token. */
+    NumberScan_Truncated,
+    /** Not a number, or not one JSON accepts. */
+    NumberScan_Invalid,
+} NumberScanResult;
+
+/** Match a number against the JSON grammar without converting or consuming it:
+ *
+ *     -?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+-]?[0-9]+)?
+ *
+ * The sign is the caller's, already consumed. Every place the scan can run out of window is
+ * reported separately from running out of data, because only the second one ends a number:
+ * a number has no closing delimiter, so the end of a file window says nothing about whether
+ * more digits follow.
+ *
+ * @param outEnd Set to one past the last character of the token.
+ * @param outIsInteger Set false if a fraction or exponent means it cannot be one.
+ */
+static NumberScanResult scanNumberToken(const KSJSONDecodeContext *const context, const char **outEnd,
+                                        bool *outIsInteger)
+{
+    const char *ptr = context->bufferPtr;
+    const char *const end = context->bufferEnd;
+    bool isInteger = true;
+    // Whether the token would be whole if the data stopped right here.
+    bool completeAtEnd = false;
+
+#define NUMBER_RAN_OUT()                                               \
+    do {                                                               \
+        if (!context->bufferEndIsEOF) return NumberScan_NeedsMoreData; \
+        if (!completeAtEnd) return NumberScan_Truncated;               \
+        *outEnd = ptr;                                                 \
+        *outIsInteger = isInteger;                                     \
+        return NumberScan_Complete;                                    \
+    } while (0)
+
+    if (ptr >= end) NUMBER_RAN_OUT();
+    if (!isdigit((unsigned char)*ptr)) return NumberScan_Invalid;
+
+    // Integer part: a lone zero, or a non-zero digit and whatever follows it.
+    if (*ptr == '0') {
+        ptr++;
+        if (ptr < end && isdigit((unsigned char)*ptr)) return NumberScan_Invalid;
+    } else {
+        while (ptr < end && isdigit((unsigned char)*ptr)) {
+            ptr++;
+        }
+    }
+    completeAtEnd = true;
+    if (ptr >= end) NUMBER_RAN_OUT();
+
+    // Fraction: '.' must be followed by at least one digit.
+    if (*ptr == '.') {
+        isInteger = false;
+        completeAtEnd = false;
+        ptr++;
+        if (ptr >= end) NUMBER_RAN_OUT();
+        if (!isdigit((unsigned char)*ptr)) return NumberScan_Invalid;
+        while (ptr < end && isdigit((unsigned char)*ptr)) {
+            ptr++;
+        }
+        completeAtEnd = true;
+        if (ptr >= end) NUMBER_RAN_OUT();
+    }
+
+    // Exponent: 'e' must be followed by an optional sign and at least one digit.
+    if (*ptr == 'e' || *ptr == 'E') {
+        isInteger = false;
+        completeAtEnd = false;
+        ptr++;
+        if (ptr >= end) NUMBER_RAN_OUT();
+        if (*ptr == '+' || *ptr == '-') {
+            ptr++;
+            if (ptr >= end) NUMBER_RAN_OUT();
+        }
+        if (!isdigit((unsigned char)*ptr)) return NumberScan_Invalid;
+        while (ptr < end && isdigit((unsigned char)*ptr)) {
+            ptr++;
+        }
+        completeAtEnd = true;
+        if (ptr >= end) NUMBER_RAN_OUT();
+    }
+
+#undef NUMBER_RAN_OUT
+
+    // Something follows, and it has to be something a value may be followed by, or this is
+    // the leading part of a longer piece of nonsense such as "1x" or "1.2.3".
+    if (!isJSONValueDelimiter(*ptr)) return NumberScan_Invalid;
+
+    *outEnd = ptr;
+    *outIsInteger = isInteger;
+    return NumberScan_Complete;
+}
+
+/** Decode a JSON number.
+ *
+ * sscanf stops at the first character it cannot use, so it would read "1e" as 1 and "1.2.3"
+ * as 1.2 rather than rejecting either. Nothing reaches it until the whole token has matched
+ * the grammar.
+ *
+ * @param sign Already consumed by the caller, along with the '-' it came from.
+ */
+static int decodeNumber(const char *const name, KSJSONDecodeContext *context, const int sign)
+{
+    const char *tokenEnd = NULL;
+    bool isInteger = true;
+
+    for (bool scanned = false; !scanned;) {
+        switch (scanNumberToken(context, &tokenEnd, &isInteger)) {
+            case NumberScan_Complete:
+                scanned = true;
+                break;
+            case NumberScan_Invalid:
+                KSLOG_DEBUG("Not a valid number");
+                return KSJSON_ERROR_INVALID_CHARACTER;
+            case NumberScan_Truncated:
+                KSLOG_DEBUG("Premature end of number");
+                return KSJSON_ERROR_INCOMPLETE;
+            case NumberScan_NeedsMoreData:
+            default: {
+                // Refilling moves the token to the front of the window, so the next scan
+                // starts from bufferPtr again rather than from anything cached here.
+                const int result = requestMoreData(context);
+                unlikely_if(result != KSJSON_OK) { return result; }
+                break;
+            }
+        }
+    }
+
+    const char *const start = context->bufferPtr;
+    const int length = (int)(tokenEnd - start);
+    context->bufferPtr = tokenEnd;
+
+    if (isInteger) {
+        uint64_t accum = 0;
+        bool isOverflow = false;
+        for (const char *digit = start; digit < tokenEnd; digit++) {
+            const uint64_t nextDigit = (uint64_t)(*digit - '0');
+            unlikely_if((isOverflow = accum > (ULLONG_MAX / 10))) { break; }
+            accum *= 10;
+            unlikely_if((isOverflow = accum > (ULLONG_MAX - nextDigit))) { break; }
+            accum += nextDigit;
+        }
+
+        if (!isOverflow) {
+            if (sign > 0) {
+                if (accum <= (uint64_t)LLONG_MAX) {
+                    return context->callbacks->onIntegerElement(name, (int64_t)accum, context->userData);
+                }
+                return context->callbacks->onUnsignedIntegerElement(name, accum, context->userData);
+            }
+            if (accum <= ((uint64_t)LLONG_MAX + 1)) {
+                const int64_t signedAccum = accum == ((uint64_t)LLONG_MAX + 1) ? LLONG_MIN : -(int64_t)accum;
+                return context->callbacks->onIntegerElement(name, signedAccum, context->userData);
+            }
+        }
+        // Too big for either integer type, so take it as floating point instead.
+    }
+
+    // The buffer is not necessarily NULL-terminated, so copy the validated token out before
+    // handing it to sscanf.
+    unlikely_if(length >= context->stringBufferLength)
+    {
+        KSLOG_DEBUG("Number is too long.");
+        return KSJSON_ERROR_DATA_TOO_LONG;
+    }
+    memcpy(context->stringBuffer, start, (size_t)length);
+    context->stringBuffer[length] = '\0';
+
+    double value;
+    sscanf(context->stringBuffer, "%lg", &value);
+    value *= sign;
+    return context->callbacks->onFloatingPointElement(name, value, context->userData);
+}
+
 static int decodeElement(const char *const name, KSJSONDecodeContext *context)
 {
-    SKIP_WHITESPACE(context);
+    skipWhitespace(context);
     unlikely_if(context->bufferPtr >= context->bufferEnd)
     {
         KSLOG_DEBUG("Premature end of data");
@@ -837,7 +1101,7 @@ static int decodeElement(const char *const name, KSJSONDecodeContext *context)
             result = context->callbacks->onBeginArray(name, context->userData);
             unlikely_if(result != KSJSON_OK) return result;
             while (context->bufferPtr < context->bufferEnd) {
-                SKIP_WHITESPACE(context);
+                skipWhitespace(context);
                 unlikely_if(context->bufferPtr >= context->bufferEnd) { break; }
                 unlikely_if(*context->bufferPtr == ']')
                 {
@@ -846,7 +1110,7 @@ static int decodeElement(const char *const name, KSJSONDecodeContext *context)
                 }
                 result = decodeElement(NULL, context);
                 unlikely_if(result != KSJSON_OK) return result;
-                SKIP_WHITESPACE(context);
+                skipWhitespace(context);
                 unlikely_if(context->bufferPtr >= context->bufferEnd) { break; }
                 likely_if(*context->bufferPtr == ',') { context->bufferPtr++; }
             }
@@ -858,7 +1122,7 @@ static int decodeElement(const char *const name, KSJSONDecodeContext *context)
             result = context->callbacks->onBeginObject(name, context->userData);
             unlikely_if(result != KSJSON_OK) return result;
             while (context->bufferPtr < context->bufferEnd) {
-                SKIP_WHITESPACE(context);
+                skipWhitespace(context);
                 unlikely_if(context->bufferPtr >= context->bufferEnd) { break; }
                 unlikely_if(*context->bufferPtr == '}')
                 {
@@ -867,7 +1131,7 @@ static int decodeElement(const char *const name, KSJSONDecodeContext *context)
                 }
                 result = decodeString(context, context->nameBuffer, context->nameBufferLength);
                 unlikely_if(result != KSJSON_OK) return result;
-                SKIP_WHITESPACE(context);
+                skipWhitespace(context);
                 unlikely_if(context->bufferPtr >= context->bufferEnd) { break; }
                 unlikely_if(*context->bufferPtr != ':')
                 {
@@ -875,10 +1139,10 @@ static int decodeElement(const char *const name, KSJSONDecodeContext *context)
                     return KSJSON_ERROR_INVALID_CHARACTER;
                 }
                 context->bufferPtr++;
-                SKIP_WHITESPACE(context);
+                skipWhitespace(context);
                 result = decodeElement(context->nameBuffer, context);
                 unlikely_if(result != KSJSON_OK) return result;
-                SKIP_WHITESPACE(context);
+                skipWhitespace(context);
                 unlikely_if(context->bufferPtr >= context->bufferEnd) { break; }
                 likely_if(*context->bufferPtr == ',') { context->bufferPtr++; }
             }
@@ -892,7 +1156,7 @@ static int decodeElement(const char *const name, KSJSONDecodeContext *context)
             return result;
         }
         case 'f': {
-            unlikely_if(context->bufferEnd - context->bufferPtr < 5)
+            unlikely_if(!ensureBuffered(context, 5))
             {
                 KSLOG_DEBUG("Premature end of data");
                 return KSJSON_ERROR_INCOMPLETE;
@@ -908,7 +1172,7 @@ static int decodeElement(const char *const name, KSJSONDecodeContext *context)
             return context->callbacks->onBooleanElement(name, false, context->userData);
         }
         case 't': {
-            unlikely_if(context->bufferEnd - context->bufferPtr < 4)
+            unlikely_if(!ensureBuffered(context, 4))
             {
                 KSLOG_DEBUG("Premature end of data");
                 return KSJSON_ERROR_INCOMPLETE;
@@ -923,7 +1187,7 @@ static int decodeElement(const char *const name, KSJSONDecodeContext *context)
             return context->callbacks->onBooleanElement(name, true, context->userData);
         }
         case 'n': {
-            unlikely_if(context->bufferEnd - context->bufferPtr < 4)
+            unlikely_if(!ensureBuffered(context, 4))
             {
                 KSLOG_DEBUG("Premature end of data");
                 return KSJSON_ERROR_INCOMPLETE;
@@ -940,11 +1204,6 @@ static int decodeElement(const char *const name, KSJSONDecodeContext *context)
         case '-':
             sign = -1;
             context->bufferPtr++;
-            unlikely_if(!isdigit(*context->bufferPtr))
-            {
-                KSLOG_DEBUG("Not a digit: '%c'", *context->bufferPtr);
-                return KSJSON_ERROR_INVALID_CHARACTER;
-            }
             // Fallthrough
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wimplicit-fallthrough"
@@ -958,78 +1217,8 @@ static int decodeElement(const char *const name, KSJSONDecodeContext *context)
         case '6':
         case '7':
         case '8':
-        case '9': {
-            // Try integer conversion.
-            uint64_t accum = 0;
-            bool isOverflow = false;
-            const char *const start = context->bufferPtr;
-
-            for (; context->bufferPtr < context->bufferEnd && isdigit(*context->bufferPtr); context->bufferPtr++) {
-                unlikely_if((isOverflow = accum > (ULLONG_MAX / 10))) { break; }
-                accum *= 10;
-                uint64_t nextDigit = (uint64_t)(*context->bufferPtr - '0');
-                unlikely_if((isOverflow = accum > (ULLONG_MAX - nextDigit))) { break; }
-                accum += nextDigit;
-            }
-
-            unlikely_if(context->bufferPtr >= context->bufferEnd)
-            {
-                KSLOG_DEBUG("Premature end of data");
-                return KSJSON_ERROR_INCOMPLETE;
-            }
-
-            if (!isFPChar(*context->bufferPtr) && !isOverflow) {
-                if (sign > 0) {
-                    if (accum <= (uint64_t)LLONG_MAX) {
-                        // Positive number within int64_t range
-                        return context->callbacks->onIntegerElement(name, (int64_t)accum, context->userData);
-                    } else {
-                        // Positive number exceeding int64_t range, use unsigned
-                        return context->callbacks->onUnsignedIntegerElement(name, accum, context->userData);
-                    }
-                } else {
-                    if (accum <= ((uint64_t)LLONG_MAX + 1)) {
-                        int64_t signedAccum;
-                        if (accum == ((uint64_t)LLONG_MAX + 1)) {
-                            signedAccum = LLONG_MIN;
-                        } else {
-                            signedAccum = -(int64_t)accum;
-                        }
-                        return context->callbacks->onIntegerElement(name, signedAccum, context->userData);
-                    }
-                    // If negative and exceeding int64_t range, fall through to floating point
-                }
-            }
-
-            while (context->bufferPtr < context->bufferEnd && isFPChar(*context->bufferPtr)) {
-                context->bufferPtr++;
-            }
-
-            unlikely_if(context->bufferPtr >= context->bufferEnd)
-            {
-                KSLOG_DEBUG("Premature end of data");
-                return KSJSON_ERROR_INCOMPLETE;
-            }
-
-            // our buffer is not necessarily NULL-terminated, so
-            // it would be undefined to call sscanf/sttod etc. directly.
-            // instead we create a temporary string.
-            double value;
-            int len = (int)(context->bufferPtr - start);
-            if (len >= context->stringBufferLength) {
-                KSLOG_DEBUG("Number is too long.");
-                return KSJSON_ERROR_DATA_TOO_LONG;
-            }
-            // memcpy, not strlcpy: `start` points into the JSON buffer and is not
-            // NUL-terminated, so only the counted bytes may be read. Terminated explicitly.
-            memcpy(context->stringBuffer, start, (size_t)len);
-            context->stringBuffer[len] = '\0';
-
-            sscanf(context->stringBuffer, "%lg", &value);
-
-            value *= sign;
-            return context->callbacks->onFloatingPointElement(name, value, context->userData);
-        }
+        case '9':
+            return decodeNumber(name, context, sign);
         default:
             KSLOG_DEBUG("Invalid character '%c'", *context->bufferPtr);
             return KSJSON_ERROR_INVALID_CHARACTER;
@@ -1045,6 +1234,7 @@ int ksjson_decode(const char *const data, int length, char *stringBuffer, int st
     stringBufferLength -= nameBufferLength;
     KSJSONDecodeContext context = { .bufferPtr = (char *)data,
                                     .bufferEnd = (char *)data + length,
+                                    .bufferEndIsEOF = true,
                                     .nameBuffer = nameBuffer,
                                     .nameBufferLength = nameBufferLength,
                                     .stringBuffer = stringBuffer,
@@ -1052,12 +1242,13 @@ int ksjson_decode(const char *const data, int length, char *stringBuffer, int st
                                     .callbacks = callbacks,
                                     .userData = userData };
 
-    const char *ptr = data;
-
     int result = decodeElement(NULL, &context);
+    likely_if(result == KSJSON_OK) { result = requireEndOfData(&context); }
     likely_if(result == KSJSON_OK) { result = callbacks->onEndData(userData); }
 
-    unlikely_if(result != KSJSON_OK && errorOffset != NULL) { *errorOffset = (int)(ptr - data); }
+    // Where the decoder actually stopped. This used to report a pointer that was never
+    // advanced, so every error came back at offset 0.
+    unlikely_if(result != KSJSON_OK && errorOffset != NULL) { *errorOffset = (int)(context.bufferPtr - data); }
     return result;
 }
 
@@ -1068,6 +1259,9 @@ typedef struct JSONFromFileContext {
     KSJSONEncodeContext *encodeContext;
     KSJSONDecodeContext *decodeContext;
     char *bufferStart;
+    /** How much bufferStart can hold. bufferEnd moves as the window fills and drains, so it
+     * cannot stand in for this. */
+    int bufferCapacity;
     const char *sourceFilename;
     int fd;
     bool isEOF;
@@ -1080,35 +1274,56 @@ typedef struct JSONFromFileContext {
 
 static void updateDecoder_doNothing(__unused struct JSONFromFileContext *context) {}
 
+static int refillDecoder_readFile(KSJSONDecodeContext *decodeContext, const char *const preserveFrom)
+{
+    JSONFromFileContext *context = (JSONFromFileContext *)decodeContext->userData;
+
+    char *const start = context->bufferStart;
+    const int keep = (int)(decodeContext->bufferEnd - preserveFrom);
+    unlikely_if(keep >= context->bufferCapacity)
+    {
+        // The element already spans the whole window, so there is nowhere to put more of it.
+        KSLOG_DEBUG("Element is longer than the read window");
+        return KSJSON_ERROR_DATA_TOO_LONG;
+    }
+
+    // Move what is still needed to the front, keeping the cursor pointing at the same byte.
+    const ptrdiff_t shift = preserveFrom - start;
+    memmove(start, preserveFrom, (size_t)keep);
+    decodeContext->bufferPtr -= shift;
+
+    const int fillLength = context->bufferCapacity - keep;
+    int bytesRead = (int)read(context->fd, start + keep, (unsigned)fillLength);
+    unlikely_if(bytesRead < 0)
+    {
+        // errno numerically, not via strerror: this runs at crash time and Apple's strerror
+        // calloc()s its return buffer.
+        KSLOG_ERROR("Error reading file %s: errno %d", context->sourceFilename, errno);
+        bytesRead = 0;
+    }
+
+    // Only ever point at bytes read() actually wrote; the rest of the window is whatever
+    // was there before.
+    decodeContext->bufferEnd = start + keep + bytesRead;
+    unlikely_if(bytesRead < fillLength)
+    {
+        // A short read is the only proof of EOF we get. Until one happens, the end of the
+        // window says nothing about the end of the file.
+        context->isEOF = true;
+        decodeContext->bufferEndIsEOF = true;
+    }
+    return KSJSON_OK;
+}
+
 static void updateDecoder_readFile(struct JSONFromFileContext *context)
 {
     likely_if(!context->isEOF)
     {
-        const char *end = context->decodeContext->bufferEnd;
-        char *start = context->bufferStart;
-        const char *ptr = context->decodeContext->bufferPtr;
-        int bufferLength = (int)(end - start);
-        int remainingLength = (int)(end - ptr);
-        unlikely_if(remainingLength < bufferLength / 2)
+        const char *const ptr = context->decodeContext->bufferPtr;
+        const int remaining = (int)(context->decodeContext->bufferEnd - ptr);
+        unlikely_if(remaining < context->bufferCapacity / 2)
         {
-            int fillLength = bufferLength - remainingLength;
-            memcpy(start, ptr, (size_t)remainingLength);
-            context->decodeContext->bufferPtr = start;
-            int bytesRead = (int)read(context->fd, start + remainingLength, (unsigned)fillLength);
-            unlikely_if(bytesRead < fillLength)
-            {
-                if (bytesRead < 0) {
-                    // errno numerically, not via strerror: this runs at crash time and
-                    // Apple's strerror calloc()s its return buffer.
-                    KSLOG_ERROR("Error reading file %s: errno %d", context->sourceFilename, errno);
-                    bytesRead = 0;
-                }
-                // The read fell short, so the file is done. Pull the end in to the last byte
-                // actually read: the tail past it was never written, and leaving it in range
-                // would have the decoder parse whatever the stack happened to leave there.
-                context->decodeContext->bufferEnd = start + remainingLength + bytesRead;
-                context->isEOF = true;
-            }
+            (void)refillDecoder_readFile(context->decodeContext, ptr);
         }
     }
 }
@@ -1314,10 +1529,12 @@ static int decodeJSONElement(const char *const jsonData, const int jsonDataLengt
     KSJSONDecodeContext decodeContext = {
         .bufferPtr = jsonData,
         .bufferEnd = jsonData + jsonDataLength,
+        // The whole payload is in hand, so its end is the end of the data.
+        .bufferEndIsEOF = true,
         .nameBuffer = nameBuffer,
-        .nameBufferLength = KSJSON_MAX_EMBEDDED_STRING_LENGTH,
+        .nameBufferLength = KSJSON_MAX_EMBEDDED_STRING_LENGTH + 1,
         .stringBuffer = stringBuffer,
-        .stringBufferLength = KSJSON_MAX_EMBEDDED_STRING_LENGTH,
+        .stringBufferLength = KSJSON_MAX_EMBEDDED_STRING_LENGTH + 1,
         .callbacks = callbacks,
         .userData = NULL,
     };
@@ -1334,7 +1551,9 @@ static int decodeJSONElement(const char *const jsonData, const int jsonDataLengt
     };
     decodeContext.userData = &jsonContext;
 
-    return decodeElement(name, &decodeContext);
+    const int result = decodeElement(name, &decodeContext);
+    unlikely_if(result != KSJSON_OK) { return result; }
+    return requireEndOfData(&decodeContext);
 }
 
 /** One decode pass over an already-open file. See decodeJSONElement() for the buffers. */
@@ -1346,10 +1565,12 @@ static int decodeJSONFile(const int fd, const char *const filename, const char *
     KSJSONDecodeContext decodeContext = {
         .bufferPtr = fileBuffer,
         .bufferEnd = fileBuffer + KSJSON_EMBEDDED_FILE_WINDOW,
+        .bufferEndIsEOF = false,
+        .refill = refillDecoder_readFile,
         .nameBuffer = nameBuffer,
-        .nameBufferLength = KSJSON_MAX_EMBEDDED_STRING_LENGTH,
+        .nameBufferLength = KSJSON_MAX_EMBEDDED_STRING_LENGTH + 1,
         .stringBuffer = stringBuffer,
-        .stringBufferLength = KSJSON_MAX_EMBEDDED_STRING_LENGTH,
+        .stringBufferLength = KSJSON_MAX_EMBEDDED_STRING_LENGTH + 1,
         .callbacks = callbacks,
         .userData = NULL,
     };
@@ -1357,6 +1578,7 @@ static int decodeJSONFile(const int fd, const char *const filename, const char *
         .encodeContext = encodeContext,
         .decodeContext = &decodeContext,
         .bufferStart = fileBuffer,
+        .bufferCapacity = KSJSON_EMBEDDED_FILE_WINDOW,
         .sourceFilename = filename,
         .fd = fd,
         .closeLastContainer = closeLastContainer,
@@ -1370,29 +1592,34 @@ static int decodeJSONFile(const int fd, const char *const filename, const char *
     decodeContext.bufferPtr = decodeContext.bufferEnd;
     jsonContext.updateDecoderCallback(&jsonContext);
 
-    return decodeElement(name, &decodeContext);
+    const int result = decodeElement(name, &decodeContext);
+    unlikely_if(result != KSJSON_OK) { return result; }
+    return requireEndOfData(&decodeContext);
 }
 
-int ksjson_checkJSONElement(const char *const jsonData, const int jsonDataLength)
+int ksjson_checkJSONElement(const KSJSONEncodeContext *const destination, const char *const jsonData,
+                            const int jsonDataLength)
 {
-    char nameBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH];
-    char stringBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH];
+    char nameBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH + 1];
+    char stringBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH + 1];
     KSJSONDecodeCallbacks callbacks = checkCallbacks();
 
-    return decodeJSONElement(jsonData, jsonDataLength, NULL, &callbacks, NULL, true, 0, nameBuffer, stringBuffer);
+    return decodeJSONElement(jsonData, jsonDataLength, NULL, &callbacks, NULL, true, destination->containerLevel,
+                             nameBuffer, stringBuffer);
 }
 
-int ksjson_checkJSONFile(const char *const filename)
+int ksjson_checkJSONFile(const KSJSONEncodeContext *const destination, const char *const filename)
 {
-    char nameBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH];
-    char stringBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH];
+    char nameBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH + 1];
+    char stringBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH + 1];
     char fileBuffer[KSJSON_EMBEDDED_FILE_WINDOW];
     KSJSONDecodeCallbacks callbacks = checkCallbacks();
 
     int fd = open(filename, O_RDONLY);
     unlikely_if(fd < 0) { return KSJSON_ERROR_CANNOT_ADD_DATA; }
 
-    int result = decodeJSONFile(fd, filename, NULL, &callbacks, NULL, true, 0, nameBuffer, stringBuffer, fileBuffer);
+    int result = decodeJSONFile(fd, filename, NULL, &callbacks, NULL, true, destination->containerLevel, nameBuffer,
+                                stringBuffer, fileBuffer);
     close(fd);
     return result;
 }
@@ -1400,8 +1627,8 @@ int ksjson_checkJSONFile(const char *const filename)
 int ksjson_addJSONFromFile(KSJSONEncodeContext *const encodeContext, const char *restrict const name,
                            const char *restrict const filename, const bool closeLastContainer)
 {
-    char nameBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH];
-    char stringBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH];
+    char nameBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH + 1];
+    char stringBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH + 1];
     char fileBuffer[KSJSON_EMBEDDED_FILE_WINDOW];
 
     int fd = open(filename, O_RDONLY);
@@ -1438,8 +1665,8 @@ int ksjson_addJSONFromFile(KSJSONEncodeContext *const encodeContext, const char 
 int ksjson_addJSONElement(KSJSONEncodeContext *const encodeContext, const char *restrict const name,
                           const char *restrict const jsonData, const int jsonDataLength, const bool closeLastContainer)
 {
-    char nameBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH];
-    char stringBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH];
+    char nameBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH + 1];
+    char stringBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH + 1];
 
     // Rejected before anything is written. See ksjson_addJSONFromFile().
     KSJSONDecodeCallbacks callbacks = checkCallbacks();

--- a/Sources/KSCrashRecordingCore/KSJSONCodec.c
+++ b/Sources/KSCrashRecordingCore/KSJSONCodec.c
@@ -454,6 +454,9 @@ int ksjson_endDataElement(KSJSONEncodeContext *const context) { return ksjson_en
 
 int ksjson_beginArray(KSJSONEncodeContext *const context, const char *const name)
 {
+    // isObject[] is indexed by containerLevel, so refuse rather than run off the end.
+    unlikely_if(context->containerLevel + 1 >= KSJSON_MAX_CONTAINER_DEPTH) { return KSJSON_ERROR_DATA_TOO_LONG; }
+
     likely_if(context->containerLevel >= 0)
     {
         int result = ksjson_beginElement(context, name);
@@ -469,6 +472,9 @@ int ksjson_beginArray(KSJSONEncodeContext *const context, const char *const name
 
 int ksjson_beginObject(KSJSONEncodeContext *const context, const char *const name)
 {
+    // isObject[] is indexed by containerLevel, so refuse rather than run off the end.
+    unlikely_if(context->containerLevel + 1 >= KSJSON_MAX_CONTAINER_DEPTH) { return KSJSON_ERROR_DATA_TOO_LONG; }
+
     likely_if(context->containerLevel >= 0)
     {
         int result = ksjson_beginElement(context, name);
@@ -1066,6 +1072,9 @@ typedef struct JSONFromFileContext {
     int fd;
     bool isEOF;
     bool closeLastContainer;
+    /** Containers open right now. Only the checking callbacks maintain this; the embedding
+     * callbacks let the encoder track depth for them. */
+    int containerDepth;
     UpdateDecoderCallback updateDecoderCallback;
 } JSONFromFileContext;
 
@@ -1090,7 +1099,12 @@ static void updateDecoder_readFile(struct JSONFromFileContext *context)
             {
                 if (bytesRead < 0) {
                     KSLOG_ERROR("Error reading file %s: %s", context->sourceFilename, strerror(errno));
+                    bytesRead = 0;
                 }
+                // The read fell short, so the file is done. Pull the end in to the last byte
+                // actually read: the tail past it was never written, and leaving it in range
+                // would have the decoder parse whatever the stack happened to leave there.
+                context->decodeContext->bufferEnd = start + remainingLength + bytesRead;
                 context->isEOF = true;
             }
         }
@@ -1174,10 +1188,100 @@ static int addJSONFromFile_onEndContainer(void *const userData)
 
 static int addJSONFromFile_onEndData(__unused void *const userData) { return KSJSON_OK; }
 
-int ksjson_addJSONFromFile(KSJSONEncodeContext *const encodeContext, const char *restrict const name,
-                           const char *restrict const filename, const bool closeLastContainer)
+// The checking callbacks below run the same decoder the embedding callbacks do, but reach
+// no encoder, so a payload that fails leaves nothing written anywhere. They still pump the
+// buffer refill, because decodeElement only advances the file window from its callbacks,
+// and they count containers, because the decoder has no depth limit of its own while the
+// encoder's isObject[] does.
+
+static int check_onScalarElement(void *const userData)
 {
-    KSJSONDecodeCallbacks callbacks = {
+    JSONFromFileContext *context = (JSONFromFileContext *)userData;
+    context->updateDecoderCallback(context);
+    return KSJSON_OK;
+}
+
+static int check_onBooleanElement(__unused const char *const name, __unused const bool value, void *const userData)
+{
+    return check_onScalarElement(userData);
+}
+
+static int check_onFloatingPointElement(__unused const char *const name, __unused const double value,
+                                        void *const userData)
+{
+    return check_onScalarElement(userData);
+}
+
+static int check_onIntegerElement(__unused const char *const name, __unused const int64_t value, void *const userData)
+{
+    return check_onScalarElement(userData);
+}
+
+static int check_onUnsignedIntegerElement(__unused const char *const name, __unused const uint64_t value,
+                                          void *const userData)
+{
+    return check_onScalarElement(userData);
+}
+
+static int check_onNullElement(__unused const char *const name, void *const userData)
+{
+    return check_onScalarElement(userData);
+}
+
+static int check_onStringElement(__unused const char *const name, __unused const char *const value,
+                                 void *const userData)
+{
+    return check_onScalarElement(userData);
+}
+
+static int check_onBeginContainer(void *const userData)
+{
+    JSONFromFileContext *context = (JSONFromFileContext *)userData;
+    unlikely_if(context->containerDepth + 1 >= KSJSON_MAX_CONTAINER_DEPTH) { return KSJSON_ERROR_DATA_TOO_LONG; }
+    context->containerDepth++;
+    context->updateDecoderCallback(context);
+    return KSJSON_OK;
+}
+
+static int check_onBeginObject(__unused const char *const name, void *const userData)
+{
+    return check_onBeginContainer(userData);
+}
+
+static int check_onBeginArray(__unused const char *const name, void *const userData)
+{
+    return check_onBeginContainer(userData);
+}
+
+static int check_onEndContainer(void *const userData)
+{
+    JSONFromFileContext *context = (JSONFromFileContext *)userData;
+    context->containerDepth--;
+    context->updateDecoderCallback(context);
+    return KSJSON_OK;
+}
+
+static int check_onEndData(__unused void *const userData) { return KSJSON_OK; }
+
+static KSJSONDecodeCallbacks checkCallbacks(void)
+{
+    return (KSJSONDecodeCallbacks) {
+        .onBeginArray = check_onBeginArray,
+        .onBeginObject = check_onBeginObject,
+        .onBooleanElement = check_onBooleanElement,
+        .onEndContainer = check_onEndContainer,
+        .onEndData = check_onEndData,
+        .onFloatingPointElement = check_onFloatingPointElement,
+        .onIntegerElement = check_onIntegerElement,
+        .onUnsignedIntegerElement = check_onUnsignedIntegerElement,
+        .onNullElement = check_onNullElement,
+        .onStringElement = check_onStringElement,
+    };
+}
+
+static KSJSONDecodeCallbacks embedCallbacks(void)
+{
+    return (KSJSONDecodeCallbacks) {
         .onBeginArray = addJSONFromFile_onBeginArray,
         .onBeginObject = addJSONFromFile_onBeginObject,
         .onBooleanElement = addJSONFromFile_onBooleanElement,
@@ -1189,21 +1293,64 @@ int ksjson_addJSONFromFile(KSJSONEncodeContext *const encodeContext, const char 
         .onNullElement = addJSONFromFile_onNullElement,
         .onStringElement = addJSONFromFile_onStringElement,
     };
-    char nameBuffer[100] = { 0 };
-    char stringBuffer[500] = { 0 };
-    char fileBuffer[1000] = { 0 };
+}
+
+/** One decode pass over a payload already in memory.
+ *
+ * The caller owns the buffers so that the checking pass and the embedding pass share one
+ * set instead of stacking two of them on the crash-time stack.
+ *
+ * @param encodeContext Where to emit, or NULL when only checking.
+ * @param startDepth Containers already open at the destination, so a payload is judged
+ *                   against the depth actually left to it rather than the whole limit.
+ */
+static int decodeJSONElement(const char *const jsonData, const int jsonDataLength, const char *const name,
+                             KSJSONDecodeCallbacks *const callbacks, KSJSONEncodeContext *const encodeContext,
+                             const bool closeLastContainer, const int startDepth, char *const nameBuffer,
+                             char *const stringBuffer)
+{
     KSJSONDecodeContext decodeContext = {
-        .bufferPtr = fileBuffer,
-        .bufferEnd = fileBuffer + sizeof(fileBuffer),
+        .bufferPtr = jsonData,
+        .bufferEnd = jsonData + jsonDataLength,
         .nameBuffer = nameBuffer,
-        .nameBufferLength = sizeof(nameBuffer),
+        .nameBufferLength = KSJSON_MAX_EMBEDDED_STRING_LENGTH,
         .stringBuffer = stringBuffer,
-        .stringBufferLength = sizeof(stringBuffer),
-        .callbacks = &callbacks,
+        .stringBufferLength = KSJSON_MAX_EMBEDDED_STRING_LENGTH,
+        .callbacks = callbacks,
         .userData = NULL,
     };
+    JSONFromFileContext jsonContext = {
+        .encodeContext = encodeContext,
+        .decodeContext = &decodeContext,
+        .bufferStart = (char *)jsonData,
+        .sourceFilename = NULL,
+        .fd = -1,
+        .closeLastContainer = closeLastContainer,
+        .containerDepth = startDepth,
+        .isEOF = false,
+        .updateDecoderCallback = updateDecoder_doNothing,
+    };
+    decodeContext.userData = &jsonContext;
 
-    int fd = open(filename, O_RDONLY);
+    return decodeElement(name, &decodeContext);
+}
+
+/** One decode pass over an already-open file. See decodeJSONElement() for the buffers. */
+static int decodeJSONFile(const int fd, const char *const filename, const char *const name,
+                          KSJSONDecodeCallbacks *const callbacks, KSJSONEncodeContext *const encodeContext,
+                          const bool closeLastContainer, const int startDepth, char *const nameBuffer,
+                          char *const stringBuffer, char *const fileBuffer)
+{
+    KSJSONDecodeContext decodeContext = {
+        .bufferPtr = fileBuffer,
+        .bufferEnd = fileBuffer + KSJSON_EMBEDDED_FILE_WINDOW,
+        .nameBuffer = nameBuffer,
+        .nameBufferLength = KSJSON_MAX_EMBEDDED_STRING_LENGTH,
+        .stringBuffer = stringBuffer,
+        .stringBufferLength = KSJSON_MAX_EMBEDDED_STRING_LENGTH,
+        .callbacks = callbacks,
+        .userData = NULL,
+    };
     JSONFromFileContext jsonContext = {
         .encodeContext = encodeContext,
         .decodeContext = &decodeContext,
@@ -1211,71 +1358,97 @@ int ksjson_addJSONFromFile(KSJSONEncodeContext *const encodeContext, const char 
         .sourceFilename = filename,
         .fd = fd,
         .closeLastContainer = closeLastContainer,
+        .containerDepth = startDepth,
         .isEOF = false,
         .updateDecoderCallback = updateDecoder_readFile,
     };
     decodeContext.userData = &jsonContext;
-    int containerLevel = encodeContext->containerLevel;
 
     // Manually trigger a data load.
     decodeContext.bufferPtr = decodeContext.bufferEnd;
     jsonContext.updateDecoderCallback(&jsonContext);
 
-    int result = decodeElement(name, &decodeContext);
+    return decodeElement(name, &decodeContext);
+}
+
+int ksjson_checkJSONElement(const char *const jsonData, const int jsonDataLength)
+{
+    char nameBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH];
+    char stringBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH];
+    KSJSONDecodeCallbacks callbacks = checkCallbacks();
+
+    return decodeJSONElement(jsonData, jsonDataLength, NULL, &callbacks, NULL, true, 0, nameBuffer, stringBuffer);
+}
+
+int ksjson_checkJSONFile(const char *const filename)
+{
+    char nameBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH];
+    char stringBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH];
+    char fileBuffer[KSJSON_EMBEDDED_FILE_WINDOW];
+    KSJSONDecodeCallbacks callbacks = checkCallbacks();
+
+    int fd = open(filename, O_RDONLY);
+    unlikely_if(fd < 0) { return KSJSON_ERROR_CANNOT_ADD_DATA; }
+
+    int result = decodeJSONFile(fd, filename, NULL, &callbacks, NULL, true, 0, nameBuffer, stringBuffer, fileBuffer);
     close(fd);
-    // On failure, always rebalance: a partial decode leaves containers open, and leaving
-    // them dangling would nest everything written afterwards inside this element.
-    while ((closeLastContainer || result != KSJSON_OK) && encodeContext->containerLevel > containerLevel) {
-        ksjson_endContainer(encodeContext);
+    return result;
+}
+
+int ksjson_addJSONFromFile(KSJSONEncodeContext *const encodeContext, const char *restrict const name,
+                           const char *restrict const filename, const bool closeLastContainer)
+{
+    char nameBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH];
+    char stringBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH];
+    char fileBuffer[KSJSON_EMBEDDED_FILE_WINDOW];
+
+    int fd = open(filename, O_RDONLY);
+    unlikely_if(fd < 0) { return KSJSON_ERROR_CANNOT_ADD_DATA; }
+
+    // Check before emitting anything. The encoder writes as the decoder reads, so a file
+    // that only fails partway would leave a truncated element behind that the caller can
+    // neither see nor take back. Rejecting up front leaves the name free for the caller.
+    KSJSONDecodeCallbacks callbacks = checkCallbacks();
+    int result = decodeJSONFile(fd, filename, NULL, &callbacks, NULL, true, encodeContext->containerLevel, nameBuffer,
+                                stringBuffer, fileBuffer);
+
+    if (result == KSJSON_OK) {
+        unlikely_if(lseek(fd, 0, SEEK_SET) != 0) { result = KSJSON_ERROR_CANNOT_ADD_DATA; }
+        else
+        {
+            int containerLevel = encodeContext->containerLevel;
+            callbacks = embedCallbacks();
+            result = decodeJSONFile(fd, filename, name, &callbacks, encodeContext, closeLastContainer, 0, nameBuffer,
+                                    stringBuffer, fileBuffer);
+            // The file passed the check, so a failure here is the encoder refusing to take
+            // data, meaning the destination is already lost. Rebalance anyway so whatever
+            // the caller does next is at least not nested inside this element.
+            while ((closeLastContainer || result != KSJSON_OK) && encodeContext->containerLevel > containerLevel) {
+                ksjson_endContainer(encodeContext);
+            }
+        }
     }
 
+    close(fd);
     return result;
 }
 
 int ksjson_addJSONElement(KSJSONEncodeContext *const encodeContext, const char *restrict const name,
                           const char *restrict const jsonData, const int jsonDataLength, const bool closeLastContainer)
 {
-    KSJSONDecodeCallbacks callbacks = {
-        .onBeginArray = addJSONFromFile_onBeginArray,
-        .onBeginObject = addJSONFromFile_onBeginObject,
-        .onBooleanElement = addJSONFromFile_onBooleanElement,
-        .onEndContainer = addJSONFromFile_onEndContainer,
-        .onEndData = addJSONFromFile_onEndData,
-        .onFloatingPointElement = addJSONFromFile_onFloatingPointElement,
-        .onIntegerElement = addJSONFromFile_onIntegerElement,
-        .onUnsignedIntegerElement = addJSONFromFile_onUnsignedIntegerElement,
-        .onNullElement = addJSONFromFile_onNullElement,
-        .onStringElement = addJSONFromFile_onStringElement,
-    };
-    char nameBuffer[100] = { 0 };
-    char stringBuffer[5000] = { 0 };
-    KSJSONDecodeContext decodeContext = {
-        .bufferPtr = jsonData,
-        .bufferEnd = jsonData + jsonDataLength,
-        .nameBuffer = nameBuffer,
-        .nameBufferLength = sizeof(nameBuffer),
-        .stringBuffer = stringBuffer,
-        .stringBufferLength = sizeof(stringBuffer),
-        .callbacks = &callbacks,
-        .userData = NULL,
-    };
+    char nameBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH];
+    char stringBuffer[KSJSON_MAX_EMBEDDED_STRING_LENGTH];
 
-    JSONFromFileContext jsonContext = {
-        .encodeContext = encodeContext,
-        .decodeContext = &decodeContext,
-        .bufferStart = (char *)jsonData,
-        .sourceFilename = NULL,
-        .fd = 0,
-        .closeLastContainer = closeLastContainer,
-        .isEOF = false,
-        .updateDecoderCallback = updateDecoder_doNothing,
-    };
-    decodeContext.userData = &jsonContext;
+    // Rejected before anything is written. See ksjson_addJSONFromFile().
+    KSJSONDecodeCallbacks callbacks = checkCallbacks();
+    int result = decodeJSONElement(jsonData, jsonDataLength, NULL, &callbacks, NULL, true,
+                                   encodeContext->containerLevel, nameBuffer, stringBuffer);
+    unlikely_if(result != KSJSON_OK) { return result; }
+
     int containerLevel = encodeContext->containerLevel;
-
-    int result = decodeElement(name, &decodeContext);
-    // On failure, always rebalance: a partial decode leaves containers open, and leaving
-    // them dangling would nest everything written afterwards inside this element.
+    callbacks = embedCallbacks();
+    result = decodeJSONElement(jsonData, jsonDataLength, name, &callbacks, encodeContext, closeLastContainer, 0,
+                               nameBuffer, stringBuffer);
     while ((closeLastContainer || result != KSJSON_OK) && encodeContext->containerLevel > containerLevel) {
         ksjson_endContainer(encodeContext);
     }

--- a/Sources/KSCrashRecordingCore/include/KSJSONCodec.h
+++ b/Sources/KSCrashRecordingCore/include/KSJSONCodec.h
@@ -44,20 +44,23 @@ extern "C" {
  */
 #define KSJSON_SIZE_AUTOMATIC -1
 
-/* Limits on JSON embedded via ksjson_addJSONElement() and ksjson_addJSONFromFile().
+/* The longest key or string value, in decoded bytes, that may appear in JSON embedded via
+ * ksjson_addJSONElement() or ksjson_addJSONFromFile().
  *
- * Embedding re-decodes the payload, and decoding runs at crash time where memory cannot
- * be allocated, so every key and string value has to fit in a buffer sized up front.
- * These are the sizes of those buffers. Note that they bound the individual pieces, not
- * the payload: a megabyte of short strings is fine, a single over-long one is not.
+ * Embedding re-decodes the payload, and decoding runs at crash time where memory cannot be
+ * allocated, so each key and value has to fit a buffer sized up front. The limit is on what
+ * a value decodes to, not on how it was written: escapes only ever shrink, so "\u0061" costs
+ * the one byte it becomes. It also bounds the individual pieces, not the payload, so a
+ * megabyte of short strings is fine while one over-long string is not.
  *
- * ksjson_checkJSONElement() answers whether a given payload is within them.
+ * ksjson_checkJSONElement() answers whether a given payload is within it.
  */
 #define KSJSON_MAX_EMBEDDED_STRING_LENGTH 8192
 
 /* How much of a file the decoder keeps in view at once, which also bounds how long one
- * string's *source* text may be. Heavily escaped strings therefore run out of window before
- * they reach KSJSON_MAX_EMBEDDED_STRING_LENGTH. Either way the payload is rejected whole.
+ * element's *source* text may be. A heavily escaped string can therefore run out of window
+ * before it reaches KSJSON_MAX_EMBEDDED_STRING_LENGTH. Either way the payload is rejected
+ * whole rather than embedded in part.
  */
 #define KSJSON_EMBEDDED_FILE_WINDOW (KSJSON_MAX_EMBEDDED_STRING_LENGTH * 2)
 
@@ -327,11 +330,15 @@ int ksjson_endDataElement(KSJSONEncodeContext *const context);
 int ksjson_addJSONElement(KSJSONEncodeContext *const encodeContext, const char *restrict const name,
                           const char *restrict const jsonData, const int jsonDataLength, const bool closeLastContainer);
 
-/** Check whether a payload can be embedded by ksjson_addJSONElement().
+/** Check whether a payload can be embedded into a given destination.
  *
- * Valid JSON can still be rejected: a key or string value over
- * KSJSON_MAX_EMBEDDED_STRING_LENGTH bytes, or nesting past KSJSON_MAX_CONTAINER_DEPTH.
- * This runs the same decoder the embedding does, so the answer matches, but writes nothing.
+ * Valid JSON can still be rejected: a key or string value decoding to more than
+ * KSJSON_MAX_EMBEDDED_STRING_LENGTH bytes, or nesting the destination has no room for.
+ * How much nesting is left depends on how deep the destination already is, which is why
+ * this takes one rather than answering in the abstract. It runs the same decoder against
+ * the same limits as the embedding, so the answer matches, but it writes nothing.
+ *
+ * @param destination The context the payload would be embedded into.
  *
  * @param jsonData The payload to check.
  *
@@ -339,7 +346,8 @@ int ksjson_addJSONElement(KSJSONEncodeContext *const encodeContext, const char *
  *
  * @return KSJSON_OK if it can be embedded, otherwise the error the embedding would return.
  */
-int ksjson_checkJSONElement(const char *const jsonData, const int jsonDataLength);
+int ksjson_checkJSONElement(const KSJSONEncodeContext *const destination, const char *const jsonData,
+                            const int jsonDataLength);
 
 /** Begin a new object container.
  *
@@ -408,13 +416,17 @@ int ksjson_endContainer(KSJSONEncodeContext *context);
 int ksjson_addJSONFromFile(KSJSONEncodeContext *const context, const char *restrict const name,
                            const char *restrict const filename, const bool closeLastContainer);
 
-/** Check whether a file's contents can be embedded by ksjson_addJSONFromFile().
+/** Check whether a file's contents can be embedded into a given destination.
+ *
+ * See ksjson_checkJSONElement() for why the destination is needed.
+ *
+ * @param destination The context the file's contents would be embedded into.
  *
  * @param filename The file to check.
  *
  * @return KSJSON_OK if it can be embedded, otherwise the error the embedding would return.
  */
-int ksjson_checkJSONFile(const char *const filename);
+int ksjson_checkJSONFile(const KSJSONEncodeContext *const destination, const char *const filename);
 
 // ============================================================================
 // Decode

--- a/Sources/KSCrashRecordingCore/include/KSJSONCodec.h
+++ b/Sources/KSCrashRecordingCore/include/KSJSONCodec.h
@@ -44,6 +44,26 @@ extern "C" {
  */
 #define KSJSON_SIZE_AUTOMATIC -1
 
+/* Limits on JSON embedded via ksjson_addJSONElement() and ksjson_addJSONFromFile().
+ *
+ * Embedding re-decodes the payload, and decoding runs at crash time where memory cannot
+ * be allocated, so every key and string value has to fit in a buffer sized up front.
+ * These are the sizes of those buffers. Note that they bound the individual pieces, not
+ * the payload: a megabyte of short strings is fine, a single over-long one is not.
+ *
+ * ksjson_checkJSONElement() answers whether a given payload is within them.
+ */
+#define KSJSON_MAX_EMBEDDED_STRING_LENGTH 8192
+
+/* How much of a file the decoder keeps in view at once, which also bounds how long one
+ * string's *source* text may be. Heavily escaped strings therefore run out of window before
+ * they reach KSJSON_MAX_EMBEDDED_STRING_LENGTH. Either way the payload is rejected whole.
+ */
+#define KSJSON_EMBEDDED_FILE_WINDOW (KSJSON_MAX_EMBEDDED_STRING_LENGTH * 2)
+
+/* The deepest nesting the encoder can track, counting containers already open. */
+#define KSJSON_MAX_CONTAINER_DEPTH 200
+
 enum {
     /** Encoding or decoding: Everything completed without error */
     KSJSON_OK = 0,
@@ -107,7 +127,7 @@ typedef struct {
     int containerLevel;
 
     /** Whether or not the current container is an object. */
-    bool isObject[200];
+    bool isObject[KSJSON_MAX_CONTAINER_DEPTH];
 
     /** true if this is the first entry at the current container level. */
     bool containerFirstEntry;
@@ -287,6 +307,11 @@ int ksjson_endDataElement(KSJSONEncodeContext *const context);
 
 /** Add a pre-formatted JSON element.
  *
+ * The payload is re-decoded and re-encoded rather than copied, so it must be valid JSON
+ * and must be within the limits described at KSJSON_MAX_EMBEDDED_STRING_LENGTH. A payload
+ * that isn't is rejected whole: nothing at all is written, and the caller is free to write
+ * something else under the same name. Use ksjson_checkJSONElement() to ask in advance.
+ *
  * @param encodeContext The encoding context.
  *
  * @param name The element's name.
@@ -301,6 +326,20 @@ int ksjson_endDataElement(KSJSONEncodeContext *const context);
  */
 int ksjson_addJSONElement(KSJSONEncodeContext *const encodeContext, const char *restrict const name,
                           const char *restrict const jsonData, const int jsonDataLength, const bool closeLastContainer);
+
+/** Check whether a payload can be embedded by ksjson_addJSONElement().
+ *
+ * Valid JSON can still be rejected: a key or string value over
+ * KSJSON_MAX_EMBEDDED_STRING_LENGTH bytes, or nesting past KSJSON_MAX_CONTAINER_DEPTH.
+ * This runs the same decoder the embedding does, so the answer matches, but writes nothing.
+ *
+ * @param jsonData The payload to check.
+ *
+ * @param jsonDataLength The length of the payload.
+ *
+ * @return KSJSON_OK if it can be embedded, otherwise the error the embedding would return.
+ */
+int ksjson_checkJSONElement(const char *const jsonData, const int jsonDataLength);
 
 /** Begin a new object container.
  *
@@ -355,6 +394,9 @@ int ksjson_endContainer(KSJSONEncodeContext *context);
 
 /** Decode and add JSON data from a file.
  *
+ * Same contract as ksjson_addJSONElement(): the file's contents must be valid JSON within
+ * the embedding limits, and a file that isn't is rejected whole, writing nothing.
+ *
  * @param context The encoding context.
  *
  * @param name The name to give the top element from the file.
@@ -365,6 +407,14 @@ int ksjson_endContainer(KSJSONEncodeContext *context);
  */
 int ksjson_addJSONFromFile(KSJSONEncodeContext *const context, const char *restrict const name,
                            const char *restrict const filename, const bool closeLastContainer);
+
+/** Check whether a file's contents can be embedded by ksjson_addJSONFromFile().
+ *
+ * @param filename The file to check.
+ *
+ * @return KSJSON_OK if it can be embedded, otherwise the error the embedding would return.
+ */
+int ksjson_checkJSONFile(const char *const filename);
 
 // ============================================================================
 // Decode

--- a/Tests/KSCrashBenchmarks/KSJSONCodecBenchmarks.swift
+++ b/Tests/KSCrashBenchmarks/KSJSONCodecBenchmarks.swift
@@ -283,4 +283,82 @@ class KSJSONCodecBenchmarks: KSBenchmarkTestCase {
             }
         }
     }
+
+    // MARK: - Embedding Pre-Formatted JSON
+
+    // ksjson_addJSONElement re-decodes and re-encodes its payload rather than copying it,
+    // and checks it through the same decoder first so a payload it cannot embed writes
+    // nothing. These measure that whole path, which is what the user-info section costs.
+
+    /// A payload shaped like typical user info: flat, short keys, short values.
+    private func userInfoPayload(fieldCount: Int) -> String {
+        var json = "{"
+        for i in 0..<fieldCount {
+            json += "\(i == 0 ? "" : ",")\"key\(i)\":\"value\(i)\""
+        }
+        return json + "}"
+    }
+
+    private func embedBenchmark(payload: String, bufferCapacity: Int) {
+        payload.withCString { payloadPtr in
+            let length = Int32(strlen(payloadPtr))
+            measure {
+                withJSONEncoder(bufferCapacity: bufferCapacity) { context in
+                    ksjson_beginObject(&context, nil)
+                    _ = "user".withCString {
+                        ksjson_addJSONElement(&context, $0, payloadPtr, length, true)
+                    }
+                    ksjson_endContainer(&context)
+                }
+            }
+        }
+    }
+
+    /// Benchmark embedding a small pre-formatted payload
+    func testBenchmarkEmbedJSONElement() {
+        embedBenchmark(payload: userInfoPayload(fieldCount: 20), bufferCapacity: 4096)
+    }
+
+    /// Benchmark embedding a large pre-formatted payload
+    func testBenchmarkEmbedLargeJSONElement() {
+        embedBenchmark(payload: userInfoPayload(fieldCount: 500), bufferCapacity: 65536)
+    }
+
+    /// Benchmark checking a payload without embedding it
+    func testBenchmarkCheckJSONElement() {
+        // The gap between this and testBenchmarkEmbedJSONElement is what the checking pass
+        // costs on its own, since embedding runs this and then decodes a second time.
+        let payload = userInfoPayload(fieldCount: 20)
+        payload.withCString { payloadPtr in
+            let length = Int32(strlen(payloadPtr))
+            measure {
+                for _ in 0..<100 {
+                    _ = ksjson_checkJSONElement(payloadPtr, length)
+                }
+            }
+        }
+    }
+
+    /// Benchmark embedding a pre-formatted payload read from a file
+    func testBenchmarkEmbedJSONFromFile() {
+        let path = NSTemporaryDirectory() + "/kscrash-benchmark-embed.json"
+        let payload = userInfoPayload(fieldCount: 20)
+        guard (try? payload.write(toFile: path, atomically: true, encoding: .utf8)) != nil else {
+            XCTFail("could not stage the benchmark payload")
+            return
+        }
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        path.withCString { pathPtr in
+            measure {
+                withJSONEncoder(bufferCapacity: 4096) { context in
+                    ksjson_beginObject(&context, nil)
+                    _ = "user".withCString {
+                        ksjson_addJSONFromFile(&context, $0, pathPtr, true)
+                    }
+                    ksjson_endContainer(&context)
+                }
+            }
+        }
+    }
 }

--- a/Tests/KSCrashBenchmarks/KSJSONCodecBenchmarks.swift
+++ b/Tests/KSCrashBenchmarks/KSJSONCodecBenchmarks.swift
@@ -331,9 +331,11 @@ class KSJSONCodecBenchmarks: KSBenchmarkTestCase {
         let payload = userInfoPayload(fieldCount: 20)
         payload.withCString { payloadPtr in
             let length = Int32(strlen(payloadPtr))
+            var destination = KSJSONEncodeContext()
+            ksjson_beginEncode(&destination, false, { _, _, _ in Int32(KSJSON_OK) }, nil)
             measure {
                 for _ in 0..<100 {
-                    _ = ksjson_checkJSONElement(payloadPtr, length)
+                    _ = ksjson_checkJSONElement(&destination, payloadPtr, length)
                 }
             }
         }

--- a/Tests/KSCrashRecordingCoreTests/KSJSONCodec_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSJSONCodec_Tests.m
@@ -554,15 +554,22 @@ static NSString *toString(NSData *data)
 
 - (void)testDeserializeUnicodeExtended
 {
-    // 𐌣 = 0x10323 = 0x40,0x323 = 0xd840,0xdf23
+    // A surrogate pair encodes the code point less 0x10000, so 𐌣 = U+10323 is
+    // 0x10323 - 0x10000 = 0x323, split as 0xd800,0xdf23. Dropping that bias on either side
+    // is what made this test and the decoder agree on the wrong character for years.
     NSError *error = (NSError *)self;
-    NSString *json = @"[\"ABC\\ud840\\udf23DEFGHIJ\"]";
+    NSString *json = @"[\"ABC\\ud800\\udf23DEFGHIJ\"]";
     NSString *expected = @"ABC𐌣DEFGHIJ";
     NSArray *result = [KSJSONCodec decode:toData(json) options:0 error:&error];
     XCTAssertNotNil(result, @"");
     XCTAssertNil(error, @"");
     NSString *value = [result objectAtIndex:0];
     XCTAssertEqualObjects(value, expected, @"");
+
+    // And the pair this used to carry really is a different character.
+    error = nil;
+    result = [KSJSONCodec decode:toData(@"[\"ABC\\ud840\\udf23DEFGHIJ\"]") options:0 error:&error];
+    XCTAssertEqualObjects([result objectAtIndex:0], @"ABC𠌣DEFGHIJ");
 }
 
 - (void)testDeserializeUnicodeExtendedLoneTrailSurrogate
@@ -1232,10 +1239,13 @@ static NSString *toString(NSData *data)
 
     NSData *data = [NSData dataWithBytesNoCopy:buffer length:0x1000000 freeWhenDone:YES];
 
+    // The object is followed by 16MB of filler, so this is not a valid document. What is
+    // being guarded is that parsing the float stops at the '}' instead of running away into
+    // the filler, which the reported offset is what proves.
     NSDictionary *result = [KSJSONCodec decode:data options:0 error:&error];
-    XCTAssertNotNil(result, @"");
-    XCTAssertNil(error, @"");
-    XCTAssertTrue([result count] == 1, @"");
+    XCTAssertNil(result, @"");
+    XCTAssertNotNil(error, @"");
+    XCTAssertTrue([error.localizedDescription containsString:@"offset 12"], @"got: %@", error.localizedDescription);
 }
 
 static int addJSONData(const char *data, int length, void *userData)
@@ -1498,7 +1508,7 @@ static int addJSONData(const char *data, int length, void *userData)
 
     for (NSString *label in cases) {
         const char *json = cases[label].UTF8String;
-        int checkResult = ksjson_checkJSONElement(json, (int)strlen(json));
+        int checkResult = [self checkElement:json atDepth:0];
 
         NSMutableData *encodedData = [NSMutableData data];
         KSJSONEncodeContext context = { 0 };
@@ -1519,7 +1529,7 @@ static int addJSONData(const char *data, int length, void *userData)
     [json appendString:@"\":1}"];
 
     const char *bytes = json.UTF8String;
-    XCTAssertEqual(ksjson_checkJSONElement(bytes, (int)strlen(bytes)), KSJSON_ERROR_DATA_TOO_LONG);
+    XCTAssertEqual([self checkElement:bytes atDepth:0], KSJSON_ERROR_DATA_TOO_LONG);
 }
 
 - (void)testCheckJSONElementAcceptsPayloadLargerThanTheStringLimit
@@ -1534,22 +1544,369 @@ static int addJSONData(const char *data, int length, void *userData)
 
     const char *bytes = json.UTF8String;
     XCTAssertGreaterThan(strlen(bytes), (size_t)KSJSON_MAX_EMBEDDED_STRING_LENGTH);
-    XCTAssertEqual(ksjson_checkJSONElement(bytes, (int)strlen(bytes)), KSJSON_OK);
+    XCTAssertEqual([self checkElement:bytes atDepth:0], KSJSON_OK);
+}
+
+/** Open `depth` nested containers. Arrays, because a nameless object cannot be nested
+ * inside another object.
+ */
+- (void)nestEncoder:(KSJSONEncodeContext *)context toDepth:(int)depth
+{
+    for (int i = 0; i < depth; i++) {
+        XCTAssertEqual(ksjson_beginArray(context, NULL), KSJSON_OK);
+    }
+    XCTAssertEqual(context->containerLevel, depth);
+}
+
+/** Check a payload against a destination already nested `depth` containers deep. */
+- (int)checkElement:(const char *)json atDepth:(int)depth
+{
+    NSMutableData *scratch = [NSMutableData data];
+    KSJSONEncodeContext destination = { 0 };
+    ksjson_beginEncode(&destination, false, addJSONData, (__bridge void *)(scratch));
+    [self nestEncoder:&destination toDepth:depth];
+    return ksjson_checkJSONElement(&destination, json, (int)strlen(json));
+}
+
+- (int)checkFile:(NSString *)path atDepth:(int)depth
+{
+    NSMutableData *scratch = [NSMutableData data];
+    KSJSONEncodeContext destination = { 0 };
+    ksjson_beginEncode(&destination, false, addJSONData, (__bridge void *)(scratch));
+    [self nestEncoder:&destination toDepth:depth];
+    return ksjson_checkJSONFile(&destination, path.UTF8String);
+}
+
+/** A payload nested `depth` containers deep. */
+- (NSString *)nestedPayloadOfDepth:(int)depth
+{
+    NSMutableString *json = [NSMutableString string];
+    for (int i = 0; i < depth; i++) {
+        [json appendString:@"["];
+    }
+    [json appendString:@"1"];
+    for (int i = 0; i < depth; i++) {
+        [json appendString:@"]"];
+    }
+    return json;
+}
+
+#pragma mark - Numbers
+
+// A number is the only element with no closing delimiter, so the end of the data is where
+// it ends. That is only true of the real end, though.
+- (void)testNumberAtRealEndOfDataIsAccepted
+{
+    for (NSString *content in @[ @"1", @"0", @"42", @"-1.5", @"1e3", @"1E+3", @"-0.5e-3", @"9223372036854775807" ]) {
+        XCTAssertEqual([self checkElement:content.UTF8String atDepth:0], KSJSON_OK, @"in memory: %@", content);
+
+        NSString *path = [self.tempPath stringByAppendingPathComponent:@"number.json"];
+        XCTAssertTrue([[content dataUsingEncoding:NSUTF8StringEncoding] writeToFile:path atomically:YES]);
+        XCTAssertEqual([self checkFile:path atDepth:0], KSJSON_OK, @"from file: %@", content);
+    }
+}
+
+/** Write `content` to a file and embed it, returning the decoded element. */
+- (id)embedFileWithContent:(NSString *)content result:(int *)outResult
+{
+    NSString *path = [self.tempPath stringByAppendingPathComponent:@"window.json"];
+    XCTAssertTrue([[content dataUsingEncoding:NSUTF8StringEncoding] writeToFile:path atomically:YES]);
+
+    NSMutableData *encodedData = [NSMutableData data];
+    KSJSONEncodeContext context = { 0 };
+    ksjson_beginEncode(&context, false, addJSONData, (__bridge void *)(encodedData));
+    ksjson_beginObject(&context, NULL);
+    int addResult = ksjson_addJSONFromFile(&context, "n", path.UTF8String, true);
+    ksjson_endContainer(&context);
+    ksjson_endEncode(&context);
+
+    if (outResult != NULL) {
+        *outResult = addResult;
+    }
+    XCTAssertEqual([self checkFile:path atDepth:0], addResult, @"check and add must agree");
+    if (addResult != KSJSON_OK) {
+        return nil;
+    }
+    return [NSJSONSerialization JSONObjectWithData:encodedData options:0 error:nil][@"n"];
+}
+
+- (NSString *)spacesOfLength:(NSUInteger)length
+{
+    return [@"" stringByPaddingToLength:length withString:@" " startingAtIndex:0];
+}
+
+// Whether a number is whole cannot depend on where the read window happens to land, so the
+// decoder pulls in more of the file rather than deciding at the boundary.
+- (void)testNumberSplitAcrossTheFileWindow
+{
+    int result = KSJSON_OK;
+
+    // The window ends in the middle of the digits.
+    id value = [self
+        embedFileWithContent:[[self spacesOfLength:KSJSON_EMBEDDED_FILE_WINDOW - 2] stringByAppendingString:@"1234"]
+                      result:&result];
+    XCTAssertEqual(result, KSJSON_OK);
+    XCTAssertEqualObjects(value, @1234, @"digits past the window boundary must not be dropped");
+
+    // The window ends right after a lone zero, with the fraction still to come.
+    value = [self
+        embedFileWithContent:[[self spacesOfLength:KSJSON_EMBEDDED_FILE_WINDOW - 1] stringByAppendingString:@"0.5"]
+                      result:&result];
+    XCTAssertEqual(result, KSJSON_OK);
+    XCTAssertEqualObjects(value, @0.5, @"a zero at the boundary must not swallow its own fraction");
+
+    // The file ends exactly on the window, so the read is full and proves nothing.
+    value =
+        [self embedFileWithContent:[[self spacesOfLength:KSJSON_EMBEDDED_FILE_WINDOW - 1] stringByAppendingString:@"1"]
+                            result:&result];
+    XCTAssertEqual(result, KSJSON_OK, @"a file ending exactly on the window is still a whole file");
+    XCTAssertEqualObjects(value, @1);
+}
+
+// The end of the data completes a whole number. It does not complete a half-written one.
+- (void)testIncompleteAndMalformedNumbersAreRejected
+{
+    for (NSString *content in @[ @"1e", @"1e+", @"1e-", @"1.", @"-", @"-e1", @"01" ]) {
+        XCTAssertNotEqual([self checkElement:content.UTF8String atDepth:0], KSJSON_OK, @"%@", content);
+    }
+}
+
+- (void)testNumbersInsideContainersAreUnaffected
+{
+    for (NSString *content in @[ @"{\"a\":1}", @"[1]", @"[1,2]", @"[1.5,-2e3]", @"{\"a\":0}" ]) {
+        XCTAssertEqual([self checkElement:content.UTF8String atDepth:0], KSJSON_OK, @"%@", content);
+    }
+    for (NSString *content in @[ @"{\"a\":", @"[1,", @"{\"a\":1", @"[1e" ]) {
+        XCTAssertNotEqual([self checkElement:content.UTF8String atDepth:0], KSJSON_OK, @"%@", content);
+    }
+}
+
+// A number ends where the grammar says it ends, and what follows has to be something a
+// value may be followed by. Otherwise only the prefix that happens to parse is taken.
+- (void)testNumberFollowedByJunkIsRejected
+{
+    for (NSString *content in @[ @"1.2.3", @"1e2e3", @"1x", @"1.2x", @"12abc", @"[1x]", @"{\"a\":1x}" ]) {
+        XCTAssertNotEqual([self checkElement:content.UTF8String atDepth:0], KSJSON_OK, @"%@", content);
+    }
+}
+
+// A payload is one element, not "whatever parses first". Anything after it is an error, or
+// a payload is only ever as valid as its opening.
+- (void)testTrailingContentAfterTheTopLevelElementIsRejected
+{
+    for (NSString *content in @[ @"1 2", @"truejunk", @"{}[]", @"[1] [2]", @"\"a\" \"b\"", @"null null" ]) {
+        XCTAssertNotEqual([self checkElement:content.UTF8String atDepth:0], KSJSON_OK, @"%@", content);
+    }
+}
+
+// Whitespace around a payload is not trailing content.
+- (void)testSurroundingWhitespaceIsAccepted
+{
+    for (NSString *content in @[ @"  {\"a\":1}  ", @"[1]\n", @"1\n", @"\t\"x\" " ]) {
+        XCTAssertEqual([self checkElement:content.UTF8String atDepth:0], KSJSON_OK, @"%@", content);
+    }
+}
+
+// The public decoder is subject to the same rules. Nothing here goes through the embedding
+// path, so these pin the grammar and the end-of-data requirement on their own.
+- (void)testPublicDecoderRejectsJunkAfterAValue
+{
+    for (NSString *content in @[ @"[1x]", @"[1.2.3]", @"[1e2e3]", @"{\"a\":1x}" ]) {
+        NSError *error = nil;
+        XCTAssertNil([KSJSONCodec decode:toData(content) options:0 error:&error], @"%@", content);
+    }
+}
+
+- (void)testPublicDecoderRejectsTrailingContent
+{
+    for (NSString *content in @[ @"[1] [2]", @"{} junk", @"[1]x" ]) {
+        NSError *error = nil;
+        XCTAssertNil([KSJSONCodec decode:toData(content) options:0 error:&error], @"%@", content);
+    }
+    NSError *error = nil;
+    XCTAssertNotNil([KSJSONCodec decode:toData(@"  [1]  \n") options:0 error:&error],
+                    @"surrounding whitespace is not trailing content");
+}
+
+// Whitespace is the only thing that can fill a window without producing an element, so a
+// file can look truncated before the decoder has asked for any of the rest of it.
+- (void)testElementBeginningPastTheFirstWindow
+{
+    int result = KSJSON_OK;
+
+    // Exactly a window of whitespace, then the element.
+    id value =
+        [self embedFileWithContent:[[self spacesOfLength:KSJSON_EMBEDDED_FILE_WINDOW] stringByAppendingString:@"1"]
+                            result:&result];
+    XCTAssertEqual(result, KSJSON_OK, @"leading whitespace filling the window must not look like truncation");
+    XCTAssertEqualObjects(value, @1);
+
+    // Elements whose length is known up front, straddling the boundary.
+    for (NSUInteger pad = KSJSON_EMBEDDED_FILE_WINDOW - 3; pad <= KSJSON_EMBEDDED_FILE_WINDOW; pad++) {
+        value = [self embedFileWithContent:[[self spacesOfLength:pad] stringByAppendingString:@"true"] result:&result];
+        XCTAssertEqual(result, KSJSON_OK, @"true starting %lu bytes in", (unsigned long)pad);
+        XCTAssertEqualObjects(value, @YES);
+
+        value = [self embedFileWithContent:[[self spacesOfLength:pad] stringByAppendingString:@"null"] result:&result];
+        XCTAssertEqual(result, KSJSON_OK, @"null starting %lu bytes in", (unsigned long)pad);
+        XCTAssertEqualObjects(value, [NSNull null]);
+    }
+}
+
+// A string is scanned to its closing quote, which may be past the end of the window.
+- (void)testStringStraddlingTheFileWindow
+{
+    for (NSUInteger pad = KSJSON_EMBEDDED_FILE_WINDOW - 6; pad <= KSJSON_EMBEDDED_FILE_WINDOW; pad++) {
+        int result = KSJSON_OK;
+        id value = [self embedFileWithContent:[[self spacesOfLength:pad] stringByAppendingString:@"\"hello\""]
+                                       result:&result];
+        XCTAssertEqual(result, KSJSON_OK, @"string starting %lu bytes in", (unsigned long)pad);
+        XCTAssertEqualObjects(value, @"hello");
+    }
+}
+
+#pragma mark - Nesting
+
+// How much nesting is left depends on how deep the destination already is, so the check
+// has to be asked about a destination. One that just fits, and one that does not.
+- (void)testCheckAgreesWithAddAtTheDepthBoundary
+{
+    for (int destinationDepth = 0; destinationDepth <= 20; destinationDepth += 10) {
+        // ksjson_beginObject for the element itself takes one of the remaining levels.
+        const int justFits = KSJSON_MAX_CONTAINER_DEPTH - destinationDepth - 2;
+
+        for (int payloadDepth = justFits - 1; payloadDepth <= justFits + 2; payloadDepth++) {
+            const char *bytes = [self nestedPayloadOfDepth:payloadDepth].UTF8String;
+
+            NSMutableData *encodedData = [NSMutableData data];
+            KSJSONEncodeContext context = { 0 };
+            ksjson_beginEncode(&context, false, addJSONData, (__bridge void *)(encodedData));
+            [self nestEncoder:&context toDepth:destinationDepth];
+
+            int checkResult = ksjson_checkJSONElement(&context, bytes, (int)strlen(bytes));
+            int addResult = ksjson_addJSONElement(&context, NULL, bytes, (int)strlen(bytes), true);
+            XCTAssertEqual(checkResult, addResult, @"payload %d deep into a destination %d deep", payloadDepth,
+                           destinationDepth);
+        }
+
+        XCTAssertEqual([self checkElement:[self nestedPayloadOfDepth:justFits].UTF8String atDepth:destinationDepth],
+                       KSJSON_OK, @"a payload that fits must be accepted at depth %d", destinationDepth);
+        XCTAssertEqual([self checkElement:[self nestedPayloadOfDepth:justFits + 2].UTF8String atDepth:destinationDepth],
+                       KSJSON_ERROR_DATA_TOO_LONG, @"a payload that does not fit must be refused at depth %d",
+                       destinationDepth);
+    }
+}
+
+#pragma mark - String limits
+
+/** A JSON payload whose single key or value decodes to `decodedLength` bytes, written
+ * using `escape` repeated as needed.
+ */
+- (NSString *)payloadWithEscape:(NSString *)escape count:(int)count inKey:(BOOL)inKey
+{
+    NSMutableString *repeated = [NSMutableString string];
+    for (int i = 0; i < count; i++) {
+        [repeated appendString:escape];
+    }
+    return inKey ? [NSString stringWithFormat:@"{\"%@\":1}", repeated]
+                 : [NSString stringWithFormat:@"{\"a\":\"%@\"}", repeated];
+}
+
+// The limit is on decoded bytes. Escapes only ever shrink, so what matters is what the
+// value becomes, not how wide it was written.
+- (void)testStringLimitCountsDecodedBytes
+{
+    // \n is two source bytes for one decoded byte.
+    XCTAssertEqual(
+        [self checkElement:[self payloadWithEscape:@"\\n" count:KSJSON_MAX_EMBEDDED_STRING_LENGTH inKey:NO].UTF8String
+                   atDepth:0],
+        KSJSON_OK, @"a value of exactly the limit must fit");
+    XCTAssertEqual(
+        [self
+            checkElement:[self payloadWithEscape:@"\\n" count:KSJSON_MAX_EMBEDDED_STRING_LENGTH + 1 inKey:NO].UTF8String
+                 atDepth:0],
+        KSJSON_ERROR_DATA_TOO_LONG, @"one decoded byte over the limit must be refused");
+
+    // a is six source bytes for one decoded byte.
+    XCTAssertEqual(
+        [self
+            checkElement:[self payloadWithEscape:@"\\u0061" count:KSJSON_MAX_EMBEDDED_STRING_LENGTH inKey:NO].UTF8String
+                 atDepth:0],
+        KSJSON_OK, @"one-byte escapes must be charged one byte each");
+    XCTAssertEqual([self checkElement:[self payloadWithEscape:@"\\u0061"
+                                                        count:KSJSON_MAX_EMBEDDED_STRING_LENGTH + 1
+                                                        inKey:NO]
+                                          .UTF8String
+                              atDepth:0],
+                   KSJSON_ERROR_DATA_TOO_LONG);
+}
+
+// Three-byte code points and surrogate pairs are charged what they encode to.
+- (void)testStringLimitChargesWideCodePointsTheirRealWidth
+{
+    const int threeByteCount = KSJSON_MAX_EMBEDDED_STRING_LENGTH / 3;
+    XCTAssertEqual([self checkElement:[self payloadWithEscape:@"\\u4e2d" count:threeByteCount inKey:NO].UTF8String
+                              atDepth:0],
+                   KSJSON_OK, @"three-byte code points must fit up to the limit");
+    XCTAssertEqual([self checkElement:[self payloadWithEscape:@"\\u4e2d" count:threeByteCount + 1 inKey:NO].UTF8String
+                              atDepth:0],
+                   KSJSON_ERROR_DATA_TOO_LONG, @"and must be refused past it");
+
+    // A surrogate pair is twelve source bytes for four decoded ones.
+    const int pairCount = KSJSON_MAX_EMBEDDED_STRING_LENGTH / 4;
+    XCTAssertEqual([self checkElement:[self payloadWithEscape:@"\\ud83d\\ude00" count:pairCount inKey:NO].UTF8String
+                              atDepth:0],
+                   KSJSON_OK, @"surrogate pairs must fit up to the limit");
+    XCTAssertEqual([self checkElement:[self payloadWithEscape:@"\\ud83d\\ude00" count:pairCount + 1 inKey:NO].UTF8String
+                              atDepth:0],
+                   KSJSON_ERROR_DATA_TOO_LONG, @"and must be refused past it");
+}
+
+// Keys go through the same decoder as values and are bounded the same way.
+- (void)testStringLimitAppliesToKeysAsWell
+{
+    XCTAssertEqual([self checkElement:[self payloadWithEscape:@"\\u0061"
+                                                        count:KSJSON_MAX_EMBEDDED_STRING_LENGTH
+                                                        inKey:YES]
+                                          .UTF8String
+                              atDepth:0],
+                   KSJSON_OK, @"a key of exactly the limit must fit");
+    XCTAssertEqual([self checkElement:[self payloadWithEscape:@"\\u0061"
+                                                        count:KSJSON_MAX_EMBEDDED_STRING_LENGTH + 1
+                                                        inKey:YES]
+                                          .UTF8String
+                              atDepth:0],
+                   KSJSON_ERROR_DATA_TOO_LONG, @"one decoded byte over the limit must be refused in a key too");
+}
+
+// Values embed unchanged, escapes and all.
+- (void)testEscapedValuesRoundTripThroughEmbedding
+{
+    const char *json = "{\"a\":\"x\\u0061\\u4e2d\\ud83d\\ude00\\n\"}";
+
+    NSMutableData *encodedData = [NSMutableData data];
+    KSJSONEncodeContext context = { 0 };
+    ksjson_beginEncode(&context, false, addJSONData, (__bridge void *)(encodedData));
+    XCTAssertEqual(ksjson_addJSONElement(&context, NULL, json, (int)strlen(json), true), KSJSON_OK);
+    ksjson_endEncode(&context);
+
+    NSDictionary *decoded = [NSJSONSerialization JSONObjectWithData:encodedData options:0 error:nil];
+    XCTAssertEqualObjects(decoded[@"a"], @"xa中\U0001F600\n");
 }
 
 - (void)testCheckJSONFile
 {
     NSString *goodPath = [self.tempPath stringByAppendingPathComponent:@"good.json"];
     XCTAssertTrue([[@"{\"a\":1}" dataUsingEncoding:NSUTF8StringEncoding] writeToFile:goodPath atomically:YES]);
-    XCTAssertEqual(ksjson_checkJSONFile(goodPath.UTF8String), KSJSON_OK);
+    XCTAssertEqual([self checkFile:goodPath atDepth:0], KSJSON_OK);
 
     NSString *badPath = [self.tempPath stringByAppendingPathComponent:@"bad.json"];
     NSData *badData = [[self jsonWithOversizedString] dataUsingEncoding:NSUTF8StringEncoding];
     XCTAssertTrue([badData writeToFile:badPath atomically:YES]);
-    XCTAssertEqual(ksjson_checkJSONFile(badPath.UTF8String), KSJSON_ERROR_DATA_TOO_LONG);
+    XCTAssertEqual([self checkFile:badPath atDepth:0], KSJSON_ERROR_DATA_TOO_LONG);
 
     NSString *missingPath = [self.tempPath stringByAppendingPathComponent:@"nope.json"];
-    XCTAssertNotEqual(ksjson_checkJSONFile(missingPath.UTF8String), KSJSON_OK);
+    XCTAssertNotEqual([self checkFile:missingPath atDepth:0], KSJSON_OK);
 }
 
 - (void)testEncoderRefusesToNestPastItsLimit

--- a/Tests/KSCrashRecordingCoreTests/KSJSONCodec_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSJSONCodec_Tests.m
@@ -1388,6 +1388,33 @@ static int addJSONData(const char *data, int length, void *userData)
     [self expectEquivalentJSON:encodedData.bytes toJSON:expectedJson];
 }
 
+- (void)testFailedAddJSONElementRebalancesContainers
+{
+    // A string value longer than the decoder's 5000-byte string buffer fails the element
+    // mid-parse. The opened containers must be closed again, or everything written
+    // afterwards would nest inside the failed element.
+    NSMutableString *json = [NSMutableString stringWithString:@"{\"blob\":\""];
+    for (int i = 0; i < 6000; i++) {
+        [json appendString:@"A"];
+    }
+    [json appendString:@"\"}"];
+
+    NSMutableData *encodedData = [NSMutableData data];
+    KSJSONEncodeContext context = { 0 };
+    ksjson_beginEncode(&context, false, addJSONData, (__bridge void *)(encodedData));
+    ksjson_beginObject(&context, NULL);
+    int result = ksjson_addJSONElement(&context, "bad", json.UTF8String, (int)json.length, false);
+    XCTAssertNotEqual(result, KSJSON_OK);
+    ksjson_addStringElement(&context, "after", "value", KSJSON_SIZE_AUTOMATIC);
+    ksjson_endContainer(&context);
+    ksjson_endEncode(&context);
+
+    NSError *error = nil;
+    id decoded = [NSJSONSerialization JSONObjectWithData:encodedData options:0 error:&error];
+    XCTAssertNotNil(decoded, @"report must stay well-formed after a failed element: %@", error);
+    XCTAssertEqualObjects(decoded[@"after"], @"value", @"the next element must land at the original level");
+}
+
 - (void)testSerializeDeserializeIntegerEdgeCases
 {
     [self testIntegerSerialization:INT_MAX];

--- a/Tests/KSCrashRecordingCoreTests/KSJSONCodec_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSJSONCodec_Tests.m
@@ -1334,17 +1334,15 @@ static int addJSONData(const char *data, int length, void *userData)
     [self expectData:encodedData encodesObject:expectedObject];
 }
 
+// A truncated file is rejected whole rather than embedded as far as it parsed, so the
+// element it would have written is simply absent and the caller's name is still free.
 - (void)testAddJSONFromBrokenFile
 {
     NSString *savedFilename = [self.tempPath stringByAppendingPathComponent:@"broken.json"];
     char *savedJSON = "{"
                       "\"an_object\": {";
     char *expectedJSON = "{"
-                         "\"1\": \"one\","
-                         "\"from_file\": {"
-                         "\"an_object\": {"
-                         "}"
-                         "}"
+                         "\"1\": \"one\""
                          "}";
 
     NSData *data = [NSData dataWithBytes:savedJSON length:strlen(savedJSON)];
@@ -1363,7 +1361,7 @@ static int addJSONData(const char *data, int length, void *userData)
     ksjson_beginEncode(&context, false, addJSONData, (__bridge void *)(encodedData));
     ksjson_beginObject(&context, NULL);
     ksjson_addStringElement(&context, "1", "one", KSJSON_SIZE_AUTOMATIC);
-    ksjson_addJSONFromFile(&context, "from_file", savedFilename.UTF8String, true);
+    XCTAssertNotEqual(ksjson_addJSONFromFile(&context, "from_file", savedFilename.UTF8String, true), KSJSON_OK);
     ksjson_endContainer(&context);
     ksjson_endEncode(&context);
 
@@ -1388,23 +1386,39 @@ static int addJSONData(const char *data, int length, void *userData)
     [self expectEquivalentJSON:encodedData.bytes toJSON:expectedJson];
 }
 
-/** JSON whose string value overflows either decoder's string buffer (500 bytes reading from a
- * file, 5000 in memory), so the element fails mid-parse with its object container already open.
+/** Valid JSON whose string value is past KSJSON_MAX_EMBEDDED_STRING_LENGTH, so the decoder
+ * refuses it even though the payload itself is well-formed.
  */
 - (NSString *)jsonWithOversizedString
 {
     NSMutableString *json = [NSMutableString stringWithString:@"{\"blob\":\""];
-    for (int i = 0; i < 6000; i++) {
+    for (int i = 0; i < KSJSON_MAX_EMBEDDED_STRING_LENGTH + 1000; i++) {
         [json appendString:@"A"];
     }
     [json appendString:@"\"}"];
     return json;
 }
 
-- (void)testFailedAddJSONElementRebalancesContainers
+/** Valid JSON nested past KSJSON_MAX_CONTAINER_DEPTH. */
+- (NSString *)jsonNestedTooDeep
 {
-    // The containers the failed element opened must be closed again, or everything written
-    // afterwards would nest inside it.
+    NSMutableString *json = [NSMutableString string];
+    int depth = KSJSON_MAX_CONTAINER_DEPTH + 50;
+    for (int i = 0; i < depth; i++) {
+        [json appendString:@"["];
+    }
+    [json appendString:@"1"];
+    for (int i = 0; i < depth; i++) {
+        [json appendString:@"]"];
+    }
+    return json;
+}
+
+- (void)testRejectedAddJSONElementWritesNothing
+{
+    // The encoder emits as it decodes, so a payload that only fails partway would leave a
+    // truncated element the caller can neither see nor take back. Rejection has to happen
+    // before the first byte, which is what lets the caller put its own element here instead.
     const char *json = [self jsonWithOversizedString].UTF8String;
 
     NSMutableData *encodedData = [NSMutableData data];
@@ -1412,18 +1426,21 @@ static int addJSONData(const char *data, int length, void *userData)
     ksjson_beginEncode(&context, false, addJSONData, (__bridge void *)(encodedData));
     ksjson_beginObject(&context, NULL);
     int result = ksjson_addJSONElement(&context, "bad", json, (int)strlen(json), false);
-    XCTAssertNotEqual(result, KSJSON_OK);
+    XCTAssertEqual(result, KSJSON_ERROR_DATA_TOO_LONG);
+    XCTAssertEqual(encodedData.length, 1u, @"a rejected payload must not write anything past the '{'");
+
     ksjson_addStringElement(&context, "after", "value", KSJSON_SIZE_AUTOMATIC);
     ksjson_endContainer(&context);
     ksjson_endEncode(&context);
 
     NSError *error = nil;
     id decoded = [NSJSONSerialization JSONObjectWithData:encodedData options:0 error:&error];
-    XCTAssertNotNil(decoded, @"report must stay well-formed after a failed element: %@", error);
+    XCTAssertNotNil(decoded, @"output must stay well-formed after a rejected element: %@", error);
+    XCTAssertNil(decoded[@"bad"], @"the rejected element must be absent, not partially present");
     XCTAssertEqualObjects(decoded[@"after"], @"value", @"the next element must land at the original level");
 }
 
-- (void)testFailedAddJSONFromFileRebalancesContainers
+- (void)testRejectedAddJSONFromFileWritesNothing
 {
     NSString *savedFilename = [self.tempPath stringByAppendingPathComponent:@"oversized.json"];
     NSData *savedData = [[self jsonWithOversizedString] dataUsingEncoding:NSUTF8StringEncoding];
@@ -1434,15 +1451,120 @@ static int addJSONData(const char *data, int length, void *userData)
     ksjson_beginEncode(&context, false, addJSONData, (__bridge void *)(encodedData));
     ksjson_beginObject(&context, NULL);
     int result = ksjson_addJSONFromFile(&context, "bad", savedFilename.UTF8String, false);
-    XCTAssertNotEqual(result, KSJSON_OK);
+    XCTAssertEqual(result, KSJSON_ERROR_DATA_TOO_LONG);
+    XCTAssertEqual(encodedData.length, 1u, @"a rejected file must not write anything past the '{'");
+
     ksjson_addStringElement(&context, "after", "value", KSJSON_SIZE_AUTOMATIC);
     ksjson_endContainer(&context);
     ksjson_endEncode(&context);
 
     NSError *error = nil;
     id decoded = [NSJSONSerialization JSONObjectWithData:encodedData options:0 error:&error];
-    XCTAssertNotNil(decoded, @"report must stay well-formed after a failed element: %@", error);
+    XCTAssertNotNil(decoded, @"output must stay well-formed after a rejected element: %@", error);
+    XCTAssertNil(decoded[@"bad"]);
     XCTAssertEqualObjects(decoded[@"after"], @"value", @"the next element must land at the original level");
+}
+
+- (void)testRejectedAddJSONElementLeavesContainerLevelUntouched
+{
+    // closeLastContainer=false hands the caller an open container on success. On rejection
+    // there is nothing to hand back, and the level must not drift either way or the caller's
+    // matching endContainer would close something else.
+    const char *json = [self jsonWithOversizedString].UTF8String;
+
+    NSMutableData *encodedData = [NSMutableData data];
+    KSJSONEncodeContext context = { 0 };
+    ksjson_beginEncode(&context, false, addJSONData, (__bridge void *)(encodedData));
+    ksjson_beginObject(&context, NULL);
+    int levelBefore = context.containerLevel;
+
+    XCTAssertNotEqual(ksjson_addJSONElement(&context, "bad", json, (int)strlen(json), false), KSJSON_OK);
+    XCTAssertEqual(context.containerLevel, levelBefore);
+
+    XCTAssertNotEqual(ksjson_addJSONElement(&context, "bad", json, (int)strlen(json), true), KSJSON_OK);
+    XCTAssertEqual(context.containerLevel, levelBefore);
+}
+
+- (void)testCheckJSONElementAgreesWithAdd
+{
+    NSDictionary<NSString *, NSString *> *cases = @{
+        @"valid object" : @"{\"a\":1}",
+        @"valid array" : @"[1,2,3]",
+        @"valid string" : @"\"hello\"",
+        @"malformed" : @"{\"a\":",
+        @"oversized string" : [self jsonWithOversizedString],
+        @"too deep" : [self jsonNestedTooDeep],
+    };
+
+    for (NSString *label in cases) {
+        const char *json = cases[label].UTF8String;
+        int checkResult = ksjson_checkJSONElement(json, (int)strlen(json));
+
+        NSMutableData *encodedData = [NSMutableData data];
+        KSJSONEncodeContext context = { 0 };
+        ksjson_beginEncode(&context, false, addJSONData, (__bridge void *)(encodedData));
+        ksjson_beginObject(&context, NULL);
+        int addResult = ksjson_addJSONElement(&context, "x", json, (int)strlen(json), true);
+
+        XCTAssertEqual(checkResult, addResult, @"check and add must agree for %@", label);
+    }
+}
+
+- (void)testCheckJSONElementRejectsOversizedKey
+{
+    NSMutableString *json = [NSMutableString stringWithString:@"{\""];
+    for (int i = 0; i < KSJSON_MAX_EMBEDDED_STRING_LENGTH + 1000; i++) {
+        [json appendString:@"k"];
+    }
+    [json appendString:@"\":1}"];
+
+    const char *bytes = json.UTF8String;
+    XCTAssertEqual(ksjson_checkJSONElement(bytes, (int)strlen(bytes)), KSJSON_ERROR_DATA_TOO_LONG);
+}
+
+- (void)testCheckJSONElementAcceptsPayloadLargerThanTheStringLimit
+{
+    // The limit is on each key and value, not on the payload, so a long run of short
+    // strings has to pass however big it gets.
+    NSMutableString *json = [NSMutableString stringWithString:@"{"];
+    for (int i = 0; i < 5000; i++) {
+        [json appendFormat:@"%@\"k%d\":\"v\"", i == 0 ? @"" : @",", i];
+    }
+    [json appendString:@"}"];
+
+    const char *bytes = json.UTF8String;
+    XCTAssertGreaterThan(strlen(bytes), (size_t)KSJSON_MAX_EMBEDDED_STRING_LENGTH);
+    XCTAssertEqual(ksjson_checkJSONElement(bytes, (int)strlen(bytes)), KSJSON_OK);
+}
+
+- (void)testCheckJSONFile
+{
+    NSString *goodPath = [self.tempPath stringByAppendingPathComponent:@"good.json"];
+    XCTAssertTrue([[@"{\"a\":1}" dataUsingEncoding:NSUTF8StringEncoding] writeToFile:goodPath atomically:YES]);
+    XCTAssertEqual(ksjson_checkJSONFile(goodPath.UTF8String), KSJSON_OK);
+
+    NSString *badPath = [self.tempPath stringByAppendingPathComponent:@"bad.json"];
+    NSData *badData = [[self jsonWithOversizedString] dataUsingEncoding:NSUTF8StringEncoding];
+    XCTAssertTrue([badData writeToFile:badPath atomically:YES]);
+    XCTAssertEqual(ksjson_checkJSONFile(badPath.UTF8String), KSJSON_ERROR_DATA_TOO_LONG);
+
+    NSString *missingPath = [self.tempPath stringByAppendingPathComponent:@"nope.json"];
+    XCTAssertNotEqual(ksjson_checkJSONFile(missingPath.UTF8String), KSJSON_OK);
+}
+
+- (void)testEncoderRefusesToNestPastItsLimit
+{
+    // isObject[] is indexed by containerLevel, so this is a bounds check, not a policy.
+    NSMutableData *encodedData = [NSMutableData data];
+    KSJSONEncodeContext context = { 0 };
+    ksjson_beginEncode(&context, false, addJSONData, (__bridge void *)(encodedData));
+
+    int depth = 0;
+    while (ksjson_beginArray(&context, NULL) == KSJSON_OK) {
+        depth++;
+        XCTAssertLessThan(depth, KSJSON_MAX_CONTAINER_DEPTH + 1, @"beginArray must stop before overrunning isObject");
+    }
+    XCTAssertLessThan(context.containerLevel, KSJSON_MAX_CONTAINER_DEPTH);
 }
 
 - (void)testSerializeDeserializeIntegerEdgeCases

--- a/Tests/KSCrashRecordingCoreTests/KSJSONCodec_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSJSONCodec_Tests.m
@@ -1388,22 +1388,52 @@ static int addJSONData(const char *data, int length, void *userData)
     [self expectEquivalentJSON:encodedData.bytes toJSON:expectedJson];
 }
 
-- (void)testFailedAddJSONElementRebalancesContainers
+/** JSON whose string value overflows either decoder's string buffer (500 bytes reading from a
+ * file, 5000 in memory), so the element fails mid-parse with its object container already open.
+ */
+- (NSString *)jsonWithOversizedString
 {
-    // A string value longer than the decoder's 5000-byte string buffer fails the element
-    // mid-parse. The opened containers must be closed again, or everything written
-    // afterwards would nest inside the failed element.
     NSMutableString *json = [NSMutableString stringWithString:@"{\"blob\":\""];
     for (int i = 0; i < 6000; i++) {
         [json appendString:@"A"];
     }
     [json appendString:@"\"}"];
+    return json;
+}
+
+- (void)testFailedAddJSONElementRebalancesContainers
+{
+    // The containers the failed element opened must be closed again, or everything written
+    // afterwards would nest inside it.
+    const char *json = [self jsonWithOversizedString].UTF8String;
 
     NSMutableData *encodedData = [NSMutableData data];
     KSJSONEncodeContext context = { 0 };
     ksjson_beginEncode(&context, false, addJSONData, (__bridge void *)(encodedData));
     ksjson_beginObject(&context, NULL);
-    int result = ksjson_addJSONElement(&context, "bad", json.UTF8String, (int)json.length, false);
+    int result = ksjson_addJSONElement(&context, "bad", json, (int)strlen(json), false);
+    XCTAssertNotEqual(result, KSJSON_OK);
+    ksjson_addStringElement(&context, "after", "value", KSJSON_SIZE_AUTOMATIC);
+    ksjson_endContainer(&context);
+    ksjson_endEncode(&context);
+
+    NSError *error = nil;
+    id decoded = [NSJSONSerialization JSONObjectWithData:encodedData options:0 error:&error];
+    XCTAssertNotNil(decoded, @"report must stay well-formed after a failed element: %@", error);
+    XCTAssertEqualObjects(decoded[@"after"], @"value", @"the next element must land at the original level");
+}
+
+- (void)testFailedAddJSONFromFileRebalancesContainers
+{
+    NSString *savedFilename = [self.tempPath stringByAppendingPathComponent:@"oversized.json"];
+    NSData *savedData = [[self jsonWithOversizedString] dataUsingEncoding:NSUTF8StringEncoding];
+    XCTAssertTrue([savedData writeToFile:savedFilename atomically:YES]);
+
+    NSMutableData *encodedData = [NSMutableData data];
+    KSJSONEncodeContext context = { 0 };
+    ksjson_beginEncode(&context, false, addJSONData, (__bridge void *)(encodedData));
+    ksjson_beginObject(&context, NULL);
+    int result = ksjson_addJSONFromFile(&context, "bad", savedFilename.UTF8String, false);
     XCTAssertNotEqual(result, KSJSON_OK);
     ksjson_addStringElement(&context, "after", "value", KSJSON_SIZE_AUTOMATIC);
     ksjson_endContainer(&context);

--- a/Tests/KSCrashRecordingTests/KSCrashReportC_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashReportC_Tests.m
@@ -296,6 +296,103 @@
 #endif
 }
 
+// A user-info payload the codec cannot re-decode (here: a string over the decoder's
+// per-string buffer) must not unbalance the report: sections after the user info have to
+// land in the report root and the file must stay valid JSON.
+- (void)testWriteStandardReportSurvivesOversizedUserInfoString
+{
+    struct KSMachineContext machineContext = { 0 };
+    XCTAssertTrue(ksmc_getContextForThread(pthread_mach_thread_np(pthread_self()), &machineContext, true));
+    KSCrash_MonitorContext context = { 0 };
+    snprintf(context.eventID, sizeof(context.eventID), "USERINFOTEST");
+    context.offendingMachineContext = &machineContext;
+    context.registersAreValid = true;
+    context.omitBinaryImages = true;
+    context.monitorId = kscm_machexception_getAPI()->monitorId(NULL);
+    context.mach.type = EXC_BAD_ACCESS;
+    context.signal.signum = SIGBUS;
+
+    NSString *bigValue = [@"" stringByPaddingToLength:6000 withString:@"x" startingAtIndex:0];
+    NSString *userJSON = [NSString stringWithFormat:@"{\"big\":\"%@\"}", bigValue];
+    kscrashreport_setUserInfoJSON(userJSON.UTF8String);
+
+    NSString *path = [self temporaryReportPath];
+    @try {
+        kscrashreport_writeStandardReport(&context, path.UTF8String);
+
+        NSDictionary *json = [self readJSONObjectAtPath:path];
+        XCTAssertNotNil(json[@"debug"], @"sections after a failed user info must stay in the report root");
+        XCTAssertTrue([json[@"user"] isKindOfClass:[NSDictionary class]],
+                      @"the codec's error element is the report's user section");
+    } @finally {
+        [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
+        kscrashreport_setUserInfoJSON(NULL);
+    }
+}
+
+// An array user-info payload leaves an array open where the callback's keyed fields cannot
+// land; the writer closes it and keeps the payload verbatim under a single user key.
+- (void)testWriteStandardReportSurvivesArrayUserInfo
+{
+    struct KSMachineContext machineContext = { 0 };
+    XCTAssertTrue(ksmc_getContextForThread(pthread_mach_thread_np(pthread_self()), &machineContext, true));
+    KSCrash_MonitorContext context = { 0 };
+    snprintf(context.eventID, sizeof(context.eventID), "USERINFOTEST3");
+    context.offendingMachineContext = &machineContext;
+    context.registersAreValid = true;
+    context.omitBinaryImages = true;
+    context.monitorId = kscm_machexception_getAPI()->monitorId(NULL);
+    context.mach.type = EXC_BAD_ACCESS;
+    context.signal.signum = SIGBUS;
+
+    kscrashreport_setUserInfoJSON("[1,2,3]");
+
+    NSString *path = [self temporaryReportPath];
+    @try {
+        kscrashreport_writeStandardReport(&context, path.UTF8String);
+
+        NSDictionary *json = [self readJSONObjectAtPath:path];
+        XCTAssertNotNil(json[@"debug"]);
+        NSArray *expected = @[ @1, @2, @3 ];
+        XCTAssertEqualObjects(json[@"user"], expected);
+    } @finally {
+        [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
+        kscrashreport_setUserInfoJSON(NULL);
+    }
+}
+
+// A scalar user-info payload is rejected by the codec (its error element becomes the user
+// section, closed); the writer must skip the user-section callback instead of spilling
+// into the report root.
+- (void)testWriteStandardReportSurvivesScalarUserInfo
+{
+    struct KSMachineContext machineContext = { 0 };
+    XCTAssertTrue(ksmc_getContextForThread(pthread_mach_thread_np(pthread_self()), &machineContext, true));
+    KSCrash_MonitorContext context = { 0 };
+    snprintf(context.eventID, sizeof(context.eventID), "USERINFOTEST2");
+    context.offendingMachineContext = &machineContext;
+    context.registersAreValid = true;
+    context.omitBinaryImages = true;
+    context.monitorId = kscm_machexception_getAPI()->monitorId(NULL);
+    context.mach.type = EXC_BAD_ACCESS;
+    context.signal.signum = SIGBUS;
+
+    kscrashreport_setUserInfoJSON("42");
+
+    NSString *path = [self temporaryReportPath];
+    @try {
+        kscrashreport_writeStandardReport(&context, path.UTF8String);
+
+        NSDictionary *json = [self readJSONObjectAtPath:path];
+        XCTAssertNotNil(json[@"debug"]);
+        XCTAssertEqualObjects(json[@"user"][@"json_data"], @"42",
+                              @"the rejected payload is preserved in the codec's error element");
+    } @finally {
+        [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
+        kscrashreport_setUserInfoJSON(NULL);
+    }
+}
+
 /**
  * Test concurrent reads don't interfere with each other.
  */

--- a/Tests/KSCrashRecordingTests/KSCrashReportC_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashReportC_Tests.m
@@ -28,6 +28,7 @@
 
 #import "KSCrashMonitor_MachException.h"
 #import "KSCrashReportC.h"
+#import "KSJSONCodec.h"
 #import "KSMachineContext.h"
 #import "KSStackCursor_SelfThread.h"
 
@@ -296,10 +297,8 @@
 #endif
 }
 
-// A user-info payload the codec cannot re-decode (here: a string over the decoder's
-// per-string buffer) must not unbalance the report: sections after the user info have to
-// land in the report root and the file must stay valid JSON.
-- (void)testWriteStandardReportSurvivesOversizedUserInfoString
+/** Write a report carrying the given user info and hand back the file's raw bytes. */
+- (NSString *)rawReportWithUserInfoJSON:(const char *)userInfoJSON
 {
     struct KSMachineContext machineContext = { 0 };
     XCTAssertTrue(ksmc_getContextForThread(pthread_mach_thread_np(pthread_self()), &machineContext, true));
@@ -312,85 +311,107 @@
     context.mach.type = EXC_BAD_ACCESS;
     context.signal.signum = SIGBUS;
 
-    NSString *bigValue = [@"" stringByPaddingToLength:6000 withString:@"x" startingAtIndex:0];
-    NSString *userJSON = [NSString stringWithFormat:@"{\"big\":\"%@\"}", bigValue];
-    kscrashreport_setUserInfoJSON(userJSON.UTF8String);
-
+    kscrashreport_setUserInfoJSON(userInfoJSON);
     NSString *path = [self temporaryReportPath];
     @try {
         kscrashreport_writeStandardReport(&context, path.UTF8String);
-
-        NSDictionary *json = [self readJSONObjectAtPath:path];
-        XCTAssertNotNil(json[@"debug"], @"sections after a failed user info must stay in the report root");
-        XCTAssertTrue([json[@"user"] isKindOfClass:[NSDictionary class]],
-                      @"the codec's error element is the report's user section");
+        return [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
     } @finally {
         [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
         kscrashreport_setUserInfoJSON(NULL);
     }
 }
 
-// An array user-info payload leaves an array open where the callback's keyed fields cannot
-// land; the writer closes it and keeps the payload verbatim under a single user key.
-- (void)testWriteStandardReportSurvivesArrayUserInfo
+- (NSUInteger)countOfString:(NSString *)needle in:(NSString *)haystack
 {
-    struct KSMachineContext machineContext = { 0 };
-    XCTAssertTrue(ksmc_getContextForThread(pthread_mach_thread_np(pthread_self()), &machineContext, true));
-    KSCrash_MonitorContext context = { 0 };
-    snprintf(context.eventID, sizeof(context.eventID), "USERINFOTEST3");
-    context.offendingMachineContext = &machineContext;
-    context.registersAreValid = true;
-    context.omitBinaryImages = true;
-    context.monitorId = kscm_machexception_getAPI()->monitorId(NULL);
-    context.mach.type = EXC_BAD_ACCESS;
-    context.signal.signum = SIGBUS;
+    NSUInteger count = 0;
+    NSRange search = NSMakeRange(0, haystack.length);
+    while (search.length > 0) {
+        NSRange found = [haystack rangeOfString:needle options:0 range:search];
+        if (found.location == NSNotFound) {
+            break;
+        }
+        count++;
+        search = NSMakeRange(NSMaxRange(found), haystack.length - NSMaxRange(found));
+    }
+    return count;
+}
 
-    kscrashreport_setUserInfoJSON("[1,2,3]");
+// Whatever the payload is, the report gets exactly one user section and stays parseable.
+// Counted against the raw bytes on purpose: NSJSONSerialization keeps the last of a
+// duplicated key and would hide the very thing this is guarding.
+- (void)testWriteStandardReportWritesExactlyOneUserSection
+{
+    NSString *oversized = [@"" stringByPaddingToLength:KSJSON_MAX_EMBEDDED_STRING_LENGTH + 1000
+                                            withString:@"x"
+                                       startingAtIndex:0];
+    NSMutableString *tooDeep = [NSMutableString string];
+    int depth = KSJSON_MAX_CONTAINER_DEPTH + 50;
+    for (int i = 0; i < depth; i++) {
+        [tooDeep appendString:@"["];
+    }
+    [tooDeep appendString:@"1"];
+    for (int i = 0; i < depth; i++) {
+        [tooDeep appendString:@"]"];
+    }
 
-    NSString *path = [self temporaryReportPath];
-    @try {
-        kscrashreport_writeStandardReport(&context, path.UTF8String);
+    NSDictionary<NSString *, NSString *> *payloads = @{
+        @"object" : @"{\"ok\":1}",
+        @"array" : @"[1,2,3]",
+        @"string" : @"\"just a string\"",
+        @"malformed" : @"{\"nope\":",
+        @"oversized value" : [NSString stringWithFormat:@"{\"big\":\"%@\"}", oversized],
+        @"oversized value nested" : [NSString stringWithFormat:@"{\"a\":{\"big\":\"%@\"}}", oversized],
+        @"oversized value in array" : [NSString stringWithFormat:@"[\"%@\"]", oversized],
+        @"oversized key" : [NSString stringWithFormat:@"{\"%@\":1}", oversized],
+        @"too deep" : tooDeep,
+    };
 
-        NSDictionary *json = [self readJSONObjectAtPath:path];
-        XCTAssertNotNil(json[@"debug"]);
-        NSArray *expected = @[ @1, @2, @3 ];
-        XCTAssertEqualObjects(json[@"user"], expected);
-    } @finally {
-        [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
-        kscrashreport_setUserInfoJSON(NULL);
+    for (NSString *label in payloads) {
+        NSString *raw = [self rawReportWithUserInfoJSON:payloads[label].UTF8String];
+        XCTAssertNotNil(raw, @"%@", label);
+
+        XCTAssertEqual([self countOfString:@"\"user\":" in:raw], 1u, @"%@ must produce one user section", label);
+
+        NSError *error = nil;
+        id decoded = [NSJSONSerialization JSONObjectWithData:[raw dataUsingEncoding:NSUTF8StringEncoding]
+                                                     options:0
+                                                       error:&error];
+        XCTAssertNotNil(decoded, @"%@ must leave the report parseable: %@", label, error);
+        XCTAssertNotNil(decoded[@"debug"], @"%@ must leave later sections in the report root", label);
     }
 }
 
-// A scalar user-info payload is rejected by the codec (its error element becomes the user
-// section, closed); the writer must skip the user-section callback instead of spilling
-// into the report root.
-- (void)testWriteStandardReportSurvivesScalarUserInfo
+// A payload the codec refuses is replaced whole by an error element carrying the original,
+// rather than being partially written and then annotated.
+- (void)testWriteStandardReportReplacesRejectedUserInfoWithAnError
 {
-    struct KSMachineContext machineContext = { 0 };
-    XCTAssertTrue(ksmc_getContextForThread(pthread_mach_thread_np(pthread_self()), &machineContext, true));
-    KSCrash_MonitorContext context = { 0 };
-    snprintf(context.eventID, sizeof(context.eventID), "USERINFOTEST2");
-    context.offendingMachineContext = &machineContext;
-    context.registersAreValid = true;
-    context.omitBinaryImages = true;
-    context.monitorId = kscm_machexception_getAPI()->monitorId(NULL);
-    context.mach.type = EXC_BAD_ACCESS;
-    context.signal.signum = SIGBUS;
+    NSString *oversized = [@"" stringByPaddingToLength:KSJSON_MAX_EMBEDDED_STRING_LENGTH + 1000
+                                            withString:@"x"
+                                       startingAtIndex:0];
+    NSString *payload = [NSString stringWithFormat:@"{\"big\":\"%@\"}", oversized];
+    NSString *raw = [self rawReportWithUserInfoJSON:payload.UTF8String];
 
-    kscrashreport_setUserInfoJSON("42");
+    NSDictionary *json = [NSJSONSerialization JSONObjectWithData:[raw dataUsingEncoding:NSUTF8StringEncoding]
+                                                         options:0
+                                                           error:nil];
+    XCTAssertEqualObjects(json[@"user"][@"error"], @"Invalid JSON data: Data too long");
+    XCTAssertEqualObjects(json[@"user"][@"json_data"], payload, @"the rejected payload is kept verbatim");
+    XCTAssertNil(json[@"user"][@"big"], @"none of the rejected payload may reach the report");
+}
 
-    NSString *path = [self temporaryReportPath];
-    @try {
-        kscrashreport_writeStandardReport(&context, path.UTF8String);
+// Payloads within the limits are embedded as themselves, not routed through the error path.
+- (void)testWriteStandardReportEmbedsAcceptedUserInfo
+{
+    NSString *raw = [self rawReportWithUserInfoJSON:"{\"ok\":1}"];
+    NSDictionary *json = [NSJSONSerialization JSONObjectWithData:[raw dataUsingEncoding:NSUTF8StringEncoding]
+                                                         options:0
+                                                           error:nil];
+    XCTAssertEqualObjects(json[@"user"], @{ @"ok" : @1 });
 
-        NSDictionary *json = [self readJSONObjectAtPath:path];
-        XCTAssertNotNil(json[@"debug"]);
-        XCTAssertEqualObjects(json[@"user"][@"json_data"], @"42",
-                              @"the rejected payload is preserved in the codec's error element");
-    } @finally {
-        [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
-        kscrashreport_setUserInfoJSON(NULL);
-    }
+    raw = [self rawReportWithUserInfoJSON:"[1,2,3]"];
+    json = [NSJSONSerialization JSONObjectWithData:[raw dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
+    XCTAssertEqualObjects(json[@"user"], (@[ @1, @2, @3 ]));
 }
 
 /**


### PR DESCRIPTION
`ksjson_addJSONElement` re-decodes and re-encodes its payload rather than copying it, and the encoder emits as the decoder reads. A payload that failed partway therefore left a truncated element behind, and since the caller could not see that, `addJSONElement` in KSCrashReportC.c went on to write its error object under the same key. Reports came out with two `"user"` sections.

The payload is now checked before anything is written. Both entry points run it through the same decoder twice, the first time with callbacks that reach no encoder, so a payload that cannot be embedded is rejected before the first byte and the error element takes its place rather than following it. That pass is also exposed as `ksjson_checkJSONElement` and `ksjson_checkJSONFile`, so a caller can ask at the point where it can still do something about the answer. Both take the destination context, because how much nesting is left depends on how deep the caller already is, and a context-free check cannot honestly promise to agree with an operation whose capacity depends on where it writes.

`addJSONElementFromFile` ignored its result entirely, so a bad file wrote a partial mess and reported nothing. It now writes the same error element as the string variant.

### What gets rejected

The limits are documented and raised. They bound each key and string value rather than the payload, so a long run of short strings passes however big it gets, and they count decoded bytes: escapes only ever shrink, so `a` costs the one byte it becomes rather than the six it was written as. Nesting is bounded as well, where `ksjson_beginObject` and `ksjson_beginArray` had been incrementing `containerLevel` with nothing stopping them running off the end of `isObject`.

Numbers are matched against the JSON grammar before any conversion. `sscanf` stops at the first character it cannot use, so it read `1e` as 1 and `1.2.3` as 1.2 rather than rejecting either, and nothing reaches it now until the whole token has matched. A payload is also one element, so trailing content after it is an error rather than something to decode past, and `1 2`, `truejunk` and `{}[]` no longer pass by parsing the part that parses.

### Reading past the window

The decoder reads a file through a sliding window, and everywhere it ran out of that window it treated the shortfall as the end of the data. A number is the only element with no closing delimiter of its own, so a window ending mid-token silently truncated it, and 16382 spaces followed by 1234 embedded as 12. Whitespace could fill an entire window before any element was parsed, so enough leading space made a valid file look truncated. A file whose length exactly equalled the window was rejected outright, because a full read never proves EOF.

The end of the data is now distinct from the end of the window. A flag says which one `bufferEnd` is, set only by a short read, and a refill hook pulls more in when an element needs it. Numbers and strings, scanned to an unknown length, refill from their own first character and rescan. `true`, `false` and `null` top up to the length they need. Whitespace tops up as it skips. Whether a payload is valid no longer depends on where the boundary happens to land.

### Two older bugs

Surrogate pairs were combined without the 0x10000 bias, so every astral-plane character decoded to an unrelated one and emoji in user info were silently corrupted. `testDeserializeUnicodeExtended` contained the same arithmetic error in its input, which is why the two agreed with each other for so long. Separately, `ksjson_decode` reported every error at offset 0, because the pointer it subtracted was assigned once and never advanced.

Nothing measured the embedding path before, so there are benchmarks for it now. Checking is measured separately from embedding, since embedding runs the check and then decodes a second time and a regression would otherwise be impossible to attribute.
