### PR TITLE
Add Swift async self-thread stack capture option

### DIFF
--- a/Sources/KSCrashCore/include/KSCrashNamespace.h
+++ b/Sources/KSCrashCore/include/KSCrashNamespace.h
@@ -515,6 +515,7 @@
 #define kssc_initWithUnwind KSCRASH_NS(kssc_initWithUnwind)
 #define kssc_initWithUnwindMethods KSCRASH_NS(kssc_initWithUnwindMethods)
 #define kssc_resetCursor KSCRASH_NS(kssc_resetCursor)
+#define kssc_setSwiftAsyncStackTracesEnabled KSCRASH_NS(kssc_setSwiftAsyncStackTracesEnabled)
 #define kssc_unwindMethodName KSCRASH_NS(kssc_unwindMethodName)
 #define kssignal_fatalSignals KSCRASH_NS(kssignal_fatalSignals)
 #define kssignal_numFatalSignals KSCRASH_NS(kssignal_numFatalSignals)

--- a/Sources/KSCrashCore/include/KSSystemCapabilities.h
+++ b/Sources/KSCrashCore/include/KSSystemCapabilities.h
@@ -26,6 +26,7 @@
 #define HDR_KSSystemCapabilities_h
 
 #ifdef __APPLE__
+#include <Availability.h>
 #include <TargetConditionals.h>
 #define KSCRASH_HOST_APPLE 1
 #endif
@@ -58,6 +59,21 @@
 #else
 #define KSCRASH_HAS_OBJC 0
 #define KSCRASH_HAS_SWIFT 0
+#endif
+
+#if defined(__clang_major__) && __clang_major__ >= 13 &&                                                             \
+    ((defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && defined(__MAC_12_0) &&                                              \
+      __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0) ||                                                               \
+     (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_15_0) &&                                          \
+      __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_15_0) ||                                                           \
+     (defined(__TV_OS_VERSION_MAX_ALLOWED) && defined(__TVOS_15_0) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_15_0) || \
+     (defined(__WATCH_OS_VERSION_MAX_ALLOWED) && defined(__WATCHOS_8_0) &&                                           \
+      __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_8_0) ||                                                            \
+     (defined(__VISION_OS_VERSION_MAX_ALLOWED) && defined(__VISIONOS_1_0) &&                                         \
+      __VISION_OS_VERSION_MAX_ALLOWED >= __VISIONOS_1_0))
+#define KSCRASH_HAS_BACKTRACE_ASYNC 1
+#else
+#define KSCRASH_HAS_BACKTRACE_ASYNC 0
 #endif
 
 #if KSCRASH_HOST_APPLE

--- a/Sources/KSCrashRecording/KSCrashC.c
+++ b/Sources/KSCrashRecording/KSCrashC.c
@@ -52,6 +52,7 @@
 #include "KSDynamicLinker.h"
 #include "KSFileUtils.h"
 #include "KSObjC.h"
+#include "KSStackCursor_SelfThread.h"
 #include "KSString.h"
 #include "KSSystemCapabilities.h"
 #include "KSThreadCache.h"
@@ -368,6 +369,7 @@ static void handleConfiguration(KSCrashCConfiguration *configuration)
     kscm_watchdog_setReportsHangs(configuration->enableHangReporting);
     kscm_resource_setReportsCPUExceptions(configuration->enableCPUExceptionReporting);
     kscrashreport_setCompactBinaryImages(configuration->enableCompactBinaryImages);
+    kssc_setSwiftAsyncStackTracesEnabled(configuration->enableSwiftAsyncStackTraces);
     g_shouldAddConsoleLogToReport = configuration->addConsoleLogToReport;
     g_shouldPrintPreviousLog = configuration->printPreviousLogOnStartup;
     g_willWriteReportCallback = configuration->willWriteReportCallback;

--- a/Sources/KSCrashRecording/KSCrashInstallConfiguration.m
+++ b/Sources/KSCrashRecording/KSCrashInstallConfiguration.m
@@ -63,6 +63,7 @@
         _addConsoleLogToReport = cConfig.addConsoleLogToReport ? YES : NO;
         _printPreviousLogOnStartup = cConfig.printPreviousLogOnStartup ? YES : NO;
         _enableSwapCxaThrow = cConfig.enableSwapCxaThrow ? YES : NO;
+        _enableSwiftAsyncStackTraces = cConfig.enableSwiftAsyncStackTraces ? YES : NO;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         _enableSigTermMonitoring = cConfig.enableSigTermMonitoring ? YES : NO;
@@ -134,6 +135,7 @@
     config.addConsoleLogToReport = self.addConsoleLogToReport;
     config.printPreviousLogOnStartup = self.printPreviousLogOnStartup;
     config.enableSwapCxaThrow = self.enableSwapCxaThrow;
+    config.enableSwiftAsyncStackTraces = self.enableSwiftAsyncStackTraces;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     config.enableSigTermMonitoring = self.enableSigTermMonitoring;
@@ -214,6 +216,7 @@
     copy.addConsoleLogToReport = self.addConsoleLogToReport;
     copy.printPreviousLogOnStartup = self.printPreviousLogOnStartup;
     copy.enableSwapCxaThrow = self.enableSwapCxaThrow;
+    copy.enableSwiftAsyncStackTraces = self.enableSwiftAsyncStackTraces;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     copy.enableSigTermMonitoring = self.enableSigTermMonitoring;

--- a/Sources/KSCrashRecording/include/KSCrashCConfiguration.h
+++ b/Sources/KSCrashRecording/include/KSCrashCConfiguration.h
@@ -369,6 +369,17 @@ typedef struct {
     KSReportWrittenCallback reportWrittenCallback
         __attribute__((deprecated("Use `didWriteReportCallback` for async-safety awareness (since v2.4.0).")));
 #pragma clang diagnostic pop
+
+    /** If true, use `backtrace_async()` for KSCrash's current-thread stack capture paths.
+     *
+     * This can stitch Swift async continuation frames into self-thread backtraces such as
+     * C++ exception throw-site and handler cursors, user-reported fallbacks, and current-thread
+     * `ksbt_captureBacktrace` calls. When `backtrace_async()` is not available at build time or
+     * runtime, KSCrash falls back to `backtrace()`.
+     *
+     * **Default**: false
+     */
+    bool enableSwiftAsyncStackTraces;
 } KSCrashCConfiguration;
 
 static inline KSCrashCConfiguration KSCrashCConfiguration_Default(void)
@@ -396,6 +407,7 @@ static inline KSCrashCConfiguration KSCrashCConfiguration_Default(void)
         .addConsoleLogToReport = false,
         .printPreviousLogOnStartup = false,
         .enableSwapCxaThrow = true,
+        .enableSwiftAsyncStackTraces = false,
         .enableHangReporting = false,
         .enableCPUExceptionReporting = false,
 #pragma clang diagnostic push

--- a/Sources/KSCrashRecording/include/KSCrashInstallConfiguration.h
+++ b/Sources/KSCrashRecording/include/KSCrashInstallConfiguration.h
@@ -186,6 +186,17 @@ NS_SWIFT_NAME(CrashInstallConfiguration)
  */
 @property(nonatomic, assign) BOOL enableSwapCxaThrow;
 
+/** If true, use `backtrace_async()` for KSCrash's current-thread stack capture paths.
+ *
+ * This can stitch Swift async continuation frames into self-thread backtraces such as
+ * C++ exception throw-site and handler cursors, user-reported fallbacks, and current-thread
+ * `captureBacktrace` calls. When `backtrace_async()` is not available at build time or runtime,
+ * KSCrash falls back to `backtrace()`.
+ *
+ * **Default**: false
+ */
+@property(nonatomic, assign) BOOL enableSwiftAsyncStackTraces;
+
 /** If true, enables monitoring for SIGTERM signals.
  *
  * @deprecated SIGTERM is now always caught to record a clean exit. No crash report is written. This property is

--- a/Sources/KSCrashRecordingCore/KSStackCursor_SelfThread.c
+++ b/Sources/KSCrashRecordingCore/KSStackCursor_SelfThread.c
@@ -24,7 +24,9 @@
 
 #include "KSStackCursor_SelfThread.h"
 
+#include <Availability.h>
 #include <execinfo.h>
+#include <stdatomic.h>
 
 #include "KSCompilerDefines.h"
 #include "KSStackCursor_Backtrace.h"
@@ -39,10 +41,44 @@ typedef struct {
     uintptr_t backtrace[0];
 } SelfThreadContext;
 
+#if defined(__clang_major__) && __clang_major__ >= 13 &&                                                             \
+    ((defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && defined(__MAC_12_0) &&                                              \
+      __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0) ||                                                               \
+     (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_15_0) &&                                          \
+      __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_15_0) ||                                                           \
+     (defined(__TV_OS_VERSION_MAX_ALLOWED) && defined(__TVOS_15_0) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_15_0) || \
+     (defined(__WATCH_OS_VERSION_MAX_ALLOWED) && defined(__WATCHOS_8_0) &&                                           \
+      __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_8_0) ||                                                            \
+     (defined(__VISION_OS_VERSION_MAX_ALLOWED) && defined(__VISIONOS_1_0) &&                                         \
+      __VISION_OS_VERSION_MAX_ALLOWED >= __VISIONOS_1_0))
+#define KSCRASH_HAS_BACKTRACE_ASYNC 1
+#else
+#define KSCRASH_HAS_BACKTRACE_ASYNC 0
+#endif
+
+static atomic_bool g_swiftAsyncStackTracesEnabled = false;
+
+void kssc_setSwiftAsyncStackTracesEnabled(bool enabled)
+{
+    atomic_store_explicit(&g_swiftAsyncStackTracesEnabled, enabled, memory_order_relaxed);
+}
+
+static int captureBacktrace(void **backtraceBuffer, int maxBacktraceLength)
+{
+#if KSCRASH_HAS_BACKTRACE_ASYNC
+    if (atomic_load_explicit(&g_swiftAsyncStackTracesEnabled, memory_order_relaxed)) {
+        if (__builtin_available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)) {
+            return (int)backtrace_async(backtraceBuffer, (size_t)maxBacktraceLength, NULL);
+        }
+    }
+#endif
+    return backtrace(backtraceBuffer, maxBacktraceLength);
+}
+
 void kssc_initSelfThread(KSStackCursor *cursor, int skipEntries) KS_KEEP_FUNCTION_IN_STACKTRACE
 {
     SelfThreadContext *context = (SelfThreadContext *)cursor->context;
-    int backtraceLength = backtrace((void **)context->backtrace, MAX_BACKTRACE_LENGTH);
+    int backtraceLength = captureBacktrace((void **)context->backtrace, MAX_BACKTRACE_LENGTH);
     kssc_initWithBacktrace(cursor, context->backtrace, backtraceLength, skipEntries + 1);
     KS_THWART_TAIL_CALL_OPTIMISATION
 }

--- a/Sources/KSCrashRecordingCore/KSStackCursor_SelfThread.c
+++ b/Sources/KSCrashRecordingCore/KSStackCursor_SelfThread.c
@@ -48,22 +48,23 @@ void kssc_setSwiftAsyncStackTracesEnabled(bool enabled)
     atomic_store_explicit(&g_swiftAsyncStackTracesEnabled, enabled, memory_order_relaxed);
 }
 
-static int captureBacktrace(void **backtraceBuffer, int maxBacktraceLength)
-{
-#if KSCRASH_HAS_BACKTRACE_ASYNC
-    if (atomic_load_explicit(&g_swiftAsyncStackTracesEnabled, memory_order_relaxed)) {
-        if (__builtin_available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)) {
-            return (int)backtrace_async(backtraceBuffer, (size_t)maxBacktraceLength, NULL);
-        }
-    }
-#endif
-    return backtrace(backtraceBuffer, maxBacktraceLength);
-}
-
 void kssc_initSelfThread(KSStackCursor *cursor, int skipEntries) KS_KEEP_FUNCTION_IN_STACKTRACE
 {
     SelfThreadContext *context = (SelfThreadContext *)cursor->context;
-    int backtraceLength = captureBacktrace((void **)context->backtrace, MAX_BACKTRACE_LENGTH);
+    int backtraceLength;
+#if KSCRASH_HAS_BACKTRACE_ASYNC
+    if (atomic_load_explicit(&g_swiftAsyncStackTracesEnabled, memory_order_relaxed)) {
+        if (__builtin_available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)) {
+            backtraceLength = (int)backtrace_async((void **)context->backtrace, MAX_BACKTRACE_LENGTH, NULL);
+        } else {
+            backtraceLength = backtrace((void **)context->backtrace, MAX_BACKTRACE_LENGTH);
+        }
+    } else {
+        backtraceLength = backtrace((void **)context->backtrace, MAX_BACKTRACE_LENGTH);
+    }
+#else
+    backtraceLength = backtrace((void **)context->backtrace, MAX_BACKTRACE_LENGTH);
+#endif
     kssc_initWithBacktrace(cursor, context->backtrace, backtraceLength, skipEntries + 1);
     KS_THWART_TAIL_CALL_OPTIMISATION
 }

--- a/Sources/KSCrashRecordingCore/KSStackCursor_SelfThread.c
+++ b/Sources/KSCrashRecordingCore/KSStackCursor_SelfThread.c
@@ -24,12 +24,12 @@
 
 #include "KSStackCursor_SelfThread.h"
 
-#include <Availability.h>
 #include <execinfo.h>
 #include <stdatomic.h>
 
 #include "KSCompilerDefines.h"
 #include "KSStackCursor_Backtrace.h"
+#include "KSSystemCapabilities.h"
 
 // #define KSLogger_LocalLevel TRACE
 #include "KSLogger.h"
@@ -40,21 +40,6 @@ typedef struct {
     KSStackCursor_Backtrace_Context SelfThreadContextSpacer;
     uintptr_t backtrace[0];
 } SelfThreadContext;
-
-#if defined(__clang_major__) && __clang_major__ >= 13 &&                                                             \
-    ((defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && defined(__MAC_12_0) &&                                              \
-      __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0) ||                                                               \
-     (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_15_0) &&                                          \
-      __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_15_0) ||                                                           \
-     (defined(__TV_OS_VERSION_MAX_ALLOWED) && defined(__TVOS_15_0) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_15_0) || \
-     (defined(__WATCH_OS_VERSION_MAX_ALLOWED) && defined(__WATCHOS_8_0) &&                                           \
-      __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_8_0) ||                                                            \
-     (defined(__VISION_OS_VERSION_MAX_ALLOWED) && defined(__VISIONOS_1_0) &&                                         \
-      __VISION_OS_VERSION_MAX_ALLOWED >= __VISIONOS_1_0))
-#define KSCRASH_HAS_BACKTRACE_ASYNC 1
-#else
-#define KSCRASH_HAS_BACKTRACE_ASYNC 0
-#endif
 
 static atomic_bool g_swiftAsyncStackTracesEnabled = false;
 

--- a/Sources/KSCrashRecordingCore/include/KSStackCursor_SelfThread.h
+++ b/Sources/KSCrashRecordingCore/include/KSStackCursor_SelfThread.h
@@ -42,6 +42,16 @@ extern "C" {
  */
 void kssc_initSelfThread(KSStackCursor *cursor, int skipEntries);
 
+/** Enable or disable Swift async continuation stitching for current-thread stack capture.
+ *
+ * When enabled and `backtrace_async()` is available at both build time and runtime,
+ * kssc_initSelfThread() uses it instead of `backtrace()`. If unavailable, kssc_initSelfThread()
+ * falls back to `backtrace()`.
+ *
+ * Default: false.
+ */
+void kssc_setSwiftAsyncStackTracesEnabled(bool enabled);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Tests/KSCrashRecordingCoreSwiftTests/KSBacktraceTests.swift
+++ b/Tests/KSCrashRecordingCoreSwiftTests/KSBacktraceTests.swift
@@ -84,17 +84,20 @@ import XCTest
         }
 
         @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+        @inline(never)
         private func swiftAsyncOuterFrame() async -> [String] {
             await swiftAsyncMiddleFrame()
         }
 
         @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+        @inline(never)
         private func swiftAsyncMiddleFrame() async -> [String] {
             await Task { @MainActor in }.value
             return await swiftAsyncInnerFrame()
         }
 
         @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+        @inline(never)
         private func swiftAsyncInnerFrame() async -> [String] {
             let entries = 128
             var addresses: [UInt] = Array(repeating: 0, count: entries)

--- a/Tests/KSCrashRecordingCoreSwiftTests/KSBacktraceTests.swift
+++ b/Tests/KSCrashRecordingCoreSwiftTests/KSBacktraceTests.swift
@@ -46,6 +46,82 @@ import XCTest
             }
         }
 
+        func testSwiftAsyncStackTracesToggleStillCapturesCurrentThread() {
+            defer { kssc_setSwiftAsyncStackTracesEnabled(false) }
+
+            let entries = 128
+            var addresses: [UInt] = Array(repeating: 0, count: entries)
+            kssc_setSwiftAsyncStackTracesEnabled(false)
+            let defaultCount = captureBacktrace(thread: pthread_self(), addresses: &addresses, count: Int32(entries))
+            XCTAssertGreaterThan(defaultCount, 0)
+
+            addresses = Array(repeating: 0, count: entries)
+            kssc_setSwiftAsyncStackTracesEnabled(true)
+            let enabledCount = captureBacktrace(thread: pthread_self(), addresses: &addresses, count: Int32(entries))
+            XCTAssertGreaterThan(enabledCount, 0)
+        }
+
+        @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+        func testSwiftAsyncStackTracesEnabledCapturesAsyncCallers() async {
+            defer { kssc_setSwiftAsyncStackTracesEnabled(false) }
+
+            kssc_setSwiftAsyncStackTracesEnabled(false)
+            let symbolsWithoutAsync = await swiftAsyncOuterFrame()
+            let callerSymbolsWithoutAsync = Self.swiftAsyncCallerSymbolCount(in: symbolsWithoutAsync)
+
+            kssc_setSwiftAsyncStackTracesEnabled(true)
+            let symbolsWithAsync = await swiftAsyncOuterFrame()
+            let callerSymbolsWithAsync = Self.swiftAsyncCallerSymbolCount(in: symbolsWithAsync)
+
+            XCTAssertGreaterThanOrEqual(
+                callerSymbolsWithAsync, 3,
+                "backtrace_async should include the suspended Swift async caller chain. Symbols: \(symbolsWithAsync)"
+            )
+            XCTAssertGreaterThanOrEqual(
+                callerSymbolsWithAsync, callerSymbolsWithoutAsync,
+                "Enabling Swift async stack traces must not lose async caller frames. Without: \(symbolsWithoutAsync), with: \(symbolsWithAsync)"
+            )
+        }
+
+        @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+        private func swiftAsyncOuterFrame() async -> [String] {
+            await swiftAsyncMiddleFrame()
+        }
+
+        @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+        private func swiftAsyncMiddleFrame() async -> [String] {
+            await Task { @MainActor in }.value
+            return await swiftAsyncInnerFrame()
+        }
+
+        @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+        private func swiftAsyncInnerFrame() async -> [String] {
+            let entries = 128
+            var addresses: [UInt] = Array(repeating: 0, count: entries)
+            let count = captureBacktrace(thread: pthread_self(), addresses: &addresses, count: Int32(entries))
+            return Self.symbolNames(for: addresses.prefix(Int(count)))
+        }
+
+        private static func swiftAsyncCallerSymbolCount(in symbolNames: [String]) -> Int {
+            let expectedCallers = ["swiftAsyncOuterFrame", "swiftAsyncMiddleFrame", "swiftAsyncInnerFrame"]
+            return symbolNames.filter { symbolName in
+                expectedCallers.contains { expectedCaller in
+                    symbolName.contains(expectedCaller)
+                }
+            }.count
+        }
+
+        private static func symbolNames(for addresses: ArraySlice<UInt>) -> [String] {
+            addresses.compactMap { address in
+                guard address != 0 else { return nil }
+                var result = SymbolInformation()
+                guard quickSymbolicate(address: address, result: &result), let symbolName = result.symbolName else {
+                    return nil
+                }
+                return String(cString: symbolName)
+            }
+        }
+
         func testOtherThreadSymbolicate() async {
             nonisolated(unsafe) let thread = pthread_self()
             let entries = 10

--- a/Tests/KSCrashRecordingCoreTests/KSStackCursor_SelfThread_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSStackCursor_SelfThread_Tests.m
@@ -1,6 +1,8 @@
 //
 //  KSStackCursor_SelfThread_Tests.m
 //
+//  Created by Mischan Toosarani-Hausberger on 2026-07-27.
+//
 //  Copyright (c) 2012 Karl Stenerud. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/Tests/KSCrashRecordingCoreTests/KSStackCursor_SelfThread_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSStackCursor_SelfThread_Tests.m
@@ -1,0 +1,100 @@
+//
+//  KSStackCursor_SelfThread_Tests.m
+//
+//  Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "KSCompilerDefines.h"
+#import "KSStackCursor_SelfThread.h"
+
+#import <dlfcn.h>
+
+@interface KSStackCursorSelfThreadTests : XCTestCase
+@end
+
+@implementation KSStackCursorSelfThreadTests
+
+static NSString *symbolNameForAddress(uintptr_t address)
+{
+    Dl_info info = { 0 };
+    if (dladdr((void *)address, &info) == 0 || info.dli_sname == NULL) {
+        return nil;
+    }
+    return [NSString stringWithUTF8String:info.dli_sname];
+}
+
+static NSString *firstSelfThreadFrameSymbol(int skipEntries) KS_NOINLINE KS_KEEP_FUNCTION_IN_STACKTRACE;
+static NSString *firstSelfThreadFrameSymbol(int skipEntries)
+{
+    KSStackCursor cursor;
+    kssc_initSelfThread(&cursor, skipEntries);
+    if (!cursor.advanceCursor(&cursor)) {
+        return nil;
+    }
+    return symbolNameForAddress(cursor.stackEntry.address);
+}
+
+static NSString *selfThreadCursorSkipZeroFrame(void) KS_NOINLINE KS_KEEP_FUNCTION_IN_STACKTRACE;
+static NSString *selfThreadCursorSkipZeroFrame(void)
+{
+    NSString *symbol = firstSelfThreadFrameSymbol(0);
+    KS_THWART_TAIL_CALL_OPTIMISATION
+    return symbol;
+}
+
+static NSString *selfThreadCursorSkipOneFrame(void) KS_NOINLINE KS_KEEP_FUNCTION_IN_STACKTRACE;
+static NSString *selfThreadCursorSkipOneFrame(void)
+{
+    NSString *symbol = firstSelfThreadFrameSymbol(1);
+    KS_THWART_TAIL_CALL_OPTIMISATION
+    return symbol;
+}
+
+- (void)assertSelfThreadCursorPreservesSkipEntries
+{
+    NSString *skipZeroSymbol = selfThreadCursorSkipZeroFrame();
+    XCTAssertNotNil(skipZeroSymbol);
+    XCTAssertTrue([skipZeroSymbol containsString:@"firstSelfThreadFrameSymbol"],
+                  @"skipEntries=0 should make the caller of kssc_initSelfThread the first cursor frame, got %@",
+                  skipZeroSymbol);
+
+    NSString *skipOneSymbol = selfThreadCursorSkipOneFrame();
+    XCTAssertNotNil(skipOneSymbol);
+    XCTAssertTrue([skipOneSymbol containsString:@"selfThreadCursorSkipOneFrame"],
+                  @"skipEntries=1 should skip one caller frame after kssc_initSelfThread, got %@", skipOneSymbol);
+}
+
+- (void)testInitSelfThreadPreservesSkipEntriesWhenSwiftAsyncStackTracesDisabled
+{
+    kssc_setSwiftAsyncStackTracesEnabled(false);
+    [self assertSelfThreadCursorPreservesSkipEntries];
+}
+
+- (void)testInitSelfThreadPreservesSkipEntriesWhenSwiftAsyncStackTracesEnabled
+{
+    kssc_setSwiftAsyncStackTracesEnabled(true);
+    [self assertSelfThreadCursorPreservesSkipEntries];
+    kssc_setSwiftAsyncStackTracesEnabled(false);
+}
+
+@end

--- a/Tests/KSCrashRecordingTests/KSCrashInstallConfiguration_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashInstallConfiguration_Tests.m
@@ -64,6 +64,7 @@
     XCTAssertEqual(config.reportStoreConfiguration.maxReportCount, 5);
     XCTAssertEqual(config.reportStoreConfiguration.maxRunSummaryCount, 50);
     XCTAssertTrue(config.enableSwapCxaThrow);
+    XCTAssertFalse(config.enableSwiftAsyncStackTraces);
     XCTAssertFalse(config.enableHangReporting);
     XCTAssertFalse(config.enableCPUExceptionReporting);
     XCTAssertFalse(config.enableCompactBinaryImages);
@@ -83,6 +84,7 @@
     config.reportStoreConfiguration.maxReportCount = 10;
     config.reportStoreConfiguration.maxRunSummaryCount = 7;
     config.enableSwapCxaThrow = NO;
+    config.enableSwiftAsyncStackTraces = YES;
     config.enableHangReporting = YES;
     config.enableCPUExceptionReporting = YES;
     config.enableCompactBinaryImages = YES;
@@ -103,6 +105,7 @@
     XCTAssertEqual(cConfig.reportStoreConfiguration.maxReportCount, 10);
     XCTAssertEqual(cConfig.reportStoreConfiguration.maxRunSummaryCount, 7);
     XCTAssertFalse(cConfig.enableSwapCxaThrow);
+    XCTAssertTrue(cConfig.enableSwiftAsyncStackTraces);
     XCTAssertTrue(cConfig.enableHangReporting);
     XCTAssertTrue(cConfig.enableCPUExceptionReporting);
     XCTAssertTrue(cConfig.enableCompactBinaryImages);
@@ -125,6 +128,7 @@
     config.reportStoreConfiguration.maxReportCount = 10;
     config.reportStoreConfiguration.maxRunSummaryCount = 7;
     config.enableSwapCxaThrow = NO;
+    config.enableSwiftAsyncStackTraces = YES;
     config.enableHangReporting = YES;
     config.enableCPUExceptionReporting = YES;
     config.enableCompactBinaryImages = YES;
@@ -142,6 +146,7 @@
     XCTAssertEqual(copy.reportStoreConfiguration.maxReportCount, 10);
     XCTAssertEqual(copy.reportStoreConfiguration.maxRunSummaryCount, 7);
     XCTAssertFalse(copy.enableSwapCxaThrow);
+    XCTAssertTrue(copy.enableSwiftAsyncStackTraces);
     XCTAssertTrue(copy.enableHangReporting);
     XCTAssertTrue(copy.enableCPUExceptionReporting);
     XCTAssertTrue(copy.enableCompactBinaryImages);
@@ -561,6 +566,7 @@ static bool testPluginIsEnabled(__unused void *context) { return g_testPluginEna
     XCTAssertEqual(cConfig.plugins.apis, NULL);
     XCTAssertEqual(cConfig.plugins.length, 0);
     XCTAssertEqual(cConfig.plugins.release, NULL);
+    XCTAssertFalse(cConfig.enableSwiftAsyncStackTraces);
     KSCrashCConfiguration_Release(&cConfig);
 }
 


### PR DESCRIPTION
This suggestion optionally offers to use `backtrace_async()` if available to correctly walk Swift async calls on all "current-thread" paths.

Sentry had this in production for some time now and with considerable use without any known issues. The implementation largely reflects how it was set up downstream, in the most straight-forward way, so there is certainly some design wiggle room:

* should this stay optional (given that it falls back gracefully)?
* if it should stay optional is the boolean the right choice (rather than an enum)? I guess the variants are rather bounded.
* should we keep the process-global atomic toggle?
* is it fine to ignore the `task_id` for now or should we store it in the cursor context?
* is the test non-flaky enough with the rather strong symbol assertions?