### PR TITLE
Report the stack overflow verdict, not backtrace truncation

### DIFF
--- a/Sources/KSCrashRecording/KSCrashReportC.c
+++ b/Sources/KSCrashRecording/KSCrashReportC.c
@@ -935,12 +935,11 @@ static void writeBacktrace(const KSCrashReportWriter *const writer, const char *
  *
  * @param key The object key, if needed.
  *
- * @param machineContext The context to retrieve the stack from.
- *
- * @param isStackOverflow If true, the stack has overflowed.
+ * @param machineContext The context to retrieve the stack from. Its stack-overflow verdict is
+ *                       what the report records; see KSCrashField_Overflow below.
  */
 static void writeStackContents(const KSCrashReportWriter *const writer, const char *const key,
-                               const struct KSMachineContext *const machineContext, const bool isStackOverflow)
+                               const struct KSMachineContext *const machineContext)
 {
     uintptr_t sp = kscpu_stackPointer(machineContext);
     if ((void *)sp == NULL) {
@@ -962,7 +961,11 @@ static void writeStackContents(const KSCrashReportWriter *const writer, const ch
         writer->addUIntegerElement(writer, KSCrashField_DumpStart, lowAddress);
         writer->addUIntegerElement(writer, KSCrashField_DumpEnd, highAddress);
         writer->addUIntegerElement(writer, KSCrashField_StackPtr, sp);
-        writer->addBooleanElement(writer, KSCrashField_Overflow, isStackOverflow);
+        // The context's own verdict, not "the backtrace stopped early". Consumers read this as
+        // "the stack overflowed" (KSCrashDoctor diagnoses one from it, and the report model
+        // documents it that way), and the cursor's give-up flag answers a different question at
+        // a threshold that varies by code path.
+        writer->addBooleanElement(writer, KSCrashField_Overflow, machineContext->isStackOverflow);
         uint8_t stackBuffer[kStackContentsTotalDistance * sizeof(sp)];
         int copyLength = (int)(highAddress - lowAddress);
         if (ksmem_copySafely((void *)lowAddress, stackBuffer, copyLength)) {
@@ -1193,7 +1196,7 @@ static void writeThread(const KSCrashReportWriter *const writer, const char *con
         writer->addBooleanElement(writer, KSCrashField_Crashed, isCrashedThread);
         writer->addBooleanElement(writer, KSCrashField_CurrentThread, thread == ksthread_self());
         if (isCrashedThread) {
-            writeStackContents(writer, KSCrashField_Stack, machineContext, stackCursor.state.hasGivenUp);
+            writeStackContents(writer, KSCrashField_Stack, machineContext);
             if (shouldWriteNotableAddresses) {
                 writeNotableAddresses(writer, KSCrashField_NotableAddresses, machineContext);
             }

--- a/Tests/KSCrashRecordingTests/KSCrashReportC_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashReportC_Tests.m
@@ -256,6 +256,84 @@
     }
 }
 
+static dispatch_semaphore_t g_overflowWorkerReady;
+static dispatch_semaphore_t g_overflowWorkerRelease;
+static thread_t g_overflowWorkerThread;
+
+static void *overflowWorkerMain(__unused void *arg)
+{
+    g_overflowWorkerThread = pthread_mach_thread_np(pthread_self());
+    dispatch_semaphore_signal(g_overflowWorkerReady);
+    dispatch_semaphore_wait(g_overflowWorkerRelease, DISPATCH_TIME_FOREVER);
+    return NULL;
+}
+
+- (void)testStackOverflowFieldReportsTheContextVerdictNotCursorTruncation
+{
+#if KSCRASH_HAS_MACH
+    // crash.threads[].stack.overflow is consumed as "the stack overflowed": KSCrashDoctor
+    // diagnoses a stack overflow from it and the report model documents it that way. It must
+    // therefore come from the machine context's verdict, not from whether the backtrace cursor
+    // stopped early, which is a different question asked at a threshold that varies by path
+    // (the crashed thread's pre-captured cursor uses KSSC_MAX_STACK_DEPTH, everything else uses
+    // KSSC_STACK_OVERFLOW_THRESHOLD).
+    ksdl_init();
+
+    // A suspended second thread, because the stack dump needs readable registers and you cannot
+    // read CPU state for the thread doing the reading.
+    g_overflowWorkerReady = dispatch_semaphore_create(0);
+    g_overflowWorkerRelease = dispatch_semaphore_create(0);
+    g_overflowWorkerThread = MACH_PORT_NULL;
+    pthread_t worker;
+    XCTAssertEqual(pthread_create(&worker, NULL, overflowWorkerMain, NULL), 0);
+    dispatch_semaphore_wait(g_overflowWorkerReady, DISPATCH_TIME_FOREVER);
+    usleep(10000);
+    XCTAssertEqual(thread_suspend(g_overflowWorkerThread), KERN_SUCCESS);
+
+    NSString *path = [self temporaryReportPath];
+    @try {
+        struct KSMachineContext machineContext = { 0 };
+        XCTAssertTrue(ksmc_getContextForThread(g_overflowWorkerThread, &machineContext, true));
+        XCTAssertFalse(machineContext.isStackOverflow, @"a parked worker has not overflowed its stack");
+
+        // A cursor that has given up. If the report took its value from here it would claim the
+        // stack overflowed, which is exactly the conflation being removed.
+        KSStackCursor stackCursor;
+        kssc_initWithUnwind(&stackCursor, KSSC_MAX_STACK_DEPTH, &machineContext);
+        stackCursor.state.hasGivenUp = true;
+
+        KSCrash_MonitorContext context = { 0 };
+        snprintf(context.eventID, sizeof(context.eventID), "OVERFLOWFIELDTEST");
+        context.offendingMachineContext = &machineContext;
+        context.stackCursor = &stackCursor;
+        context.registersAreValid = true;
+        context.omitBinaryImages = true;
+        context.monitorId = kscm_machexception_getAPI()->monitorId(NULL);
+        context.mach.type = EXC_BAD_ACCESS;
+
+        kscrashreport_writeStandardReport(&context, path.UTF8String);
+
+        NSDictionary *json = [self readJSONObjectAtPath:path];
+        NSArray *threads = json[@"crash"][@"threads"];
+        NSDictionary *stack = nil;
+        for (NSDictionary *t in threads) {
+            if ([t[@"crashed"] boolValue]) {
+                stack = t[@"stack"];
+                break;
+            }
+        }
+        XCTAssertNotNil(stack, @"the crashed thread must carry a stack dump");
+        XCTAssertEqualObjects(stack[@"overflow"], @NO,
+                              @"overflow must follow the machine context, not the cursor giving up");
+    } @finally {
+        thread_resume(g_overflowWorkerThread);
+        dispatch_semaphore_signal(g_overflowWorkerRelease);
+        pthread_join(worker, NULL);
+        [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
+    }
+#endif
+}
+
 - (void)testWriteStandardReportPreserves64BitMachCodeAndSubcode
 {
 #if KSCRASH_HAS_MACH


### PR DESCRIPTION
crash.threads[].stack.overflow was written from the backtrace cursor's give-up flag, which means "the walk hit its depth limit", not "the stack overflowed". Both consumers read it as the latter: KSCrashDoctor emits "Stack overflow in %@" from it, and StackDump.overflow documents it as whether a stack overflow was detected.

The two also disagree about which limit. The crashed thread of a signal or mach crash carries a cursor built with KSSC_MAX_STACK_DEPTH (512), while every other path builds one with KSSC_STACK_OVERFLOW_THRESHOLD (150), so the same flag meant 512 frames on the thread the doctor inspects and 150 frames everywhere else. A runaway recursion dying at a few hundred frames therefore reported overflow false on the crashed thread and was never diagnosed, while an ordinary deep stack on some other thread reported true.

The verdict the field wants already exists: ksmc_getContextForThread runs the overflow check when it captures a crashed context and stores the answer on the machine context. Write that instead. writeStackContents already receives the context, so the separate flag parameter goes away.

Threads with no computed verdict (siblings, and out-of-process contexts where the check would describe the reporting process rather than the subject) now report false rather than "this backtrace was long", which is the honest answer for them.

The test writes a report for a suspended worker whose context has no overflow, with a cursor deliberately marked as having given up, and checks the report says false. It fails if the field is sourced from the cursor again.