### PR TITLE
Stop KSLogger from holding a closed file descriptor

### DIFF
--- a/Sources/KSCrashRecordingCore/KSLogger.c
+++ b/Sources/KSCrashRecordingCore/KSLogger.c
@@ -308,7 +308,13 @@ static inline void setLogFD(int fd)
 
 bool kslog_setLogFilename(const char *filename, bool overwrite)
 {
-    static int fd = -1;
+    // The descriptor must NOT be remembered across calls. setLogFD closes the
+    // one it is replacing, so carrying a previous value here (what a NULL
+    // filename used to do) would leave g_fd naming a closed descriptor. The
+    // next open() anywhere in the process, the host app's files included,
+    // gets that number and then receives this logger's output, which for an
+    // mmap'd file shows up as corruption rather than an error.
+    int fd = -1;
     if (filename != NULL) {
         int openMask = O_WRONLY | O_CREAT;
         if (overwrite) {
@@ -364,8 +370,11 @@ static inline void flushLog(void) { fflush(g_file); }
 
 bool kslog_setLogFilename(const char *filename, bool overwrite)
 {
-    static FILE *file = NULL;
-    FILE *oldFile = file;
+    // Not remembered across calls, for the reason the descriptor variant
+    // above gives; setLogFD closes the stream it replaces, so this must not
+    // hand it back its own closed stream, and a NULL filename must not reach
+    // strlcpy.
+    FILE *file = NULL;
     if (filename != NULL) {
         file = fopen(filename, overwrite ? "wb" : "ab");
         unlikely_if(file == NULL)
@@ -373,13 +382,9 @@ bool kslog_setLogFilename(const char *filename, bool overwrite)
             writeFmtToLog("KSLogger: Could not open %s: %s", filename, strerror(errno));
             return false;
         }
-    }
-    if (filename != g_logFilename) {
-        strlcpy(g_logFilename, filename, sizeof(g_logFilename));
-    }
-
-    if (oldFile != NULL) {
-        fclose(oldFile);
+        if (filename != g_logFilename) {
+            strlcpy(g_logFilename, filename, sizeof(g_logFilename));
+        }
     }
 
     setLogFD(file);

--- a/Sources/KSCrashRecordingCore/KSLogger.c
+++ b/Sources/KSCrashRecordingCore/KSLogger.c
@@ -36,7 +36,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdarg.h>
-#include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -46,15 +45,14 @@
 
 /** The buffer size to use when writing log entries.
  *
- * If this value is > 0, any log entries that expand beyond this length will
- * be truncated.
- * If this value = 0, the logging system will dynamically allocate memory
- * and never truncate. However, the log functions won't be async-safe.
- *
- * Unless you're logging from within signal handlers, it's safe to set it to 0.
+ * Log entries that expand beyond this length are truncated.
  */
 #ifndef KSLOGGER_CBufferSize
 #define KSLOGGER_CBufferSize 1024
+#endif
+
+#if KSLOGGER_CBufferSize <= 0
+#error KSLOGGER_CBufferSize must be greater than 0; the logger formats into a fixed buffer to stay signal-safe.
 #endif
 
 /** Where console logs will be written */
@@ -91,8 +89,6 @@ static inline void writeFmtToLog(const char *fmt, ...)
     writeFmtArgsToLog(fmt, args);
     va_end(args);
 }
-
-#if KSLOGGER_CBufferSize > 0
 
 /** The file descriptor where log entries get written. */
 static int g_fd = -1;
@@ -334,64 +330,6 @@ bool kslog_setLogFilename(const char *filename, bool overwrite)
     setLogFD(fd);
     return true;
 }
-
-#else  // if KSLogger_CBufferSize <= 0
-
-static FILE *g_file = NULL;
-
-static inline void setLogFD(FILE *file)
-{
-    if (g_file != NULL && g_file != stdout && g_file != stderr && g_file != stdin) {
-        fclose(g_file);
-    }
-    g_file = file;
-}
-
-void writeToLog(const char *const str)
-{
-    if (g_file != NULL) {
-        fprintf(g_file, "%s", str);
-    }
-    fprintf(stdout, "%s", str);
-}
-
-static inline void writeFmtArgsToLog(const char *fmt, va_list args)
-{
-    unlikely_if(g_file == NULL) { g_file = stdout; }
-
-    if (fmt == NULL) {
-        writeToLog("(null)");
-    } else {
-        vfprintf(g_file, fmt, args);
-    }
-}
-
-static inline void flushLog(void) { fflush(g_file); }
-
-bool kslog_setLogFilename(const char *filename, bool overwrite)
-{
-    // Not remembered across calls, for the reason the descriptor variant
-    // above gives; setLogFD closes the stream it replaces, so this must not
-    // hand it back its own closed stream, and a NULL filename must not reach
-    // strlcpy.
-    FILE *file = NULL;
-    if (filename != NULL) {
-        file = fopen(filename, overwrite ? "wb" : "ab");
-        unlikely_if(file == NULL)
-        {
-            writeFmtToLog("KSLogger: Could not open %s: %s", filename, strerror(errno));
-            return false;
-        }
-        if (filename != g_logFilename) {
-            strlcpy(g_logFilename, filename, sizeof(g_logFilename));
-        }
-    }
-
-    setLogFD(file);
-    return true;
-}
-
-#endif
 
 bool kslog_clearLogFile(void) { return kslog_setLogFilename(g_logFilename, true); }
 

--- a/Sources/KSCrashRecordingCore/KSLogger.c
+++ b/Sources/KSCrashRecordingCore/KSLogger.c
@@ -325,13 +325,27 @@ bool kslog_setLogFilename(const char *filename, bool overwrite)
         if (filename != g_logFilename) {
             strlcpy(g_logFilename, filename, sizeof(g_logFilename));
         }
+    } else {
+        // The name goes with the descriptor. kslog_clearLogFile reads it back
+        // in, so a name left behind here would let a later call reopen with
+        // O_TRUNC, and truncate, a file the host told this logger to stop
+        // writing.
+        g_logFilename[0] = '\0';
     }
 
     setLogFD(fd);
     return true;
 }
 
-bool kslog_clearLogFile(void) { return kslog_setLogFilename(g_logFilename, true); }
+bool kslog_clearLogFile(void)
+{
+    // Nothing to clear while file logging is off, and reopening by name is
+    // exactly how it would come back on.
+    if (g_logFilename[0] == '\0') {
+        return true;
+    }
+    return kslog_setLogFilename(g_logFilename, true);
+}
 
 // ===========================================================================
 #pragma mark - C -

--- a/Sources/KSCrashRecordingCore/include/KSLogger.h
+++ b/Sources/KSCrashRecordingCore/include/KSLogger.h
@@ -251,7 +251,9 @@ void i_kslog_logCBasic(const char *fmt, ...);
  */
 bool kslog_setLogFilename(const char *filename, bool overwrite);
 
-/** Clear the log file. */
+/** Clear the log file. Does nothing, successfully, when logging to a file is
+ *  off.
+ */
 bool kslog_clearLogFile(void);
 
 /** Tests if the logger would print at the specified level.

--- a/Sources/KSCrashRecordingCore/include/KSLogger.h
+++ b/Sources/KSCrashRecordingCore/include/KSLogger.h
@@ -138,19 +138,13 @@
  * IMPORTANT NOTES
  * ===============
  *
- * The C logger changes its behavior depending on the value of the preprocessor
- * define KSLogger_CBufferSize.
+ * The C logger is async-signal-safe: it formats with a built-in signal-safe
+ * formatter into a fixed-size buffer and writes with write(), never
+ * vsnprintf()/printf(). Log messages longer than that buffer are truncated.
  *
- * If KSLogger_CBufferSize is > 0, the C logger will behave in an async-signal-safe
- * manner, using a built-in signal-safe formatter and write() instead of
- * vsnprintf()/printf(). Any log messages that exceed the length specified by
- * KSLogger_CBufferSize will be truncated.
- *
- * If KSLogger_CBufferSize == 0, the C logger will use printf(), and there will
- * be no limit on the log message length.
- *
- * KSLogger_CBufferSize can only be set as a preprocessor define, and will
- * default to 1024 if not specified during compilation.
+ * The buffer length is KSLOGGER_CBufferSize, which can only be set as a
+ * preprocessor define, and will default to 1024 if not specified during
+ * compilation.
  */
 
 // ============================================================================

--- a/Tests/KSCrashRecordingCoreTests/KSLogger_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSLogger_Tests.m
@@ -144,6 +144,29 @@
     XCTAssertEqualObjects(@(buffer), @(expected));
 }
 
+- (void)testClearingAfterDisablingDoesNotTruncateTheOldLog
+{
+    // Turning file logging off drops the remembered name too. Keeping it
+    // would let this clear reopen that path with O_TRUNC and destroy a file
+    // the host told the logger to stop writing.
+    NSString *logFileName = [self.tempDir stringByAppendingPathComponent:@"log.txt"];
+    kslog_setLogFilename([logFileName UTF8String], true);
+    KSLOGBASIC_ALWAYS(@"KEEP ME");
+    kslog_setLogFilename(nil, true);
+
+    XCTAssertTrue(kslog_clearLogFile(), @"clearing with logging off is a no-op, not a failure");
+
+    NSError *error = nil;
+    NSString *result = [NSString stringWithContentsOfFile:logFileName encoding:NSUTF8StringEncoding error:&error];
+    XCTAssertNil(error);
+    XCTAssertTrue([result containsString:@"KEEP ME"], @"the disabled log file was truncated, got: %@", result);
+
+    // And logging stays off: nothing new reaches the file either.
+    KSLOGBASIC_ALWAYS(@"SHOULD NOT APPEAR");
+    result = [NSString stringWithContentsOfFile:logFileName encoding:NSUTF8StringEncoding error:&error];
+    XCTAssertFalse([result containsString:@"SHOULD NOT APPEAR"]);
+}
+
 #pragma mark - C formatter (signal-safe path)
 
 extern void i_kslog_logCBasic(const char *fmt, ...);

--- a/Tests/KSCrashRecordingCoreTests/KSLogger_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSLogger_Tests.m
@@ -29,6 +29,10 @@
 
 #import "KSLogger.h"
 
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
 @interface KSLogger_Tests : XCTestCase
 
 @property(nonatomic, readwrite, copy) NSString *tempDir;
@@ -111,6 +115,33 @@
     result = [[result componentsSeparatedByString:@"\x0a"] objectAtIndex:0];
     XCTAssertNil(error, @"");
     XCTAssertEqualObjects(result, expected, @"");
+}
+
+- (void)testDisablingTheLogFileLeavesLaterOpenedFilesAlone
+{
+    // Turning file logging off must not leave the logger holding a closed
+    // descriptor: the next open() anywhere in the process inherits that
+    // number, and the log output would land in that file instead.
+    NSString *logFileName = [self.tempDir stringByAppendingPathComponent:@"log.txt"];
+    kslog_setLogFilename([logFileName UTF8String], true);
+    KSLOGBASIC_ALWAYS(@"TEST");
+    kslog_setLogFilename(nil, true);
+
+    NSString *victimPath = [self.tempDir stringByAppendingPathComponent:@"victim.bin"];
+    const char *expected = "UNTOUCHED";
+    size_t expectedLen = strlen(expected);
+    int fd = open(victimPath.UTF8String, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    XCTAssertGreaterThanOrEqual(fd, 0);
+    XCTAssertEqual(write(fd, expected, expectedLen), (ssize_t)expectedLen);
+
+    KSLOGBASIC_ALWAYS(@"this must not reach the file opened above");
+
+    XCTAssertEqual(lseek(fd, 0, SEEK_SET), 0);
+    char buffer[128] = { 0 };
+    ssize_t bytesRead = read(fd, buffer, sizeof(buffer) - 1);
+    close(fd);
+    XCTAssertEqual(bytesRead, (ssize_t)expectedLen, @"the log output was appended to an unrelated file");
+    XCTAssertEqualObjects(@(buffer), @(expected));
 }
 
 #pragma mark - C formatter (signal-safe path)


### PR DESCRIPTION
`kslog_setLogFilename(NULL, ...)` turns file logging off, but it kept the previous descriptor in a function-static and handed it back to `setLogFD`, which had just closed it. `g_fd` was then a closed descriptor, so the next `open()` in the process, a host app file included, inherited the number and received KSCrash's log output, which for an mmap'd file reads as corruption rather than an error.

The descriptor is now a local, so disabling file logging leaves `g_fd` at -1, and the remembered path goes with it. `kslog_clearLogFile` reads that path back in, so a name left behind let an unrelated call reopen the file with `O_TRUNC` and silently turn logging back on.

The second implementation, the one compiled when the C buffer size is zero, is gone rather than repaired. The header told consumers to select it with `KSLogger_CBufferSize` while the source has tested `KSLOGGER_CBufferSize` since the modules restructure, so no target ever built it, and a crash reporter has no use for a logger that is not async-signal-safe. A non-positive buffer size now fails the build.

Fixes #907.
