### PR TITLE
6/7 Use strlcpy for NULL-terminated string copies

### DIFF
--- a/Sources/KSCrashRecording/KSCrashC.c
+++ b/Sources/KSCrashRecording/KSCrashC.c
@@ -266,12 +266,12 @@ static void onExceptionEvent(struct KSCrash_MonitorContext *monitorContext, KSCr
     } else {
         char crashReportFilePath[KSFU_MAX_PATH_LENGTH];
         int64_t reportID = kscrs_getNextCrashReport(crashReportFilePath, &g_reportStoreConfig);
-        strncpy(g_lastCrashReportFilePath, crashReportFilePath, sizeof(g_lastCrashReportFilePath));
+        strlcpy(g_lastCrashReportFilePath, crashReportFilePath, sizeof(g_lastCrashReportFilePath));
         kscrashreport_writeStandardReport(monitorContext, crashReportFilePath);
 
         if (result) {
             result->reportId = reportID;
-            strncpy(result->path, g_lastCrashReportFilePath, sizeof(result->path));
+            strlcpy(result->path, g_lastCrashReportFilePath, sizeof(result->path));
         }
 
         if (g_didWriteReportCallback != NULL) {
@@ -662,7 +662,7 @@ __attribute__((unused))  // For tests. Declared as extern in TestCase
 void kscrash_testcode_setLastRunID(const char *runID)
 {
     if (runID != NULL) {
-        strncpy(g_lastRunID, runID, sizeof(g_lastRunID) - 1);
+        strlcpy(g_lastRunID, runID, sizeof(g_lastRunID));
         g_lastRunID[sizeof(g_lastRunID) - 1] = '\0';
     } else {
         g_lastRunID[0] = '\0';

--- a/Sources/KSCrashRecording/KSCrashC.c
+++ b/Sources/KSCrashRecording/KSCrashC.c
@@ -663,7 +663,6 @@ void kscrash_testcode_setLastRunID(const char *runID)
 {
     if (runID != NULL) {
         strlcpy(g_lastRunID, runID, sizeof(g_lastRunID));
-        g_lastRunID[sizeof(g_lastRunID) - 1] = '\0';
     } else {
         g_lastRunID[0] = '\0';
     }

--- a/Sources/KSCrashRecording/KSCrashReportC.c
+++ b/Sources/KSCrashRecording/KSCrashReportC.c
@@ -1576,8 +1576,8 @@ void kscrashreport_writeRecrashReport(const KSCrash_MonitorContext *const monito
     char writeBuffer[1024];
     KSBufferedWriter bufferedWriter;
     static char tempPath[KSFU_MAX_PATH_LENGTH];
-    strncpy(tempPath, path, sizeof(tempPath) - 10);
-    strncpy(tempPath + strlen(tempPath) - 5, ".old", 5);
+    strlcpy(tempPath, path, sizeof(tempPath) - 10);
+    strlcpy(tempPath + strlen(tempPath) - 5, ".old", 5);
     KSLOG_INFO("Writing recrash report to %s", path);
 
     if (rename(path, tempPath) < 0) {

--- a/Sources/KSCrashRecording/KSCrashThreadcrumb.m
+++ b/Sources/KSCrashRecording/KSCrashThreadcrumb.m
@@ -272,7 +272,7 @@ static KSCRASH_NOINLINE void *__kscrash_threadcrumb_start__(void *arg) KSCRASH_K
         // Copy to C buffer.
         memset(_data, 0, KSCrashThreadcrumbMaximumMessageLength + 1);
         if (sanitized.UTF8String) {
-            strncpy(_data, sanitized.UTF8String, KSCrashThreadcrumbMaximumMessageLength);
+            strlcpy(_data, sanitized.UTF8String, KSCrashThreadcrumbMaximumMessageLength + 1);
         }
         _index = 0;
         _messageLength = sanitized.length;

--- a/Sources/KSCrashRecordingCore/KSFileUtils.c
+++ b/Sources/KSCrashRecordingCore/KSFileUtils.c
@@ -155,7 +155,7 @@ static bool deletePathContents(const char *path, bool deleteTopLevelPathAlso)
         for (int i = 0; i < entryCount; i++) {
             char *entry = entries[i];
             if (entry != NULL && canDeletePath(entry)) {
-                strncpy(pathPtr, entry, (size_t)pathRemainingLength);
+                strlcpy(pathPtr, entry, (size_t)pathRemainingLength);
                 deletePathContents(pathBuffer, true);
             }
         }

--- a/Sources/KSCrashRecordingCore/KSJSONCodec.c
+++ b/Sources/KSCrashRecordingCore/KSJSONCodec.c
@@ -1014,7 +1014,9 @@ static int decodeElement(const char *const name, KSJSONDecodeContext *context)
                 KSLOG_DEBUG("Number is too long.");
                 return KSJSON_ERROR_DATA_TOO_LONG;
             }
-            strncpy(context->stringBuffer, start, (size_t)len);
+            // memcpy, not strlcpy: `start` points into the JSON buffer and is not
+            // NUL-terminated, so only the counted bytes may be read. Terminated explicitly.
+            memcpy(context->stringBuffer, start, (size_t)len);
             context->stringBuffer[len] = '\0';
 
             sscanf(context->stringBuffer, "%lg", &value);

--- a/Sources/KSCrashRecordingCore/KSLogger.c
+++ b/Sources/KSCrashRecordingCore/KSLogger.c
@@ -321,7 +321,7 @@ bool kslog_setLogFilename(const char *filename, bool overwrite)
             return false;
         }
         if (filename != g_logFilename) {
-            strncpy(g_logFilename, filename, sizeof(g_logFilename));
+            strlcpy(g_logFilename, filename, sizeof(g_logFilename));
         }
     }
 
@@ -375,7 +375,7 @@ bool kslog_setLogFilename(const char *filename, bool overwrite)
         }
     }
     if (filename != g_logFilename) {
-        strncpy(g_logFilename, filename, sizeof(g_logFilename));
+        strlcpy(g_logFilename, filename, sizeof(g_logFilename));
     }
 
     if (oldFile != NULL) {


### PR DESCRIPTION
strncpy does not terminate when the source is at least as long as the size given, and several callers passed sizeof(destination), leaving no room for a terminator. g_lastCrashReportFilePath, the path returned to callers of kscrash_getLastCrashReportPath, and the logger filename are all copied that way, so a source at or over the buffer size leaves an unterminated buffer that is later read as a C string.

Switch those to strlcpy, which always terminates, and drop the manual "size - 1" narrowing where it was doing strlcpy job by hand. The KSJSONCodec case becomes memcpy instead: it copies a counted run out of the JSON buffer, which is not NUL-terminated, so strlcpy would read past the count looking for one.

No test: a mechanical substitution with no behaviour to observe short of an over-long source in each caller. One of a series of unrelated fixes split out of a larger branch.