### PR TITLE
test: verify Mach-to-signal handler chaining

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,7 +4,10 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - 'Sources/KSCrashRecording/Monitors/KSCrashMonitor_MachException.c'
       - 'Sources/KSCrashRecording/Monitors/KSCrashMonitor_Signal.c'
+      - 'Sources/KSCrashRecordingCore/KSCrashMonitor.c'
+      - 'Sources/KSCrashRecordingCore/KSCrashMonitorRegistry.c'
       - 'Samples/Tests/**'
       - 'Samples/Common/Sources/CrashCallback/**'
       - 'Samples/Common/Sources/CrashTriggers/**'

--- a/Samples/Common/Sources/CrashCallback/CrashCallback.m
+++ b/Samples/Common/Sources/CrashCallback/CrashCallback.m
@@ -7,8 +7,15 @@
 
 #import "CrashCallback.h"
 #import <errno.h>
+#import <fcntl.h>
+#if defined(__arm64__)
+#import <mach/arm/thread_status.h>
+#endif
 #import <signal.h>
+#import <stdint.h>
 #import <stdio.h>
+#import <sys/ucontext.h>
+#import <unistd.h>
 #import "KSCrashC.h"
 
 static void (^g_integrationTestWillWriteReportCallback)(KSCrash_ExceptionHandlingPlan *_Nonnull const plan, const struct KSCrash_MonitorContext *_Nonnull context) =
@@ -68,6 +75,65 @@ int integrationTestIgnoreSIGPIPE(void)
     sigemptyset(&action.sa_mask);
     if (sigaction(SIGPIPE, &action, NULL) != 0) {
         return errno;
+    }
+    return 0;
+}
+
+static int g_postKSCrashSignalMarkerFD = -1;
+static struct sigaction g_previousSIGSEGVHandler;
+
+static uint64_t instructionAddressForSignalContext(void *userContext)
+{
+    const ucontext_t *context = userContext;
+#if defined(__arm64__)
+    return arm_thread_state64_get_pc(context->uc_mcontext->__ss);
+#elif defined(__x86_64__)
+    return context->uc_mcontext->__ss.__rip;
+#elif defined(__arm__)
+    return context->uc_mcontext->__ss.__pc;
+#elif defined(__i386__)
+    return context->uc_mcontext->__ss.__eip;
+#else
+    return 0;
+#endif
+}
+
+static void handlePostKSCrashSIGSEGV(int sigNum, siginfo_t *signalInfo, void *userContext)
+{
+    // The marker FD is opened before the handler is installed.
+    const IntegrationTestSignalMarker marker = { .signalNumber = sigNum,
+                                             .signalCode = signalInfo->si_code,
+                                             .instructionAddress = instructionAddressForSignalContext(userContext),
+                                             .faultAddress = (uintptr_t)signalInfo->si_addr };
+    if (g_postKSCrashSignalMarkerFD >= 0) {
+        (void)write(g_postKSCrashSignalMarkerFD, &marker, sizeof(marker));
+    }
+
+    // Behave like a cooperating crash handler: remove only ourselves and pass
+    // the signal to the handler that KSCrash installed before us.
+    if (sigaction(sigNum, &g_previousSIGSEGVHandler, NULL) != 0 || raise(sigNum) != 0) {
+        _exit(128 + sigNum);
+    }
+}
+
+int integrationTestInstallPostKSCrashSIGSEGVHandler(const char *markerPath)
+{
+    const int markerFD = open(markerPath, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (markerFD < 0) {
+        return errno;
+    }
+
+    g_postKSCrashSignalMarkerFD = markerFD;
+
+    struct sigaction action = { { 0 } };
+    action.sa_flags = SA_SIGINFO | SA_ONSTACK;
+    action.sa_sigaction = handlePostKSCrashSIGSEGV;
+    sigemptyset(&action.sa_mask);
+    if (sigaction(SIGSEGV, &action, &g_previousSIGSEGVHandler) != 0) {
+        const int error = errno;
+        g_postKSCrashSignalMarkerFD = -1;
+        close(markerFD);
+        return error;
     }
     return 0;
 }

--- a/Samples/Common/Sources/CrashCallback/include/CrashCallback.h
+++ b/Samples/Common/Sources/CrashCallback/include/CrashCallback.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include "KSCrashExceptionHandlingPlan.h"
 
 #ifdef __cplusplus
@@ -30,6 +32,19 @@ void integrationTestDidWriteReportCallback(const KSCrash_ExceptionHandlingPlan *
 void setIntegrationTestDidWriteReportCallback(void (^ _Nonnull implementation)(const KSCrash_ExceptionHandlingPlan *const _Nonnull plan, int64_t reportID));
 
 int integrationTestIgnoreSIGPIPE(void);
+
+typedef struct {
+    int32_t signalNumber;
+    int32_t signalCode;
+    uint64_t instructionAddress;
+    uint64_t faultAddress;
+} IntegrationTestSignalMarker;
+
+/**
+ * Installs a SIGSEGV handler after KSCrash that writes the received signal context
+ * to markerPath and then forwards the signal to the handler it replaced.
+ */
+int integrationTestInstallPostKSCrashSIGSEGVHandler(const char *_Nonnull markerPath);
 
 /** Runs the Swift async crash trigger. Swift async code cannot live in the Objective-C
  * CrashTriggers target, so Swift registers the implementation here at startup.

--- a/Samples/Common/Sources/IntegrationTestsHelper/InstallConfig.swift
+++ b/Samples/Common/Sources/IntegrationTestsHelper/InstallConfig.swift
@@ -38,6 +38,8 @@ public struct InstallConfig: Codable {
     public var ignoreSIGPIPEBeforeInstall: Bool?
     public var isSwiftAsyncStackTracesEnabled: Bool?
 
+    public var postInstallSIGSEGVHandlerMarkerPath: String?
+
     public init(installPath: String) {
         self.installPath = installPath
     }
@@ -78,5 +80,13 @@ extension InstallConfig {
         config.willWriteReportCallback = integrationTestWillWriteReportCallback
 
         try KSCrash.shared.install(with: config)
+
+        // Install this only after KSCrash so the test exercises a later signal handler.
+        if let postInstallSIGSEGVHandlerMarkerPath {
+            let error = integrationTestInstallPostKSCrashSIGSEGVHandler(postInstallSIGSEGVHandlerMarkerPath)
+            guard error == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: error) ?? .EINVAL)
+            }
+        }
     }
 }

--- a/Samples/Project.swift
+++ b/Samples/Project.swift
@@ -44,6 +44,7 @@ let project = Project(
                 .target(name: "Sample"),
                 .package(product: "SampleUI", type: .runtime),
                 .package(product: "CrashTriggers", type: .runtime),
+                .package(product: "CrashCallback", type: .runtime),
                 .package(product: "IntegrationTestsHelper", type: .runtime),
                 .package(product: "Report", type: .runtime),
             ],

--- a/Samples/Tests/IntegrationTests.swift
+++ b/Samples/Tests/IntegrationTests.swift
@@ -151,7 +151,7 @@ final class NSExceptionTests: IntegrationTestBase {
 
 #endif
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
     final class MachSignalHandlerChainingTests: IntegrationTestBase {
         func testBadAccessReachesSignalHandlerInstalledAfterKSCrash() throws {
@@ -181,6 +181,7 @@ final class NSExceptionTests: IntegrationTestBase {
             }
 
             XCTAssertEqual(marker.signalNumber, SIGSEGV)
+            XCTAssertEqual(marker.signalCode, SEGV_MAPERR)
             XCTAssertEqual(
                 marker.faultAddress, rawReport.crash.error.address,
                 "The signal handler must receive the original Mach fault address")

--- a/Samples/Tests/IntegrationTests.swift
+++ b/Samples/Tests/IntegrationTests.swift
@@ -181,7 +181,8 @@ final class NSExceptionTests: IntegrationTestBase {
             }
 
             XCTAssertEqual(marker.signalNumber, SIGSEGV)
-            XCTAssertEqual(marker.signalCode, SEGV_MAPERR)
+            // The trigger writes to 0x42, inside the no-access Mach-O __PAGEZERO segment.
+            XCTAssertEqual(marker.signalCode, SEGV_ACCERR)
             XCTAssertEqual(
                 marker.faultAddress, rawReport.crash.error.address,
                 "The signal handler must receive the original Mach fault address")

--- a/Samples/Tests/IntegrationTests.swift
+++ b/Samples/Tests/IntegrationTests.swift
@@ -24,7 +24,9 @@
 // THE SOFTWARE.
 //
 
+import CrashCallback
 import CrashTriggers
+import Darwin
 import IntegrationTestsHelper
 import KSCrashDemangleFilter
 import KSCrashRecording
@@ -144,6 +146,48 @@ final class NSExceptionTests: IntegrationTestBase {
             XCTAssertEqual(
                 mach?.subcode, 0xDEAD_BEEF,
                 "mach.subcode should contain the fault address (0xDEADBEEF)")
+        }
+    }
+
+#endif
+
+#if os(iOS) || os(macOS)
+
+    final class MachSignalHandlerChainingTests: IntegrationTestBase {
+        func testBadAccessReachesSignalHandlerInstalledAfterKSCrash() throws {
+            let signalMarkerURL = installUrl.appendingPathComponent("__post_kscrash_signal__")
+
+            try launchAndCrash(.mach_badAccess) { configuration in
+                // Test infrastructure installs this handler after KSCrash.shared.install returns.
+                configuration.postInstallSIGSEGVHandlerMarkerPath = signalMarkerURL.path
+            }
+
+            // A complete Mach report proves that the Mach exception handler ran before
+            // the exception was allowed to continue through XNU's signal path.
+            let rawReport = try readCrashReport()
+            try rawReport.validate()
+            XCTAssertEqual(rawReport.crash.error.type, .mach)
+            XCTAssertEqual(rawReport.crash.error.signal?.signal, UInt64(SIGSEGV))
+
+            // The later handler records the original signal context using write(2),
+            // then restores and re-raises into the handler it displaced.
+            let markerData = try Data(contentsOf: signalMarkerURL)
+            XCTAssertEqual(markerData.count, MemoryLayout<IntegrationTestSignalMarker>.size)
+            guard markerData.count == MemoryLayout<IntegrationTestSignalMarker>.size else {
+                return
+            }
+            let marker = markerData.withUnsafeBytes {
+                $0.loadUnaligned(as: IntegrationTestSignalMarker.self)
+            }
+
+            XCTAssertEqual(marker.signalNumber, SIGSEGV)
+            XCTAssertEqual(
+                marker.faultAddress, rawReport.crash.error.address,
+                "The signal handler must receive the original Mach fault address")
+            XCTAssertEqual(
+                marker.instructionAddress,
+                rawReport.crashedThread?.backtrace?.contents.first?.instructionAddr,
+                "The signal context and Mach report must point to the same faulting instruction")
         }
     }
 


### PR DESCRIPTION
Add integration coverage for a signal handler installed after KSCrash.

The test:

- installs KSCrash with its default monitors
- installs a `SIGSEGV` handler afterward (usually installed by some third party)
- triggers an `EXC_BAD_ACCESS`
- verifies KSCrash writes a Mach exception report
- verifies the later signal handler receives the associated `SIGSEGV`
- confirms its fault address and program counter match the Mach report
- restores and re-raises to the handler it displaced

The integration workflow now also runs when the Mach exception or central monitor implementation changes.

I am not sure you are super happy about encoding such a concrete contract, but that is exactly the kind of situation we run into from time to time, so I primarily wrote it to verify whether #698 sufficiently resolves the scenario we care about. But now I think that this contract also makes sense upstream and could be a sensible starting point for similar chaining contracts.