### PR TITLE
Target Dependabot update PRs at develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     commit-message:
@@ -18,6 +19,7 @@ updates:
   # Swift Package Manager
   - package-ecosystem: "swift"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     commit-message:


### PR DESCRIPTION
Mirrors the same change landing on master in #900, keeping the two copies of `dependabot.yml` in sync so the setting survives the next merge between the branches. Only the default-branch copy is actually read by GitHub.