### PR TITLE
Expose reserved-thread lookup

### DIFF
--- a/Sources/KSCrashCore/include/KSCrashNamespace.h
+++ b/Sources/KSCrashCore/include/KSCrashNamespace.h
@@ -453,6 +453,7 @@
 #define ksmc_hasValidExceptionRegisters KSCRASH_NS(ksmc_hasValidExceptionRegisters)
 #define ksmc_indexOfThread KSCRASH_NS(ksmc_indexOfThread)
 #define ksmc_isCrashedContext KSCRASH_NS(ksmc_isCrashedContext)
+#define ksmc_isReservedThread KSCRASH_NS(ksmc_isReservedThread)
 #define ksmc_resumeEnvironment KSCRASH_NS(ksmc_resumeEnvironment)
 #define ksmc_suspendEnvironment KSCRASH_NS(ksmc_suspendEnvironment)
 #define ksmem_copyMaxPossible KSCRASH_NS(ksmem_copyMaxPossible)

--- a/Sources/KSCrashRecordingCore/KSMachineContext.c
+++ b/Sources/KSCrashRecordingCore/KSMachineContext.c
@@ -27,6 +27,7 @@
 #include "KSMachineContext.h"
 
 #include <mach/mach.h>
+#include <stdatomic.h>
 
 #if __has_include(<sys/_types/_ucontext64.h>)
 #include <sys/_types/_ucontext64.h>
@@ -59,7 +60,11 @@ typedef ucontext_t SignalUserContext;
 
 static KSThread g_reservedThreads[10];
 static int g_reservedThreadsMaxIndex = sizeof(g_reservedThreads) / sizeof(g_reservedThreads[0]) - 1;
-static int g_reservedThreadsCount = 0;
+// Registration calls are serialized. Mach exception handlers can run before installation finishes,
+// so publish the initialized, append-only prefix to crash-time and other concurrent readers without
+// taking a blocking lock.
+_Static_assert(ATOMIC_INT_LOCK_FREE == 2, "Reserved thread lookup must be lock-free");
+static atomic_int g_reservedThreadsCount = 0;
 
 static inline bool getThreadList(KSMachineContext *context)
 {
@@ -140,25 +145,25 @@ bool ksmc_getContextForSignal(void *signalUserContext, KSMachineContext *destina
 
 void ksmc_addReservedThread(KSThread thread)
 {
-    int nextIndex = g_reservedThreadsCount;
+    int nextIndex = atomic_load_explicit(&g_reservedThreadsCount, memory_order_relaxed);
     if (nextIndex > g_reservedThreadsMaxIndex) {
         KSLOG_ERROR("Too many reserved threads (%d). Max is %d", nextIndex, g_reservedThreadsMaxIndex);
         return;
     }
-    g_reservedThreads[g_reservedThreadsCount++] = thread;
+    g_reservedThreads[nextIndex] = thread;
+    atomic_store_explicit(&g_reservedThreadsCount, nextIndex + 1, memory_order_release);
 }
 
-#if KSCRASH_HAS_THREADS_API
-static inline bool isThreadInList(thread_t thread, KSThread *list, int listCount)
+bool ksmc_isReservedThread(KSThread thread)
 {
-    for (int i = 0; i < listCount; i++) {
-        if (list[i] == (KSThread)thread) {
+    const int count = atomic_load_explicit(&g_reservedThreadsCount, memory_order_acquire);
+    for (int i = 0; i < count; i++) {
+        if (g_reservedThreads[i] == thread) {
             return true;
         }
     }
     return false;
 }
-#endif
 
 void ksmc_suspendEnvironment(thread_act_array_t *threadsToSuspend, mach_msg_type_number_t *threadsToSuspendCount)
 {
@@ -189,7 +194,7 @@ void ksmc_suspendEnvironment(thread_act_array_t *threadsToSuspend, mach_msg_type
 
     for (mach_msg_type_number_t i = 0; i < threadsCount; i++) {
         thread_t thread = threads[i];
-        if (thread != thisThread && !isThreadInList(thread, g_reservedThreads, g_reservedThreadsCount)) {
+        if (thread != thisThread && !ksmc_isReservedThread(thread)) {
             if ((kr = thread_suspend(thread)) != KERN_SUCCESS) {
                 // Note the error and keep going.
                 KSLOG_ERROR("thread_suspend (%08x): %s", thread, mach_error_string(kr));
@@ -233,7 +238,7 @@ void ksmc_resumeEnvironment(thread_act_array_t *threads_inOut, mach_msg_type_num
 
     for (mach_msg_type_number_t i = 0; i < numThreads; i++) {
         thread_t thread = threads[i];
-        if (thread != thisThread && !isThreadInList(thread, g_reservedThreads, g_reservedThreadsCount)) {
+        if (thread != thisThread && !ksmc_isReservedThread(thread)) {
             if ((kr = thread_resume(thread)) != KERN_SUCCESS) {
                 // Record the error and keep going.
                 KSLOG_ERROR("thread_resume (%08x): %s", thread, mach_error_string(kr));

--- a/Sources/KSCrashRecordingCore/include/KSMachineContext.h
+++ b/Sources/KSCrashRecordingCore/include/KSMachineContext.h
@@ -133,9 +133,26 @@ bool ksmc_hasValidExceptionRegisters(const struct KSMachineContext *const contex
 
 /** Add a thread to the reserved threads list.
  *
+ * Registration calls must be serialized, as they are during KSCrash monitor installation.
+ * Lookup may run concurrently with registration. The list is fixed-capacity and process-lifetime;
+ * this does not retain a Mach right or remove IDs when threads exit.
+ *
  * @param thread The thread to add to the list.
  */
 void ksmc_addReservedThread(KSThread thread);
+
+/** Check whether a thread is reserved for KSCrash infrastructure.
+ *
+ * Reserved threads must not be suspended or unwound by clients while KSCrash is installed.
+ * This lookup is lock-free and may run concurrently with registration. It observes registrations
+ * published at the time of the query; it does not prevent subsequent registration. Clients using
+ * it to filter thread capture should do so after monitor installation has completed.
+ *
+ * @param thread The thread to check.
+ *
+ * @return true if the thread is reserved by KSCrash.
+ */
+bool ksmc_isReservedThread(KSThread thread);
 
 #ifdef __cplusplus
 }

--- a/Tests/KSCrashRecordingCoreTests/KSMachineContext_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSMachineContext_Tests.m
@@ -33,6 +33,49 @@
 
 @implementation KSMachineContext_Tests
 
+- (void)testReservedThreadLookup
+{
+    const KSThread reservedThread = ~(KSThread)0;
+
+    XCTAssertFalse(ksmc_isReservedThread(reservedThread));
+    ksmc_addReservedThread(reservedThread);
+    XCTAssertTrue(ksmc_isReservedThread(reservedThread));
+    XCTAssertFalse(ksmc_isReservedThread(reservedThread - 1));
+}
+
+- (void)testReservedThreadLookupConcurrentRegistration
+{
+    // Use only two additional process-lifetime slots, including when other suites install monitors.
+    const KSThread firstThread = ~(KSThread)0 - 2;
+    const KSThread secondThread = ~(KSThread)0 - 3;
+    dispatch_group_t group = dispatch_group_create();
+    dispatch_queue_t queue = dispatch_queue_create("reserved-thread-registration", DISPATCH_QUEUE_CONCURRENT);
+    dispatch_semaphore_t start = dispatch_semaphore_create(0);
+    dispatch_group_async(group, queue, ^{
+        dispatch_semaphore_wait(start, DISPATCH_TIME_FOREVER);
+        ksmc_addReservedThread(firstThread);
+        ksmc_addReservedThread(secondThread);
+    });
+    for (int reader = 0; reader < 4; reader++) {
+        dispatch_group_async(group, queue, ^{
+            dispatch_semaphore_wait(start, DISPATCH_TIME_FOREVER);
+            for (int i = 0; i < 10000; i++) {
+                (void)ksmc_isReservedThread(firstThread);
+                (void)ksmc_isReservedThread(secondThread);
+            }
+        });
+    }
+    for (int i = 0; i < 5; i++) {
+        dispatch_semaphore_signal(start);
+    }
+    dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+
+    XCTAssertTrue(ksmc_isReservedThread(firstThread));
+    XCTAssertTrue(ksmc_isReservedThread(secondThread));
+    XCTAssertFalse(ksmc_isReservedThread(firstThread - 2));
+    XCTAssertFalse(ksmc_isReservedThread(MACH_PORT_NULL));
+}
+
 - (void)testSuspendResumeThreads
 {
     thread_act_array_t threads1 = NULL;


### PR DESCRIPTION
What the title says :-)

We need to identify reserved threads downstream, and I can imagine that other users might need this too.

I also made a race for the reserved thread index more explicit (unrelated to my proposal and existed without exposing lookup as a public interface):

The Mach exception monitor installs the exception ports and creates the handler thread _before_ it calls `ksmc_addReservedThread()`, meaning we could see a concurrent read from the handler thread. Since I assume there are no other concurrent writers, I thought a non-CAS publish would be enough. 

Of course, this does not enforce order, but I think that is sufficient for most cases. But please let me know if you'd prefer a more complex synchronization. I tried to keep it minimal and also extended the inline function docs to explain assumptions (and preferred client behavior).