### PR TITLE
3/7 Bound the eh_frame reads that take their length from the section

### DIFF
--- a/Sources/KSCrashRecordingCore/Unwind/KSDwarfUnwind.c
+++ b/Sources/KSCrashRecordingCore/Unwind/KSDwarfUnwind.c
@@ -155,6 +155,26 @@ static inline bool readerHasData(const KSDwarfReader *reader, size_t bytes)
     return reader->data + bytes <= reader->end;
 }
 
+/** Take a CFI expression of @c exprLen bytes from the reader.
+ *
+ * The length comes straight off the eh_frame bytes and is not otherwise bounded, so an
+ * implausible one must not be recorded: evaluateDwarfExpression derives its end as expr + len
+ * and would walk off the section. On rejection the reader is drained so the instruction loop
+ * stops rather than resuming at a misaligned offset.
+ *
+ * @return true if the expression fit, with @c outExpr set and the reader advanced past it.
+ */
+static inline bool readerTakeExpression(KSDwarfReader *reader, uint64_t exprLen, const uint8_t **outExpr)
+{
+    if (exprLen > (uint64_t)(reader->end - reader->data)) {
+        reader->data = reader->end;
+        return false;
+    }
+    *outExpr = reader->data;
+    reader->data += exprLen;
+    return true;
+}
+
 static inline uint8_t readU8(KSDwarfReader *reader)
 {
     if (!readerHasData(reader, 1)) return 0;
@@ -645,22 +665,28 @@ static bool executeCFIInstructions(const uint8_t *instructions, size_t len, cons
 
                 case DW_CFA_def_cfa_expression: {
                     uint64_t exprLen = readULEB128(&reader);
+                    const uint8_t *expr = NULL;
+                    if (!readerTakeExpression(&reader, exprLen, &expr)) {
+                        break;
+                    }
                     row->cfaRule = KSDwarfRuleExpression;
-                    row->cfaExpression = reader.data;
+                    row->cfaExpression = expr;
                     row->cfaExpressionLen = (size_t)exprLen;
-                    reader.data += exprLen;
                     break;
                 }
 
                 case DW_CFA_expression: {
                     uint64_t reg = readULEB128(&reader);
                     uint64_t exprLen = readULEB128(&reader);
+                    const uint8_t *expr = NULL;
+                    if (!readerTakeExpression(&reader, exprLen, &expr)) {
+                        break;
+                    }
                     if (reg < KSDWARF_MAX_REGISTERS) {
                         row->registers[reg].type = KSDwarfRuleExpression;
-                        row->registers[reg].expr = reader.data;
+                        row->registers[reg].expr = expr;
                         row->registers[reg].exprLen = (size_t)exprLen;
                     }
-                    reader.data += exprLen;
                     break;
                 }
 
@@ -712,12 +738,15 @@ static bool executeCFIInstructions(const uint8_t *instructions, size_t len, cons
                 case DW_CFA_val_expression: {
                     uint64_t reg = readULEB128(&reader);
                     uint64_t exprLen = readULEB128(&reader);
+                    const uint8_t *expr = NULL;
+                    if (!readerTakeExpression(&reader, exprLen, &expr)) {
+                        break;
+                    }
                     if (reg < KSDWARF_MAX_REGISTERS) {
                         row->registers[reg].type = KSDwarfRuleValExpression;
-                        row->registers[reg].expr = reader.data;
+                        row->registers[reg].expr = expr;
                         row->registers[reg].exprLen = (size_t)exprLen;
                     }
-                    reader.data += exprLen;
                     break;
                 }
 
@@ -1110,6 +1139,17 @@ bool ksdwarf_findFDE(const void *ehFrame, size_t ehFrameSize, uintptr_t targetPC
         const uint8_t *entryEnd = ptr + actualLength;
         if (entryEnd > end) break;
 
+        // The entry must be long enough to hold the CIE pointer/ID field that is read next.
+        // actualLength is untrusted and the loop guard only guarantees one byte past the length
+        // field, so without this a short entry reads past the end of the section. Skip it rather
+        // than abandoning the scan: entryEnd is already known to be inside the section and past
+        // ptr, so where the next entry starts is still known and later entries may hold the FDE.
+        const uint64_t ciePointerSize = entryIs64bit ? 8 : 4;
+        if (actualLength < ciePointerSize) {
+            ptr = entryEnd;
+            continue;
+        }
+
         // Read CIE pointer/ID
         uint64_t ciePointer = 0;
         if (entryIs64bit) {
@@ -1131,11 +1171,26 @@ bool ksdwarf_findFDE(const void *ehFrame, size_t ehFrameSize, uintptr_t targetPC
         // This is an FDE
         // ciePointer is an offset back to the CIE from the CIE pointer field
         // Per .eh_frame spec, this points to the CIE's length field (start of CIE record)
-        const uint8_t *cieLengthField = (entryStart - (uintptr_t)ciePointer);
-        if (cieLengthField < (const uint8_t *)ehFrame) {
+        //
+        // Every address below is derived in integer space and only turned back into a pointer
+        // once it is known to be inside the section. ciePointer and the CIE length are both read
+        // out of the eh_frame bytes, and forming an out-of-section address as a POINTER is
+        // already undefined at the moment it is computed, before any check could reject it.
+        const uintptr_t sectionStart = (uintptr_t)ehFrame;
+        const uintptr_t sectionEnd = (uintptr_t)end;
+
+        // Bounded at BOTH ends: below the section start, and with room for the four-byte length
+        // field read next, so one sitting within three bytes of the end cannot overread.
+        if (ciePointer > (uintptr_t)entryStart - sectionStart) {
             ptr = entryEnd;
             continue;
         }
+        const uintptr_t cieLengthFieldAddr = (uintptr_t)entryStart - (uintptr_t)ciePointer;
+        if (sectionEnd - cieLengthFieldAddr < 4) {
+            ptr = entryEnd;
+            continue;
+        }
+        const uint8_t *cieLengthField = (const uint8_t *)cieLengthFieldAddr;
 
         // Parse FDE to get PC range
         // First, parse the CIE - read length from the length field
@@ -1143,23 +1198,31 @@ bool ksdwarf_findFDE(const void *ehFrame, size_t ehFrameSize, uintptr_t targetPC
         memcpy(&cieLength32, cieLengthField, sizeof(cieLength32));
         bool cieIs64bit = false;
         uint64_t cieLength = cieLength32;
-        const uint8_t *cieIdField = NULL;
-        const uint8_t *cieDataStart = NULL;
+        uintptr_t cieIdFieldAddr = 0;
+        uintptr_t cieDataStartAddr = 0;
 
         if (cieLength32 == 0xFFFFFFFF) {
-            if (cieLengthField + 12 > end) {
+            if (sectionEnd - cieLengthFieldAddr < 12) {
                 ptr = entryEnd;
                 continue;
             }
             memcpy(&cieLength, cieLengthField + 4, sizeof(cieLength));
             cieIs64bit = true;
-            cieIdField = cieLengthField + 12;  // length marker (4) + length (8)
-            cieDataStart = cieIdField + 8;
+            cieIdFieldAddr = cieLengthFieldAddr + 12;  // length marker (4) + length (8)
+            cieDataStartAddr = cieIdFieldAddr + 8;
         } else {
             // CIE structure: [4: length][4: CIE_id=0][rest: CIE data]
-            cieIdField = cieLengthField + 4;
-            cieDataStart = cieIdField + 4;
+            cieIdFieldAddr = cieLengthFieldAddr + 4;
+            cieDataStartAddr = cieIdFieldAddr + 4;
         }
+
+        // Both forms step past the length field, so the data start can land outside a section
+        // that only just had room for the field itself.
+        if (cieDataStartAddr > sectionEnd) {
+            ptr = entryEnd;
+            continue;
+        }
+        const uint8_t *cieIdField = (const uint8_t *)cieIdFieldAddr;
 
         if (cieIs64bit != entryIs64bit) {
             ptr = entryEnd;
@@ -1173,10 +1236,11 @@ bool ksdwarf_findFDE(const void *ehFrame, size_t ehFrameSize, uintptr_t targetPC
         }
 
         size_t cieDataSize = (size_t)(cieLength - cieIdSize);
-        if (cieDataStart + cieDataSize > end) {
+        if (cieDataSize > sectionEnd - cieDataStartAddr) {
             ptr = entryEnd;
             continue;
         }
+        const uint8_t *cieDataStart = (const uint8_t *)cieDataStartAddr;
 
         KSDwarfCIE cie;
         if (!parseCIE(cieDataStart, cieDataSize, &cie)) {

--- a/Tests/KSCrashRecordingCoreTests/KSUnwind_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSUnwind_Tests.m
@@ -873,6 +873,83 @@ static void *ksunwind_test_thread_main(void *arg)
 // These tests verify DWARF CFI parsing using synthetic .eh_frame data.
 // They test specific CFI instructions that need coverage.
 
+/** Does an expression of @c len bytes at @c expr end at or before @c bufferEnd?
+ *
+ * Checked in integer space on purpose. The lengths under test are deliberately implausible, and
+ * forming @c expr+len would already be undefined before the comparison could reject it.
+ */
+static bool expressionEndsWithin(const uint8_t *expr, size_t len, const uint8_t *bufferEnd)
+{
+    return (uintptr_t)expr <= (uintptr_t)bufferEnd && len <= (uintptr_t)bufferEnd - (uintptr_t)expr;
+}
+
+- (void)testDwarf_ExpressionLengthPastEndOfBufferIsRejected
+{
+    // DW_CFA_def_cfa_expression, DW_CFA_expression and DW_CFA_val_expression each read their
+    // length as a ULEB128 straight out of the section. The evaluator later derives its end as
+    // expr + len, so a length larger than what is left must not be recorded: doing so walks off
+    // the buffer. Under ASan an unbounded read here is a heap-buffer-overflow.
+    const uint8_t cieData[] = {
+        0x00, 0x00, 0x00, 0x00,  // CIE ID
+        0x03,                    // version
+        'z',  'R',  0x00,        // augmentation "zR"
+        0x01,                    // code alignment
+        0x78,                    // data alignment (-8)
+        0x10,                    // return address register
+        0x01,                    // augmentation data length
+        0x03,                    // FDE pointer encoding: udata4
+        0x0C, 0x07, 0x08,        // DW_CFA_def_cfa r7, 8
+    };
+
+    // Each FDE ends with an expression opcode whose declared length runs far past the buffer.
+    const uint8_t defCfaExpr[] = {
+        0x00, 0x00, 0x00, 0x00,  // CIE pointer
+        0x00, 0x10, 0x00, 0x00,  // PC start 0x1000
+        0x00, 0x01, 0x00, 0x00,  // PC range 0x100
+        0x00,                    // augmentation data length
+        0x0F, 0xFF, 0xFF, 0x7F,  // DW_CFA_def_cfa_expression, len = huge ULEB128
+    };
+    const uint8_t regExpr[] = {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x01,
+        0x00, 0x00, 0x00, 0x10, 0x1E, 0xFF, 0xFF, 0xFF, 0x7F,  // DW_CFA_expression, reg 30, len = huge
+    };
+    const uint8_t valExpr[] = {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x01,
+        0x00, 0x00, 0x00, 0x16, 0x1E, 0xFF, 0xFF, 0xFF, 0x7F,  // DW_CFA_val_expression, reg 30, len = huge
+    };
+
+    const struct {
+        const uint8_t *fde;
+        size_t size;
+        const char *name;
+    } cases[] = {
+        { defCfaExpr, sizeof(defCfaExpr), "DW_CFA_def_cfa_expression" },
+        { regExpr, sizeof(regExpr), "DW_CFA_expression" },
+        { valExpr, sizeof(valExpr), "DW_CFA_val_expression" },
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        KSDwarfCFIRow row;
+        // The contract is only that this returns without reading past the buffer. Whatever it
+        // reports, it must not have recorded an expression rule pointing outside the section.
+        bool built = ksdwarf_buildCFIRow(cieData, sizeof(cieData), cases[i].fde, cases[i].size, 0x1000, false, &row);
+        if (built) {
+            const uint8_t *fdeEnd = cases[i].fde + cases[i].size;
+            if (row.cfaRule == KSDwarfRuleExpression) {
+                XCTAssertTrue(expressionEndsWithin(row.cfaExpression, row.cfaExpressionLen, fdeEnd),
+                              @"%s: recorded a CFA expression running past the section", cases[i].name);
+            }
+            for (size_t r = 0; r < KSDWARF_MAX_REGISTERS; r++) {
+                if (row.registers[r].type == KSDwarfRuleExpression ||
+                    row.registers[r].type == KSDwarfRuleValExpression) {
+                    XCTAssertTrue(expressionEndsWithin(row.registers[r].expr, row.registers[r].exprLen, fdeEnd),
+                                  @"%s: recorded a register expression running past the section", cases[i].name);
+                }
+            }
+        }
+    }
+}
+
 - (void)testDwarf_BuildCFIRow_OffsetWithNegativeDataAlign
 {
     // Test: DW_CFA_offset with positive ULEB128 operand and negative data alignment factor


### PR DESCRIPTION
Three CFI opcodes record an expression whose length is read as a ULEB128 and never checked against what is left of the section: DW_CFA_def_cfa_expression, DW_CFA_expression and DW_CFA_val_expression. evaluateDwarfExpression later derives its end as expr + len, so an implausible length sends the opcode loop off the end of the section.

ksdwarf_findFDE has the same shape twice. The loop guarantees only one byte past the length field, then reads a four or eight byte CIE pointer; and the CIE length field is bounded from below against the section start but not from above, so one within three bytes of the end overreads.

Bound all five: expressions go through a helper that refuses a length that does not fit and drains the reader, and findFDE checks the entry is long enough for its CIE pointer and that the CIE length field is inside the section. The test feeds each of the three opcodes a length past the end of the buffer and checks no expression rule is recorded pointing outside it.

One of a series of unrelated fixes split out of a larger branch.