### PR TITLE
Seed report IDs from wall-clock nanoseconds (microseconds * 1K actually)

### DIFF
--- a/Sources/KSCrashRecording/KSCrashReportStoreC.m
+++ b/Sources/KSCrashRecording/KSCrashReportStoreC.m
@@ -33,6 +33,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 #include <uuid/uuid.h>
 
@@ -41,7 +42,6 @@
 #include "KSCrashMonitorRegistry.h"
 #include "KSCrashReportRunId.h"
 #include "KSCrashReportStoreC+Private.h"
-#include "KSDate.h"
 #include "KSFileUtils.h"
 #include "KSLogger.h"
 
@@ -461,23 +461,21 @@ static void pruneReports(const KSCrashReportStoreCConfiguration *const config)
         }
     }
 }
-// clang-format off
 static void initializeIDs(void)
 {
-    time_t rawTime = (time_t)ksdate_seconds();
-    struct tm time;
-    gmtime_r(&rawTime, &time);
-    int64_t baseID = (int64_t)time.tm_sec
-                   + (int64_t)time.tm_min * 61
-                   + (int64_t)time.tm_hour * 61 * 60
-                   + (int64_t)time.tm_yday * 61 * 60 * 24
-                   + (int64_t)time.tm_year * 61 * 60 * 24 * 366;
-    baseID <<= 23;
+    // Wall-clock nanoseconds: IDs roughly track creation time (pruning deletes lowest
+    // first; concurrent writers can still interleave numerically), and two writer
+    // processes seeding in the same instant (several short-lived extension reporters
+    // sharing one store) cannot collide the way the old seconds-derived seed could.
+    // Positive int64 until the year 2262.
+    int64_t baseID = (int64_t)clock_gettime_nsec_np(CLOCK_REALTIME);
 
-    g_nextUniqueIDHigh = baseID & ~(int64_t)0xffffffff;
-    g_nextUniqueIDLow = (uint32_t)(baseID & 0xffffffff);
+    // The counter starts at zero rather than carrying the seed's arbitrary low bits,
+    // which could start it near the 32-bit wrap and send IDs backwards after a handful
+    // of reports.
+    g_nextUniqueIDHigh = baseID;
+    g_nextUniqueIDLow = 0;
 }
-// clang-format on
 
 // Public API
 

--- a/Sources/KSCrashRecording/KSCrashReportStoreC.m
+++ b/Sources/KSCrashRecording/KSCrashReportStoreC.m
@@ -30,6 +30,7 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <pthread.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -50,9 +51,10 @@
 #import "KSCrashReportFixer.h"
 #import "KSJSONCodecObjC.h"
 
-// Have to use max 32-bit atomics because of MIPS.
-static _Atomic(uint32_t) g_nextUniqueIDLow;
-static int64_t g_nextUniqueIDHigh;
+// Minted from the crash handler without g_mutex: threads are suspended there, so whoever
+// holds the lock may never resume. Must stay lock-free for that same reason.
+_Static_assert(ATOMIC_LLONG_LOCK_FREE == 2, "report ID counter is minted in the crash handler");
+static _Atomic(int64_t) g_nextUniqueID;
 static pthread_mutex_t g_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 // The stitch config used by the no-config readers (readReportAtPath,
@@ -88,7 +90,7 @@ static int compareInt64(const void *a, const void *b)
     return 0;
 }
 
-static inline int64_t getNextUniqueID(void) { return g_nextUniqueIDHigh + g_nextUniqueIDLow++; }
+static inline int64_t getNextUniqueID(void) { return g_nextUniqueID++; }
 
 static void getCrashReportPathByID(int64_t id, char *pathBuffer, const KSCrashReportStoreCConfiguration *const config)
 {
@@ -463,18 +465,14 @@ static void pruneReports(const KSCrashReportStoreCConfiguration *const config)
 }
 static void initializeIDs(void)
 {
-    // Wall-clock nanoseconds: IDs roughly track creation time (pruning deletes lowest
-    // first; concurrent writers can still interleave numerically), and two writer
-    // processes seeding in the same instant (several short-lived extension reporters
-    // sharing one store) cannot collide the way the old seconds-derived seed could.
-    // Positive int64 until the year 2262.
-    int64_t baseID = (int64_t)clock_gettime_nsec_np(CLOCK_REALTIME);
-
-    // The counter starts at zero rather than carrying the seed's arbitrary low bits,
-    // which could start it near the 32-bit wrap and send IDs backwards after a handful
-    // of reports.
-    g_nextUniqueIDHigh = baseID;
-    g_nextUniqueIDLow = 0;
+    // CLOCK_REALTIME is gettimeofday-derived, so this is microsecond resolution expressed in
+    // nanoseconds: every seed is a multiple of 1000, and that scale factor doubles as the
+    // counter's headroom. Two processes sharing one store (short-lived extension reporters in
+    // an App Group) now have to initialize within the same microsecond to mint the same ID,
+    // where the old seconds-derived seed only needed the same second. Minting past 1000 IDs
+    // walks into later microseconds' seed space, widening that window rather than breaking;
+    // IDs stay unique and increasing within the process either way. Positive int64 until 2262.
+    g_nextUniqueID = (int64_t)clock_gettime_nsec_np(CLOCK_REALTIME);
 }
 
 // Public API
@@ -503,6 +501,8 @@ KSCrashInstallErrorCode kscrs_initialize(const KSCrashReportStoreCConfiguration 
 int64_t kscrs_getNextCrashReport(char *crashReportPathBuffer,
                                  const KSCrashReportStoreCConfiguration *const configuration)
 {
+    // Deliberately outside g_mutex: this runs in the crash handler. The atomic counter is
+    // what keeps concurrent minting unique.
     int64_t nextID = getNextUniqueID();
     if (crashReportPathBuffer) {
         getCrashReportPathByID(nextID, crashReportPathBuffer, configuration);

--- a/Tests/KSCrashRecordingTests/KSCrashReportStoreC_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashReportStoreC_Tests.m
@@ -234,6 +234,19 @@
     XCTAssertEqual(count, 0);
 }
 
+// Several short-lived writer processes can share one store (extension reporters in an App
+// Group), so a store seeded twice in the same instant must still mint distinct, increasing
+// IDs; the old seconds-derived seed re-minted the same first ID within a second.
+- (void)testReinitializedStoreMintsDistinctReportIDs
+{
+    [self prepareReportStoreWithPathEnd:@"testReinitializedStoreMintsDistinctReportIDs"];
+    char path[KSCRS_MAX_PATH_LENGTH];
+    int64_t firstID = kscrs_getNextCrashReport(path, &_storeConfig);
+    kscrs_initialize(&_storeConfig);
+    int64_t secondID = kscrs_getNextCrashReport(path, &_storeConfig);
+    XCTAssertGreaterThan(secondID, firstID);
+}
+
 - (void)testNextReportIDWithOneReport
 {
     [self prepareReportStoreWithPathEnd:@"testNextReportIDWithOneReport"];


### PR DESCRIPTION
The report store seeds its ID counter from the wall-clock second, which is fine while one long-lived process owns a store but collides when several short-lived processes write into a shared one: two processes initializing in the same second mint the same first report ID, and the second write overwrites the first report's file. An out-of-process crash reporter writing into an App Group store hits exactly this shape.

The seed is now the wall-clock nanosecond count, stored whole, with the counter starting at zero so its arbitrary low bits cannot start the counter near the 32-bit wrap and send IDs backwards. IDs roughly track creation time, so pruning still deletes oldest first, and a same-instant collision is practically impossible. A test covers re-initializing the store and minting a distinct, increasing ID.