### PR TITLE
Fix arm64 symbolication of Swift async continuation frames

### DIFF
--- a/Samples/Common/Sources/CrashCallback/CrashCallback.m
+++ b/Samples/Common/Sources/CrashCallback/CrashCallback.m
@@ -50,6 +50,17 @@ void setIntegrationTestDidWriteReportCallback(void (^ _Nonnull implementation)(c
     g_integrationTestDidWriteReportCallback = implementation;
 }
 
+static void (^g_integrationTestSwiftAsyncTrigger)(void) = ^void(void) {
+    printf("No Swift async crash trigger registered\n");
+};
+
+void integrationTestSwiftAsyncTrigger(void) { g_integrationTestSwiftAsyncTrigger(); }
+
+void setIntegrationTestSwiftAsyncTrigger(void (^implementation)(void))
+{
+    g_integrationTestSwiftAsyncTrigger = implementation;
+}
+
 int integrationTestIgnoreSIGPIPE(void)
 {
     struct sigaction action = { { 0 } };

--- a/Samples/Common/Sources/CrashCallback/include/CrashCallback.h
+++ b/Samples/Common/Sources/CrashCallback/include/CrashCallback.h
@@ -31,6 +31,13 @@ void setIntegrationTestDidWriteReportCallback(void (^ _Nonnull implementation)(c
 
 int integrationTestIgnoreSIGPIPE(void);
 
+/** Runs the Swift async crash trigger. Swift async code cannot live in the Objective-C
+ * CrashTriggers target, so Swift registers the implementation here at startup.
+ */
+void integrationTestSwiftAsyncTrigger(void);
+
+void setIntegrationTestSwiftAsyncTrigger(void (^_Nonnull implementation)(void));
+
 #ifdef __cplusplus
 }
 #endif

--- a/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
+++ b/Samples/Common/Sources/CrashTriggers/KSCrashTriggersList.mm
@@ -107,6 +107,8 @@ void KSStacktraceCheckCrash() __attribute__((disable_tail_calls))
 
 NSString *const KSCrashNSExceptionStacktraceFuncName = @"exceptionWithStacktraceForException";
 
+static void trigger_user_swiftAsync(void) { integrationTestSwiftAsyncTrigger(); }
+
 @implementation KSCrashTriggersList
 
 + (void)trigger_nsException_genericNSException
@@ -221,6 +223,11 @@ NSString *const KSCrashNSExceptionStacktraceFuncName = @"exceptionWithStacktrace
 + (void)trigger_user_fatal
 {
     trigger_user_fatal();
+}
+
++ (void)trigger_user_swiftAsync
+{
+    trigger_user_swiftAsync();
 }
 
 + (void)trigger_memory_oom

--- a/Samples/Common/Sources/CrashTriggers/include/KSCrashTriggersList.h
+++ b/Samples/Common/Sources/CrashTriggers/include/KSCrashTriggersList.h
@@ -59,6 +59,7 @@ extern NSString *const KSCrashNSExceptionStacktraceFuncName;
     __PROCESS_TRIGGER(signal, sigpipe, @"SIGPIPE")                                                     \
     __PROCESS_TRIGGER(user, nonfatal, @"Nonfatal")                                                     \
     __PROCESS_TRIGGER(user, fatal, @"Fatal")                                                           \
+    __PROCESS_TRIGGER(user, swiftAsync, @"Fatal (from Swift async)")                                   \
     __PROCESS_TRIGGER(multiple, mach_mach, @"Mach + Mach")                                             \
     __PROCESS_TRIGGER(multiple, mach_signal, @"Mach + Signal")                                         \
     __PROCESS_TRIGGER(multiple, mach_cpp, @"Mach + CPP")                                               \

--- a/Samples/Common/Sources/IntegrationTestsHelper/InstallConfig.swift
+++ b/Samples/Common/Sources/IntegrationTestsHelper/InstallConfig.swift
@@ -36,6 +36,7 @@ public struct InstallConfig: Codable {
     public var isHangReportingEnabled: Bool?
     public var isCompactBinaryImagesEnabled: Bool?
     public var ignoreSIGPIPEBeforeInstall: Bool?
+    public var isSwiftAsyncStackTracesEnabled: Bool?
 
     public init(installPath: String) {
         self.installPath = installPath
@@ -64,6 +65,9 @@ extension InstallConfig {
         }
         if let isCompactBinaryImagesEnabled {
             config.enableCompactBinaryImages = isCompactBinaryImagesEnabled
+        }
+        if let isSwiftAsyncStackTracesEnabled {
+            config.enableSwiftAsyncStackTraces = isSwiftAsyncStackTracesEnabled
         }
         setIntegrationTestWillWriteReportCallback({
             (plan: UnsafeMutablePointer<ExceptionHandlingPlan>, ctx: UnsafePointer<KSCrash_MonitorContext>) in

--- a/Samples/Common/Sources/IntegrationTestsHelper/SwiftAsyncCrashTrigger.swift
+++ b/Samples/Common/Sources/IntegrationTestsHelper/SwiftAsyncCrashTrigger.swift
@@ -1,0 +1,87 @@
+//
+//  SwiftAsyncCrashTrigger.swift
+//
+//  Created by Gleb Linnik on 28.07.2026.
+//
+//  Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import CrashCallback
+import Foundation
+
+// Reports a fatal user exception from inside a suspended Swift async call chain.
+//
+// `reportUserException` captures the current thread through `kssc_initSelfThread`, so with
+// `enableSwiftAsyncStackTraces` on, the callers below are reported by `backtrace_async()` as
+// continuation frames rather than as ordinary frame-pointer return addresses.
+
+/// Source names of the helpers below, for the integration test to assert on.
+public let swiftAsyncOuterFuncName = "swiftAsyncTriggerOuter"
+public let swiftAsyncMiddleFuncName = "swiftAsyncTriggerMiddle"
+public let swiftAsyncInnerFuncName = "swiftAsyncTriggerInner"
+
+@inline(never)
+func swiftAsyncTriggerInner() async -> Int {
+    UserReportConfig.UserException(
+        name: "Swift Async Exception",
+        reason: "Reported from a Swift async continuation",
+        language: "Swift",
+        lineOfCode: swiftAsyncInnerFuncName,
+        logAllThreads: true,
+        terminateProgram: true
+    ).report()
+    return 1
+}
+
+/// The `+ 1` on the callee's result has to run *after* the await resumes, which stops the
+/// compiler turning these into tail calls and collapsing the continuations the test asserts on.
+/// A bare `await callee()` body would be a tail call and the frame could vanish under `-O`.
+@inline(never)
+func swiftAsyncTriggerMiddle() async -> Int {
+    // Force a real suspension so the caller chain becomes async continuations rather than
+    // plain frames the frame-pointer walker would have found anyway.
+    //
+    // This must not hop to the main actor: the trigger is dispatched on the main queue and the
+    // handler below blocks that thread, so awaiting main-actor work here would deadlock.
+    // Task.sleep resumes on the generic cooperative executor instead.
+    try? await Task.sleep(nanoseconds: 10_000_000)
+    return await swiftAsyncTriggerInner() + 1
+}
+
+@inline(never)
+func swiftAsyncTriggerOuter() async -> Int {
+    return await swiftAsyncTriggerMiddle() + 1
+}
+
+/// Registers the Swift implementation of the `user/swiftAsync` trigger. Call once at startup,
+/// so both the integration-test script and the sample app's own trigger list can use it.
+public func registerSwiftAsyncCrashTrigger() {
+    setIntegrationTestSwiftAsyncTrigger {
+        let semaphore = DispatchSemaphore(value: 0)
+        Task.detached {
+            _ = await swiftAsyncTriggerOuter()
+            semaphore.signal()
+        }
+        // The trigger API is synchronous; block until the async chain has reported.
+        // `terminateProgram: true` means this normally never returns.
+        _ = semaphore.wait(timeout: .now() + 30)
+    }
+}

--- a/Samples/Sources/App.swift
+++ b/Samples/Sources/App.swift
@@ -36,6 +36,7 @@ struct SampleApp: App {
 
     init() {
         runLeaksTestIfRequired()
+        registerSwiftAsyncCrashTrigger()
         IntegrationTestRunner.runEarlyIfNeeded()
     }
 

--- a/Samples/Tests/SwiftAsyncStackTraceTests.swift
+++ b/Samples/Tests/SwiftAsyncStackTraceTests.swift
@@ -1,0 +1,101 @@
+//
+//  SwiftAsyncStackTraceTests.swift
+//
+//  Created by Gleb Linnik on 28.07.2026.
+//
+//  Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import CrashTriggers
+import IntegrationTestsHelper
+import KSCrashReportModel
+import XCTest
+
+#if !os(watchOS)
+
+    final class SwiftAsyncStackTraceTests: IntegrationTestBase {
+
+        /// With `enableSwiftAsyncStackTraces` on, the suspended async callers of the reporting
+        /// function must appear in the captured backtrace. Plain `backtrace()` cannot see them,
+        /// because a suspended async caller has no frame on the current stack.
+        func testAsyncCallersAppearInBacktrace() throws {
+            let backtrace = try captureAsyncBacktrace()
+            let symbolNames = backtrace.contents.compactMap(\.symbolName)
+
+            for expected in [
+                swiftAsyncInnerFuncName,
+                swiftAsyncMiddleFuncName,
+                swiftAsyncOuterFuncName,
+            ] {
+                XCTAssertTrue(
+                    symbolNames.contains { $0.contains(expected) },
+                    "\(expected) missing from async backtrace. Symbols: \(symbolNames)")
+            }
+        }
+
+        /// Regression guard for the arm64 continuation off-by-one (see `KSSymbolicator.c`).
+        ///
+        /// A name-based assertion cannot catch this: the symbol landed on is usually a sibling
+        /// funclet of the same Swift function, whose mangled name still contains the source name.
+        func testAsyncContinuationFramesResolveToTheirOwnFunclet() throws {
+            let backtrace = try captureAsyncBacktrace()
+
+            let asyncCallerNames = [swiftAsyncMiddleFuncName, swiftAsyncOuterFuncName]
+            let continuationFrames = backtrace.contents.filter { frame in
+                asyncCallerNames.contains { frame.symbolName?.contains($0) ?? false }
+            }
+            XCTAssertFalse(continuationFrames.isEmpty, "no async caller frames to check")
+
+            for frame in continuationFrames {
+                guard let instructionAddr = frame.instructionAddr, let symbolAddr = frame.symbolAddr
+                else {
+                    XCTFail("async frame is missing addresses: \(frame)")
+                    continue
+                }
+                // The +1 bias puts the reported address one past the funclet start, so a correctly
+                // symbolicated continuation sits at offset 1 from its own symbol.
+                XCTAssertLessThanOrEqual(
+                    instructionAddr - symbolAddr, 1,
+                    """
+                    Continuation frame \(frame.symbolName ?? "?") resolved \
+                    \(instructionAddr - symbolAddr) bytes back — expected ≤1.
+                    """)
+            }
+        }
+
+        // MARK: - Helpers
+
+        private func captureAsyncBacktrace() throws -> Backtrace {
+            try launchAndCrash(
+                .user_swiftAsync,
+                installOverride: { (configuration: inout InstallConfig) in
+                    configuration.isSwiftAsyncStackTracesEnabled = true
+                })
+
+            let rawReport = try readCrashReport()
+            try rawReport.validate()
+
+            let crashedThread = try XCTUnwrap(rawReport.crashedThread)
+            return try XCTUnwrap(crashedThread.backtrace)
+        }
+    }
+
+#endif

--- a/Sources/KSCrashRecordingCore/KSSymbolicator.c
+++ b/Sources/KSCrashRecordingCore/KSSymbolicator.c
@@ -26,39 +26,39 @@
 
 #include "KSDynamicLinker.h"
 
-/** Remove any pointer tagging from an instruction address
- * On armv7 the least significant bit of the pointer distinguishes
- * between thumb mode (2-byte instructions) and normal mode (4-byte instructions).
- * On arm64 all instructions are 4-bytes wide so the two least significant
- * bytes should always be 0.
- * On x86_64 and i386, instructions are variable length so all bits are
- * signficant.
- */
-#if defined(__arm__)
-#define DETAG_INSTRUCTION_ADDRESS(A) ((A) & ~(1UL))
-#elif defined(__arm64__)
-#define DETAG_INSTRUCTION_ADDRESS(A) ((A) & ~(3UL))
-#else
-#define DETAG_INSTRUCTION_ADDRESS(A) (A)
-#endif
-
 /** Step backwards by one instruction.
  * The backtrace of an objective-C program is expected to contain return
  * addresses not call instructions, as that is what can easily be read from
  * the stack. This is not a problem except for a few cases where the return
  * address is inside a different symbol than the call address.
+ *
+ * On armv7 the least significant bit of the pointer distinguishes between thumb
+ * mode (2-byte instructions) and normal mode (4-byte instructions), so it is a
+ * tag and has to be cleared before stepping back.
+ *
+ * Everywhere else every bit of the address is significant. On arm64 in particular
+ * instructions are 4-byte aligned, so a real instruction address never has its low
+ * bits set, and backtrace_async() uses that spare encoding deliberately: Swift async
+ * continuation addresses are reported biased by +1 so that this same step back by one
+ * lands on the continuation funclet's first instruction. Masking those bits off first
+ * would consume the bias and then step back a second time, resolving one byte below
+ * the funclet, i.e. to whatever symbol happens to precede it.
+ *
+ * Pointer tags and PAC bits are stripped a layer up, by kscpu_normaliseInstructionPointer().
  */
-#define CALL_INSTRUCTION_FROM_RETURN_ADDRESS(A) (DETAG_INSTRUCTION_ADDRESS((A)) - 1)
-
 uintptr_t kssymbolicator_callInstructionAddress(const uintptr_t returnAddress)
 {
-    return CALL_INSTRUCTION_FROM_RETURN_ADDRESS(returnAddress);
+#if defined(__arm__)
+    return (returnAddress & ~(1UL)) - 1;
+#else
+    return returnAddress - 1;
+#endif
 }
 
 bool kssymbolicator_symbolicate(KSStackCursor *cursor)
 {
     Dl_info symbolsBuffer;
-    if (ksdl_dladdr(CALL_INSTRUCTION_FROM_RETURN_ADDRESS(cursor->stackEntry.address), &symbolsBuffer)) {
+    if (ksdl_dladdr(kssymbolicator_callInstructionAddress(cursor->stackEntry.address), &symbolsBuffer)) {
         cursor->stackEntry.imageAddress = (uintptr_t)symbolsBuffer.dli_fbase;
         cursor->stackEntry.imageName = symbolsBuffer.dli_fname;
         cursor->stackEntry.symbolAddress = (uintptr_t)symbolsBuffer.dli_saddr;

--- a/Tests/KSCrashRecordingCoreTests/KSSymbolicator_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSSymbolicator_Tests.m
@@ -1,0 +1,119 @@
+//
+//  KSSymbolicator_Tests.m
+//
+//  Created by Gleb Linnik on 28.07.2026.
+//
+//  Copyright (c) 2016 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#import <XCTest/XCTest.h>
+
+#import <dlfcn.h>
+
+#import "KSDynamicLinker.h"
+#import "KSStackCursor.h"
+#import "KSStackCursor_Backtrace.h"
+#import "KSSymbolicator.h"
+
+@interface KSSymbolicator_Tests : XCTestCase
+@end
+
+@implementation KSSymbolicator_Tests
+
++ (void)setUp
+{
+    [super setUp];
+    // Only the symbolicate tests need the dynamic linker cache, and it survives the class.
+    ksdl_resetCache();
+    ksdl_init();
+}
+
+/** Canonical start address of a real symbol, used as a stand-in for a Swift async
+ * continuation funclet: both are instruction-aligned symbol starts.
+ *
+ * Taken via dladdr() rather than from `&function` because the tests build as arm64e,
+ * where a raw function pointer can carry a pointer-authentication signature.
+ */
+- (uintptr_t)symbolStartAddress
+{
+    Dl_info info = { 0 };
+    XCTAssertNotEqual(dladdr((const void *)&kssymbolicator_callInstructionAddress, &info), 0);
+    XCTAssertTrue(info.dli_saddr != NULL);
+    return (uintptr_t)info.dli_saddr;
+}
+
+/** Symbolicates a single-frame backtrace and returns the resolved symbol start address. */
+- (uintptr_t)symbolAddressForBacktraceAddress:(uintptr_t)address
+{
+    const uintptr_t backtrace[] = { address };
+    KSStackCursor cursor;
+    kssc_initWithBacktrace(&cursor, backtrace, 1, 0);
+
+    XCTAssertTrue(cursor.advanceCursor(&cursor));
+    XCTAssertTrue(cursor.symbolicate(&cursor));
+    return cursor.stackEntry.symbolAddress;
+}
+
+/** A frame-pointer-walked return address is the instruction *after* the call, so
+ * symbolication must step back into the call instruction itself.
+ */
+- (void)testCallInstructionAddressStepsBackFromReturnAddress
+{
+    uintptr_t returnAddress = 0x4000;
+    XCTAssertEqual(kssymbolicator_callInstructionAddress(returnAddress), returnAddress - 1);
+}
+
+/** The unbiased case must keep resolving to the calling function, so that fixing
+ * the async path does not regress ordinary frame-pointer backtraces.
+ */
+- (void)testSymbolicateResolvesReturnAddressToCallingFunction
+{
+    uintptr_t functionStart = [self symbolStartAddress];
+    // An address a few instructions into the function, as a return address would be.
+    XCTAssertEqual([self symbolAddressForBacktraceAddress:functionStart + 8], functionStart);
+}
+
+// The two tests below are excluded on armv7, where the low bit is the Thumb-mode flag and
+// genuinely is a tag rather than the continuation bias described in KSSymbolicator.c.
+#if !defined(__arm__)
+
+/** `backtrace_async()` biases continuation addresses by +1; the bias must survive to the
+ * subtraction rather than being masked off first.
+ */
+- (void)testCallInstructionAddressKeepsAsyncContinuationBias
+{
+    uintptr_t funcletStart = 0x4000;
+    XCTAssertEqual(kssymbolicator_callInstructionAddress(funcletStart + 1), funcletStart);
+}
+
+/** End-to-end: a biased continuation address must symbolicate to its own symbol,
+ * not to the one before it.
+ */
+- (void)testSymbolicateResolvesBiasedContinuationToItsOwnSymbol
+{
+    uintptr_t funcletStart = [self symbolStartAddress];
+    XCTAssertEqual([self symbolAddressForBacktraceAddress:funcletStart + 1], funcletStart,
+                   @"biased continuation address resolved to the preceding symbol");
+}
+
+#endif
+
+@end


### PR DESCRIPTION
One-line fix in KSSymbolicator.c, plus tests.

backtrace_async biases async continuation addresses by +1, so that stepping back one byte lands on the funclet. The arm64 DETAG_INSTRUCTION_ADDRESS masked that bit off first, so the step ran twice and dladdr resolved to the preceding symbol — every async frame got the wrong symbol_name. arm64 only; x86_64 has no mask, so it never showed up in the simulator.

Drop the arm64 mask, keep the armv7 thumb one. Aligned addresses are unaffected, since (R & ~3) - 1 and R - 1 agree.

Two of the four unit tests fail without it. Worth knowing for the #878 tests: a name-based assertion can't catch this, since you usually land on another funclet of the same function and symbolName.contains still matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qCUwNE7ifM8vX8QNjDvF1
