### PR TITLE
5/7 Guard ksthread_getQueueName against non-positive buffer lengths

### DIFF
--- a/Sources/KSCrashRecordingCore/KSThread.c
+++ b/Sources/KSCrashRecordingCore/KSThread.c
@@ -107,6 +107,12 @@ bool ksthread_getQueueName(const KSThread thread, char *const buffer, int bufLen
 {
     // WARNING: This implementation is no longer async-safe!
 
+    // The copy below casts bufLength to size_t, so a non-positive length would turn into an
+    // enormous one.
+    if (bufLength < 1) {
+        return false;
+    }
+
     integer_t infoBuffer[THREAD_IDENTIFIER_INFO_COUNT] = { 0 };
     thread_info_t info = infoBuffer;
     mach_msg_type_number_t inOutSize = THREAD_IDENTIFIER_INFO_COUNT;
@@ -161,9 +167,7 @@ bool ksthread_getQueueName(const KSThread thread, char *const buffer, int bufLen
         KSLOG_TRACE("Queue label contains invalid chars");
         return false;
     }
-    bufLength = MIN(length, bufLength - 1);  // just strlen, without null-terminator
-    strncpy(buffer, queue_name, (size_t)bufLength);
-    buffer[bufLength] = 0;  // terminate string
+    strlcpy(buffer, queue_name, (size_t)bufLength);
     KSLOG_TRACE("Queue label = %s", buffer);
     return true;
 }

--- a/Tests/KSCrashRecordingCoreTests/KSThread_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSThread_Tests.m
@@ -97,4 +97,21 @@
     NSString *stateString = @"TH_STATE_STOPPED";
     XCTAssertEqual(strcmp(stateName, stateString.UTF8String), 0);
 }
+
+- (void)testGetQueueNameRejectsNonPositiveBufferLengths
+{
+    // bufLength is cast to size_t for the copy, so a non-positive length would become enormous
+    // and the copy unbounded. The guard for a real buffer with a bogus length must come before
+    // any writing, so pass a real buffer and check it is untouched.
+    char buffer[64];
+    memset(buffer, 'x', sizeof(buffer));
+
+    XCTAssertFalse(ksthread_getQueueName(ksthread_self(), buffer, 0));
+    XCTAssertFalse(ksthread_getQueueName(ksthread_self(), buffer, -1));
+
+    for (size_t i = 0; i < sizeof(buffer); i++) {
+        XCTAssertEqual(buffer[i], 'x', @"a rejected call must not write to the buffer");
+    }
+}
+
 @end


### PR DESCRIPTION
The length was narrowed with MIN(length, bufLength - 1) and then cast to size_t for the copy, so bufLength 0 underflowed to SIZE_MAX: the copy ran unbounded past the caller buffer and the terminator was then written at buffer[-1]. Not reachable from the one in-tree caller, which passes sizeof(buffer), but this is public in KSThread.h with no documented minimum.

Reject a non-positive length up front, matching what the other buffer-filling functions in this file do, and let strlcpy handle the truncation and termination the manual narrowing was doing by hand.

One of a series of unrelated fixes split out of a larger branch.