### PR TITLE
Target Dependabot update PRs at develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     commit-message:
@@ -18,6 +19,7 @@ updates:
   # Swift Package Manager
   - package-ecosystem: "swift"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     commit-message:


### PR DESCRIPTION
Dependabot has been opening its weekly version-update PRs against master, but new work lands on develop. This adds `target-branch: "develop"` to both update entries (GitHub Actions and Swift) so those PRs go where development happens. GitHub reads `dependabot.yml` from the default branch, so this copy is the one that takes effect. Security updates, if enabled, always target the default branch regardless of this setting.