### PR TITLE
Reject invalid UTF-8 in Objective-C JSON decoding

### DIFF
--- a/Sources/KSCrashRecordingCore/KSJSONCodecObjC.m
+++ b/Sources/KSCrashRecordingCore/KSJSONCodecObjC.m
@@ -144,6 +144,13 @@ static inline NSString *_Nullable stringFromCString(const char *const string)
 
 static int onElement(KSJSONCodec *codec, NSString *name, id element)
 {
+    if (element == nil) {
+        codec.error = [KSNSErrorHelper errorWithDomain:@"KSJSONCodecObjC"
+                                                  code:0
+                                           description:@"JSON string contains invalid UTF-8"];
+        return KSJSON_ERROR_INVALID_CHARACTER;
+    }
+
     id currentContainer = codec.currentContainer;
     if (currentContainer == nil) {
         codec.error = [KSNSErrorHelper errorWithDomain:@"KSJSONCodecObjC"
@@ -153,6 +160,12 @@ static int onElement(KSJSONCodec *codec, NSString *name, id element)
     }
 
     if ([currentContainer isKindOfClass:[NSMutableDictionary class]]) {
+        if (name == nil) {
+            codec.error = [KSNSErrorHelper errorWithDomain:@"KSJSONCodecObjC"
+                                                      code:0
+                                               description:@"JSON object key contains invalid UTF-8"];
+            return KSJSON_ERROR_INVALID_CHARACTER;
+        }
         [(NSMutableDictionary *)currentContainer setValue:element forKey:name];
     } else {
         [(NSMutableArray *)currentContainer addObject:element];

--- a/Sources/KSCrashRecordingCore/KSJSONCodecObjC.m
+++ b/Sources/KSCrashRecordingCore/KSJSONCodecObjC.m
@@ -144,14 +144,21 @@ static inline NSString *_Nullable stringFromCString(const char *const string)
 
 static int onElement(KSJSONCodec *codec, NSString *name, id element)
 {
-    if (element == nil) {
+    id currentContainer = codec.currentContainer;
+    if ([currentContainer isKindOfClass:[NSMutableDictionary class]] && name == nil) {
         codec.error = [KSNSErrorHelper errorWithDomain:@"KSJSONCodecObjC"
                                                   code:0
-                                           description:@"JSON string contains invalid UTF-8"];
+                                           description:@"Invalid UTF-8 in JSON object key"];
         return KSJSON_ERROR_INVALID_CHARACTER;
     }
 
-    id currentContainer = codec.currentContainer;
+    if (element == nil) {
+        codec.error = [KSNSErrorHelper errorWithDomain:@"KSJSONCodecObjC"
+                                                  code:0
+                                           description:@"Invalid UTF-8 in JSON string"];
+        return KSJSON_ERROR_INVALID_CHARACTER;
+    }
+
     if (currentContainer == nil) {
         codec.error = [KSNSErrorHelper errorWithDomain:@"KSJSONCodecObjC"
                                                   code:0
@@ -160,12 +167,6 @@ static int onElement(KSJSONCodec *codec, NSString *name, id element)
     }
 
     if ([currentContainer isKindOfClass:[NSMutableDictionary class]]) {
-        if (name == nil) {
-            codec.error = [KSNSErrorHelper errorWithDomain:@"KSJSONCodecObjC"
-                                                      code:0
-                                               description:@"JSON object key contains invalid UTF-8"];
-            return KSJSON_ERROR_INVALID_CHARACTER;
-        }
         [(NSMutableDictionary *)currentContainer setValue:element forKey:name];
     } else {
         [(NSMutableArray *)currentContainer addObject:element];
@@ -226,6 +227,9 @@ static int onNullElement(const char *const cName, void *const userData)
     KSJSONCodec *codec = (__bridge KSJSONCodec *)userData;
 
     id currentContainer = codec.currentContainer;
+    if ([currentContainer isKindOfClass:[NSDictionary class]] && name == nil) {
+        return onElement(codec, name, [NSNull null]);
+    }
     if ((codec.ignoreNullsInArrays && [currentContainer isKindOfClass:[NSArray class]]) ||
         (codec.ignoreNullsInObjects && [currentContainer isKindOfClass:[NSDictionary class]])) {
         return KSJSON_OK;

--- a/Tests/KSCrashRecordingCoreTests/KSJSONCodec_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSJSONCodec_Tests.m
@@ -1102,6 +1102,42 @@ static NSString *toString(NSData *data)
     XCTAssertNotNil(error, @"");
 }
 
+- (void)testDeserializeDictionaryInvalidUTF8Key
+{
+    const unsigned char json[] = { '{', '"', 0xff, '"', ':', '1', '}' };
+    NSData *jsonData = [NSData dataWithBytes:json length:sizeof(json)];
+    NSError *error = nil;
+    id result = nil;
+
+    XCTAssertNoThrow(result = [KSJSONCodec decode:jsonData options:KSJSONDecodeOptionKeepPartialObject error:&error]);
+    XCTAssertEqualObjects(result, @{});
+    XCTAssertNotNil(error);
+}
+
+- (void)testDeserializeDictionaryInvalidUTF8Value
+{
+    const unsigned char json[] = { '{', '"', 'k', '"', ':', '"', 0xff, '"', '}' };
+    NSData *jsonData = [NSData dataWithBytes:json length:sizeof(json)];
+    NSError *error = nil;
+    id result = nil;
+
+    XCTAssertNoThrow(result = [KSJSONCodec decode:jsonData options:KSJSONDecodeOptionKeepPartialObject error:&error]);
+    XCTAssertEqualObjects(result, @{});
+    XCTAssertNotNil(error);
+}
+
+- (void)testDeserializeArrayInvalidUTF8Value
+{
+    const unsigned char json[] = { '[', '"', 0xff, '"', ']' };
+    NSData *jsonData = [NSData dataWithBytes:json length:sizeof(json)];
+    NSError *error = nil;
+    id result = nil;
+
+    XCTAssertNoThrow(result = [KSJSONCodec decode:jsonData options:KSJSONDecodeOptionKeepPartialObject error:&error]);
+    XCTAssertEqualObjects(result, @[]);
+    XCTAssertNotNil(error);
+}
+
 - (void)testDeserializeDictionaryMissingSeparator
 {
     NSError *error = (NSError *)self;

--- a/Tests/KSCrashRecordingCoreTests/KSJSONCodec_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSJSONCodec_Tests.m
@@ -1114,6 +1114,19 @@ static NSString *toString(NSData *data)
     XCTAssertNotNil(error);
 }
 
+- (void)testDeserializeDictionaryInvalidUTF8KeyWithIgnoredNull
+{
+    const unsigned char json[] = { '{', '"', 0xff, '"', ':', 'n', 'u', 'l', 'l', '}' };
+    NSData *jsonData = [NSData dataWithBytes:json length:sizeof(json)];
+    NSError *error = nil;
+    id result = nil;
+
+    KSJSONDecodeOption options = KSJSONDecodeOptionKeepPartialObject | KSJSONDecodeOptionIgnoreNullInObject;
+    XCTAssertNoThrow(result = [KSJSONCodec decode:jsonData options:options error:&error]);
+    XCTAssertEqualObjects(result, @{});
+    XCTAssertNotNil(error);
+}
+
 - (void)testDeserializeDictionaryInvalidUTF8Value
 {
     const unsigned char json[] = { '{', '"', 'k', '"', ':', '"', 0xff, '"', '}' };


### PR DESCRIPTION
## Summary
- return a decoder error for invalid UTF-8 object keys and string values
- preserve partial objects without throwing Foundation exceptions or silently dropping values
- add regression coverage for dictionary keys, dictionary values, and array values

## Testing
- `swift test --filter KSJSONCodec_Tests` (137 tests)
- `swift test` (1,572 tests, 4 skipped)