### PR TITLE
7/7 Track stack overflow on the stack cursor

### DIFF
--- a/Sources/KSCrashCore/include/KSCrashNamespace.h
+++ b/Sources/KSCrashCore/include/KSCrashNamespace.h
@@ -451,7 +451,6 @@
 #define ksmc_contextSize KSCRASH_NS(ksmc_contextSize)
 #define ksmc_getContextForSignal KSCRASH_NS(ksmc_getContextForSignal)
 #define ksmc_getContextForThread KSCRASH_NS(ksmc_getContextForThread)
-#define ksmc_getContextForThreadCheckingStackOverflow KSCRASH_NS(ksmc_getContextForThreadCheckingStackOverflow)
 #define ksmc_getThreadAtIndex KSCRASH_NS(ksmc_getThreadAtIndex)
 #define ksmc_getThreadCount KSCRASH_NS(ksmc_getThreadCount)
 #define ksmc_getThreadFromContext KSCRASH_NS(ksmc_getThreadFromContext)

--- a/Sources/KSCrashRecording/KSCrashReportC.c
+++ b/Sources/KSCrashRecording/KSCrashReportC.c
@@ -937,10 +937,10 @@ static void writeBacktrace(const KSCrashReportWriter *const writer, const char *
  *
  * @param machineContext The context to retrieve the stack from.
  *
- * @param isStackOverflow If true, the stack has overflowed.
+ * @param stackOverflow Whether the walk reached the stack-overflow threshold.
  */
 static void writeStackContents(const KSCrashReportWriter *const writer, const char *const key,
-                               const struct KSMachineContext *const machineContext, const bool isStackOverflow)
+                               const struct KSMachineContext *const machineContext, const bool stackOverflow)
 {
     uintptr_t sp = kscpu_stackPointer(machineContext);
     if ((void *)sp == NULL) {
@@ -962,7 +962,7 @@ static void writeStackContents(const KSCrashReportWriter *const writer, const ch
         writer->addUIntegerElement(writer, KSCrashField_DumpStart, lowAddress);
         writer->addUIntegerElement(writer, KSCrashField_DumpEnd, highAddress);
         writer->addUIntegerElement(writer, KSCrashField_StackPtr, sp);
-        writer->addBooleanElement(writer, KSCrashField_Overflow, isStackOverflow);
+        writer->addBooleanElement(writer, KSCrashField_Overflow, stackOverflow);
         uint8_t stackBuffer[kStackContentsTotalDistance * sizeof(sp)];
         int copyLength = (int)(highAddress - lowAddress);
         if (ksmem_copySafely((void *)lowAddress, stackBuffer, copyLength)) {
@@ -1193,7 +1193,7 @@ static void writeThread(const KSCrashReportWriter *const writer, const char *con
         writer->addBooleanElement(writer, KSCrashField_Crashed, isCrashedThread);
         writer->addBooleanElement(writer, KSCrashField_CurrentThread, thread == ksthread_self());
         if (isCrashedThread) {
-            writeStackContents(writer, KSCrashField_Stack, machineContext, stackCursor.state.hasGivenUp);
+            writeStackContents(writer, KSCrashField_Stack, machineContext, stackCursor.state.stackOverflow);
             if (shouldWriteNotableAddresses) {
                 writeNotableAddresses(writer, KSCrashField_NotableAddresses, machineContext);
             }

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_MachException.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_MachException.c
@@ -423,8 +423,17 @@ static void handleException(ExceptionContext *exceptionCtx)
     KSMachineContext machineContext = { 0 };
     monitorCtx->offendingMachineContext = &machineContext;
     kssc_initCursor(&exceptionCtx->stackCursor, NULL, NULL);
+    bool stackOverflow = false;
     if (ksmc_getContextForThread(exceptionCtx->request->thread.name, &machineContext, true)) {
         kssc_initWithUnwind(&exceptionCtx->stackCursor, KSSC_MAX_STACK_DEPTH, &machineContext);
+        // The mach code correction below needs to know whether the stack overflowed, and that is
+        // only knowable by walking. Stop as soon as the threshold is reached so this costs no
+        // more than the old eager check, then rewind so the report writer walks from frame zero.
+        while (!exceptionCtx->stackCursor.state.stackOverflow &&
+               exceptionCtx->stackCursor.advanceCursor(&exceptionCtx->stackCursor)) {
+        }
+        stackOverflow = exceptionCtx->stackCursor.state.stackOverflow;
+        exceptionCtx->stackCursor.resetCursor(&exceptionCtx->stackCursor);
         KSLOG_TRACE("Thread %s: Fault address %p, instruction address %p", exceptionCtx->threadName,
                     kscpu_faultAddress(&machineContext), kscpu_instructionAddress(&machineContext));
         if (exceptionCtx->request->exception == EXC_BAD_ACCESS) {
@@ -440,7 +449,7 @@ static void handleException(ExceptionContext *exceptionCtx)
     monitorCtx->mach.type = exceptionCtx->request->exception;
     monitorCtx->mach.code = machCodeFromRequest(exceptionCtx->request);
     monitorCtx->mach.subcode = machSubcodeFromRequest(exceptionCtx->request);
-    if (monitorCtx->mach.code == KERN_PROTECTION_FAILURE && monitorCtx->isStackOverflow) {
+    if (monitorCtx->mach.code == KERN_PROTECTION_FAILURE && stackOverflow) {
         // A stack overflow should return KERN_INVALID_ADDRESS, but
         // when a stack blasts through the guard pages at the top of the stack,
         // it generates KERN_PROTECTION_FAILURE. Correct for this.

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Watchdog.c
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Watchdog.c
@@ -296,7 +296,7 @@ static void populateReportForCurrentHang(KSHangMonitor *monitor)
             .asyncSafety = false, .isFatal = false, .shouldRecordAllThreads = true, .shouldWriteReport = true });
 
     KSMachineContext machineContext = { 0 };
-    ksmc_getContextForThreadCheckingStackOverflow(ksthread_main(), &machineContext, true, false);
+    ksmc_getContextForThread(ksthread_main(), &machineContext, true);
     KSStackCursor stackCursor;
     kssc_initWithUnwind(&stackCursor, KSSC_MAX_STACK_DEPTH, &machineContext);
 

--- a/Sources/KSCrashRecordingCore/KSMachineContext.c
+++ b/Sources/KSCrashRecordingCore/KSMachineContext.c
@@ -61,15 +61,6 @@ static KSThread g_reservedThreads[10];
 static int g_reservedThreadsMaxIndex = sizeof(g_reservedThreads) / sizeof(g_reservedThreads[0]) - 1;
 static int g_reservedThreadsCount = 0;
 
-static inline bool isStackOverflow(const KSMachineContext *const context)
-{
-    KSStackCursor stackCursor;
-    kssc_initWithUnwind(&stackCursor, KSSC_STACK_OVERFLOW_THRESHOLD, context);
-    while (stackCursor.advanceCursor(&stackCursor)) {
-    }
-    return stackCursor.state.hasGivenUp;
-}
-
 static inline bool getThreadList(KSMachineContext *context)
 {
     const task_t thisTask = mach_task_self();
@@ -116,8 +107,7 @@ int ksmc_contextSize(void) { return sizeof(KSMachineContext); }
 
 KSThread ksmc_getThreadFromContext(const KSMachineContext *const context) { return context->thisThread; }
 
-bool ksmc_getContextForThreadCheckingStackOverflow(KSThread thread, KSMachineContext *destinationContext,
-                                                   bool isCrashedContext, bool checkForStackOverflow)
+bool ksmc_getContextForThread(KSThread thread, KSMachineContext *destinationContext, bool isCrashedContext)
 {
     KSLOG_DEBUG("Fill thread 0x%x context into %p. is crashed = %d", thread, destinationContext, isCrashedContext);
     memset(destinationContext, 0, sizeof(*destinationContext));
@@ -129,18 +119,10 @@ bool ksmc_getContextForThreadCheckingStackOverflow(KSThread thread, KSMachineCon
         kscpu_getState(destinationContext);
     }
     if (ksmc_isCrashedContext(destinationContext)) {
-        if (checkForStackOverflow) {
-            destinationContext->isStackOverflow = isStackOverflow(destinationContext);
-        }
         getThreadList(destinationContext);
     }
     KSLOG_TRACE("Context retrieved.");
     return true;
-}
-
-bool ksmc_getContextForThread(KSThread thread, KSMachineContext *destinationContext, bool isCrashedContext)
-{
-    return ksmc_getContextForThreadCheckingStackOverflow(thread, destinationContext, isCrashedContext, true);
 }
 
 bool ksmc_getContextForSignal(void *signalUserContext, KSMachineContext *destinationContext)
@@ -151,7 +133,6 @@ bool ksmc_getContextForSignal(void *signalUserContext, KSMachineContext *destina
     destinationContext->thisThread = (thread_t)ksthread_self();
     destinationContext->isCrashedContext = true;
     destinationContext->isSignalContext = true;
-    destinationContext->isStackOverflow = isStackOverflow(destinationContext);
     getThreadList(destinationContext);
     KSLOG_TRACE("Context retrieved.");
     return true;

--- a/Sources/KSCrashRecordingCore/KSStackCursor.c
+++ b/Sources/KSCrashRecordingCore/KSStackCursor.c
@@ -43,6 +43,7 @@ void kssc_resetCursor(KSStackCursor *cursor)
 {
     cursor->state.currentDepth = 0;
     cursor->state.hasGivenUp = false;
+    cursor->state.stackOverflow = false;
     cursor->stackEntry.address = 0;
     cursor->stackEntry.imageAddress = 0;
     cursor->stackEntry.imageName = NULL;

--- a/Sources/KSCrashRecordingCore/KSStackCursor_Backtrace.c
+++ b/Sources/KSCrashRecordingCore/KSStackCursor_Backtrace.c
@@ -40,6 +40,9 @@ static bool advanceCursor(KSStackCursor *cursor)
         if (nextAddress > 1) {
             cursor->stackEntry.address = kscpu_normaliseInstructionPointer(nextAddress);
             cursor->state.currentDepth++;
+            if (cursor->state.currentDepth >= KSSC_STACK_OVERFLOW_THRESHOLD) {
+                cursor->state.stackOverflow = true;
+            }
             return true;
         }
     }

--- a/Sources/KSCrashRecordingCore/Unwind/KSStackCursor_Unwind.c
+++ b/Sources/KSCrashRecordingCore/Unwind/KSStackCursor_Unwind.c
@@ -616,6 +616,9 @@ successfulExit:
 
     cursor->stackEntry.address = kscpu_normaliseInstructionPointer(nextAddress);
     cursor->state.currentDepth++;
+    if (cursor->state.currentDepth >= KSSC_STACK_OVERFLOW_THRESHOLD) {
+        cursor->state.stackOverflow = true;
+    }
     return true;
 }
 

--- a/Sources/KSCrashRecordingCore/include/KSCrashMonitorContext.h
+++ b/Sources/KSCrashRecordingCore/include/KSCrashMonitorContext.h
@@ -64,9 +64,6 @@ typedef struct KSCrash_MonitorContext {
     /** If true, the registers contain valid information about the crash. */
     bool registersAreValid;
 
-    /** True if the crash system has detected a stack overflow. */
-    bool isStackOverflow;
-
     /** The machine context that generated the event. */
     struct KSMachineContext *offendingMachineContext;
 

--- a/Sources/KSCrashRecordingCore/include/KSMachineContext.h
+++ b/Sources/KSCrashRecordingCore/include/KSMachineContext.h
@@ -67,9 +67,6 @@ int ksmc_contextSize(void);
 
 /** Fill in a machine context from a thread.
  *
- * This is a convenience wrapper that calls ksmc_getContextForThreadCheckingStackOverflow
- * with checkForStackOverflow=true.
- *
  * @param thread The thread to get information from.
  * @param destinationContext The context to fill.
  * @param isCrashedContext Used to indicate that this is the thread that crashed.
@@ -77,28 +74,6 @@ int ksmc_contextSize(void);
  * @return true if successful.
  */
 bool ksmc_getContextForThread(KSThread thread, struct KSMachineContext *destinationContext, bool isCrashedContext);
-
-/** Fill in a machine context from a thread with optional stack overflow checking.
- *
- * This function populates a machine context with the thread's CPU state and metadata.
- * When checkForStackOverflow is true and isCrashedContext is true, it also checks
- * whether the thread's stack pointer is outside valid stack bounds (indicating a
- * stack overflow) and populates the thread list for crash reporting.
- *
- * Use checkForStackOverflow=false when you only need the CPU state for unwinding
- * and don't need stack overflow detection or thread enumeration (e.g., profiling,
- * backtrace capture outside of crash context).
- *
- * @param thread The thread to get information from.
- * @param destinationContext The context to fill.
- * @param isCrashedContext Used to indicate that this is the thread that crashed.
- * @param checkForStackOverflow If true (and isCrashedContext is true), checks for
- *        stack overflow and populates the thread list. If false, skips these checks.
- *
- * @return true if successful.
- */
-bool ksmc_getContextForThreadCheckingStackOverflow(KSThread thread, struct KSMachineContext *destinationContext,
-                                                   bool isCrashedContext, bool checkForStackOverflow);
 
 /** Fill in a machine context from a signal handler.
  * A signal handler context is always assumed to be a crashed context.

--- a/Sources/KSCrashRecordingCore/include/KSMachineContext_Apple.h
+++ b/Sources/KSCrashRecordingCore/include/KSMachineContext_Apple.h
@@ -51,7 +51,6 @@ typedef struct KSMachineContext {
     int threadCount;
     bool isCrashedContext;
     bool isCurrentThread;
-    bool isStackOverflow;
     bool isSignalContext;
     STRUCT_MCONTEXT_L machineContext;
 } KSMachineContext;

--- a/Sources/KSCrashRecordingCore/include/KSStackCursor.h
+++ b/Sources/KSCrashRecordingCore/include/KSStackCursor.h
@@ -66,6 +66,12 @@ typedef struct KSStackCursor {
 
         /** If true, cursor has given up walking the stack. */
         bool hasGivenUp;
+
+        /** True once the walk has reached KSSC_STACK_OVERFLOW_THRESHOLD frames, which is what
+         * reports mean by a stack overflow. Deliberately independent of the cursor's configured
+         * maximum depth, so cursors built with different limits agree: hasGivenUp only says the
+         * walk hit whatever limit it was given, which is a different question. */
+        bool stackOverflow;
     } state;
 
     /** Reset the cursor back to the beginning. */

--- a/Tests/KSCrashRecordingCoreTests/KSUnwind_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSUnwind_Tests.m
@@ -220,6 +220,8 @@ static void *ksunwind_test_thread_main(void *arg)
 @end
 #endif  // TARGET_OS_WATCH
 
+static void testStackOverflowSentinel(void) {}
+
 @implementation KSUnwind_Tests
 
 // =============================================================================
@@ -420,6 +422,52 @@ static KSTestUnwindSection validTestUnwindSection(void)
     section.header.indexCount = 0xFFFFFFFF;
     XCTAssertFalse(kscu_findEntry(&section, sizeof(section), 0x1000, 0, 0, &entry),
                    @"an index count whose table size overflows 32 bits must not be searched");
+}
+
+- (void)testStackOverflowFlagIsIndependentOfTheCursorDepthLimit
+{
+    // stack.overflow means "the stack reached KSSC_STACK_OVERFLOW_THRESHOLD frames". It must not
+    // depend on the limit the cursor happened to be built with: the crashed thread's cursor uses
+    // KSSC_MAX_STACK_DEPTH while every other path uses the threshold, and before this the flag
+    // was the cursor's give-up state, so the same stack answered differently by code path.
+    uintptr_t backtrace[KSSC_STACK_OVERFLOW_THRESHOLD + 50];
+    for (size_t i = 0; i < sizeof(backtrace) / sizeof(backtrace[0]); i++) {
+        backtrace[i] = (uintptr_t)&testStackOverflowSentinel + i * 4;
+    }
+
+    // Walked to exhaustion with a generous limit: never gives up, but does reach the threshold.
+    KSStackCursor deep;
+    kssc_initWithBacktrace(&deep, backtrace, (int)(sizeof(backtrace) / sizeof(backtrace[0])), 0);
+    while (deep.advanceCursor(&deep)) {
+    }
+    XCTAssertFalse(deep.state.hasGivenUp, @"a backtrace cursor runs out of entries, it does not give up");
+    XCTAssertTrue(deep.state.stackOverflow, @"reaching the threshold must set the flag");
+
+    // A short stack sets neither.
+    KSStackCursor shallow;
+    kssc_initWithBacktrace(&shallow, backtrace, 10, 0);
+    while (shallow.advanceCursor(&shallow)) {
+    }
+    XCTAssertFalse(shallow.state.stackOverflow, @"a short stack has not overflowed");
+
+    // The threshold frame itself counts, one frame short of it does not. This is the boundary the
+    // old hasGivenUp reading had: a cursor limited to the threshold gave up on the walk that came
+    // back for frame 151, so a stack of exactly 150 frames already read as overflowed.
+    KSStackCursor atThreshold;
+    kssc_initWithBacktrace(&atThreshold, backtrace, KSSC_STACK_OVERFLOW_THRESHOLD, 0);
+    while (atThreshold.advanceCursor(&atThreshold)) {
+    }
+    XCTAssertTrue(atThreshold.state.stackOverflow, @"a stack of exactly the threshold has overflowed");
+
+    KSStackCursor belowThreshold;
+    kssc_initWithBacktrace(&belowThreshold, backtrace, KSSC_STACK_OVERFLOW_THRESHOLD - 1, 0);
+    while (belowThreshold.advanceCursor(&belowThreshold)) {
+    }
+    XCTAssertFalse(belowThreshold.state.stackOverflow, @"one frame short of the threshold has not");
+
+    // Reset clears it.
+    deep.resetCursor(&deep);
+    XCTAssertFalse(deep.state.stackOverflow, @"reset must clear the flag");
 }
 
 - (void)testCompactUnwind_EncodingRequiresDwarf


### PR DESCRIPTION
crash.threads[].stack.overflow is consumed as "the stack overflowed": KSCrashDoctor emits "Stack overflow in %@" from it and StackDump.overflow documents it that way. It was written from the cursor's give-up flag, which only says the walk hit whatever depth limit it was handed, and that limit varies: the crashed thread of a signal or mach crash carries a cursor built with KSSC_MAX_STACK_DEPTH (512) while every other path uses KSSC_STACK_OVERFLOW_THRESHOLD (150). The same stack answered differently depending on which code path produced the cursor.

The machine context carried its own verdict for this, computed by walking a throwaway cursor at capture time, but it was never read, and it was only ever right for two of the five crashed-context paths. ksmc_canHaveCPUState is false for a context captured on the current thread, so no registers are fetched, the throwaway walk exits on its first frame, and the answer is always false. NSException, C++ and user reports all capture that way, so they paid for a walk that could not succeed.

Put the flag where the walking happens. The cursor sets state.stackOverflow once the walk reaches the threshold, which is the same boundary the old give-up reading had (a cursor limited to the threshold gave up on the walk that came back for frame 151, so a stack of exactly 150 frames already read as overflowed), and it is independent of the cursor's configured limit, so every path agrees. The report reads it off the cursor it has already walked. The mach handler, which needs the answer before the report is written, walks its own cursor only until the threshold is reached and then rewinds it, so it costs no more than the eager check it replaces.

Removes KSMachineContext.isStackOverflow, the throwaway walk, ksmc_getContextForThreadCheckingStackOverflow (now identical to ksmc_getContextForThread), and KSCrash_MonitorContext.isStackOverflow, which was read once and written nowhere.

Supersedes #873 and #876. One of a series of unrelated fixes split out of a larger branch.
