### PR TITLE
ci: bump the github-actions group with 3 updates

### DIFF
--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -48,7 +48,7 @@ jobs:
           - { name: visionOS, target: arm64-apple-xros2,     sdk: xros,       xcode_platform: visionOS }
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,7 +30,7 @@ jobs:
       has_browserstack_scheme: ${{ steps.check.outputs.has_scheme }}
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.base_ref }}
 
@@ -77,7 +77,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Download PR Results
         uses: actions/download-artifact@v8

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -29,13 +29,13 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: pr
 
       - name: Checkout Base
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: base

--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.sha }}
 

--- a/.github/workflows/build-devices.yml
+++ b/.github/workflows/build-devices.yml
@@ -32,7 +32,7 @@ jobs:
           - macOS
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Use Latest Stable Xcode
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/build-sample.yml
+++ b/.github/workflows/build-sample.yml
@@ -35,7 +35,7 @@ jobs:
             macos-version: "15"
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Use Latest Stable Xcode
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       DIRS: 'Sources Tests Samples/Common/Sources/CrashTriggers'
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Install clang-format-20
       run: |

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,7 +24,7 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
         

--- a/.github/workflows/infer.yml
+++ b/.github/workflows/infer.yml
@@ -45,13 +45,13 @@ jobs:
     steps:
       # ── Checkout ──────────────────────────────────────────────
       - name: Checkout PR Branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: pr-branch
 
       - name: Checkout Base Branch
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: base-branch
@@ -76,7 +76,7 @@ jobs:
         run: gem install xcpretty
 
       - name: Cache Infer Binary
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cache/infer-*
           key: infer-${{ env.INFER_VERSION }}-${{ runner.arch }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,7 +37,7 @@ jobs:
           # - platform: watchOS
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Use Latest Stable Xcode
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/leaks.yml
+++ b/.github/workflows/leaks.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Use Latest Stable Xcode
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/namespace-check.yml
+++ b/.github/workflows/namespace-check.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: '3.x'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -36,7 +36,7 @@ jobs:
     name: ${{ matrix.name }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Use Latest Stable Xcode
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/static-analyzer.yml
+++ b/.github/workflows/static-analyzer.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Use Latest Stable Xcode
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/swift-format.yml
+++ b/.github/workflows/swift-format.yml
@@ -18,7 +18,7 @@ jobs:
     container:
       image: swift:6.2
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Install make
       run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -83,7 +83,7 @@ jobs:
             experimental: true
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Beta-only images must ask for 'latest', not 'latest-stable': setup-xcode
       # marks any Xcode whose LicenseInfo.plist says "beta" as unstable, and

--- a/.github/workflows/unrelease.yml
+++ b/.github/workflows/unrelease.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch }}


### PR DESCRIPTION
Ports dependabot's #891 from master to develop: actions/checkout v6 to v7, actions/setup-python v6 to v7, and actions/cache v5 to v6 across all workflows. The cocoapods-lint.yml hunk is dropped since develop removed CocoaPods support. Authorship stays with dependabot via cherry-pick.

Replaces #891.