### PR TITLE
5/7 Read the stack overflow verdict from the machine context

### DIFF
--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_MachException.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_MachException.c
@@ -440,7 +440,10 @@ static void handleException(ExceptionContext *exceptionCtx)
     monitorCtx->mach.type = exceptionCtx->request->exception;
     monitorCtx->mach.code = machCodeFromRequest(exceptionCtx->request);
     monitorCtx->mach.subcode = machSubcodeFromRequest(exceptionCtx->request);
-    if (monitorCtx->mach.code == KERN_PROTECTION_FAILURE && monitorCtx->isStackOverflow) {
+    // machineContext, not monitorCtx: the stack-overflow verdict is produced by
+    // ksmc_getContextForThread above and lives on the machine context. (The monitor context
+    // carried a same-named field that nothing ever wrote, so this correction never fired.)
+    if (monitorCtx->mach.code == KERN_PROTECTION_FAILURE && machineContext.isStackOverflow) {
         // A stack overflow should return KERN_INVALID_ADDRESS, but
         // when a stack blasts through the guard pages at the top of the stack,
         // it generates KERN_PROTECTION_FAILURE. Correct for this.

--- a/Sources/KSCrashRecordingCore/include/KSCrashMonitorContext.h
+++ b/Sources/KSCrashRecordingCore/include/KSCrashMonitorContext.h
@@ -64,9 +64,6 @@ typedef struct KSCrash_MonitorContext {
     /** If true, the registers contain valid information about the crash. */
     bool registersAreValid;
 
-    /** True if the crash system has detected a stack overflow. */
-    bool isStackOverflow;
-
     /** The machine context that generated the event. */
     struct KSMachineContext *offendingMachineContext;
 


### PR DESCRIPTION
The Mach exception handler corrects KERN_PROTECTION_FAILURE to KERN_INVALID_ADDRESS when the fault is a stack overflow blowing through the guard page, so the report records SIGSEGV rather than SIGBUS. It read the verdict from KSCrash_MonitorContext.isStackOverflow, a field declared in the header and read in exactly this one place and written nowhere: kscm_fillMonitorContext copies only monitorId and monitorFlags, and no monitor assigns it. The correction therefore never fired.

The verdict it wanted is on the machine context the handler filled two lines earlier, via ksmc_getContextForThread with stack-overflow checking on. Read it from there, and drop the monitor-context field, which has no producer and no route by which it could get one.

No test: reaching it needs a real guard-page overflow delivered through the Mach handler. One of a series of unrelated fixes split out of a larger branch.