### PR TITLE
Preserve the page protection when the __cxa_throw swapper writes to __DATA_CONST

### DIFF
--- a/Sources/KSCrashRecordingCore/KSCxaThrowSwapper.c
+++ b/Sources/KSCrashRecordingCore/KSCxaThrowSwapper.c
@@ -82,7 +82,7 @@ typedef struct {
     uintptr_t image;
     _Atomic(uintptr_t) function;  // Atomic: non-zero signals slot is ready (written last)
     void **binding;               // Pointer to the GOT entry, for restoring original
-    bool isConstSegment;          // True if binding is in __DATA_CONST (needs mprotect)
+    bool isConstSegment;          // True if binding is in __DATA_CONST (may need mprotect)
 } KSAddressPair;
 
 // Maximum number of dylibs we expect to handle. Modern iOS apps typically have
@@ -179,16 +179,34 @@ static uintptr_t findAddress(void *address)
     return (uintptr_t)NULL;
 }
 
+static int posixProtection(vm_prot_t protection)
+{
+    int result = PROT_NONE;
+    if (protection & VM_PROT_READ) {
+        result |= PROT_READ;
+    }
+    if (protection & VM_PROT_WRITE) {
+        result |= PROT_WRITE;
+    }
+    if (protection & VM_PROT_EXECUTE) {
+        result |= PROT_EXEC;
+    }
+    return result;
+}
+
 static bool writeProtectedBinding(void **binding, void *value, bool isConstSegment)
 {
-    // __DATA_CONST segments are read-only and need mprotect to write.
     // __DATA segments are writable, so we can write directly without syscalls.
-    // This avoids the vm_region syscall that ksmacho_getSectionProtection would use.
-    //
-    // Note: mprotect operates on page granularity. While multiple dylibs could
-    // theoretically share a page, Mach-O segments are typically page-aligned in
-    // memory, making it safe to toggle protection during serial image loading.
     if (!isConstSegment) {
+        *binding = value;
+        return true;
+    }
+
+    // __DATA_CONST is not always read-only: dyld only protects segments flagged SG_READ_ONLY and
+    // reopens them around the Objective-C map_images callback. Hand the page back with the
+    // protection it had, or the next write by dyld or the Objective-C runtime faults.
+    vm_prot_t currentProtection = ksmacho_getSectionProtection(binding);
+    if (currentProtection & VM_PROT_WRITE) {
         *binding = value;
         return true;
     }
@@ -206,10 +224,7 @@ static bool writeProtectedBinding(void **binding, void *value, bool isConstSegme
 
     *binding = value;
 
-    // Restore read-only protection. __DATA_CONST is always non-executable and read-only,
-    // so PROT_READ is the correct restoration. If this code were ever extended to other
-    // segments, we'd need to query/preserve the original protection flags.
-    if (mprotect((void *)pageStart, protectSize, PROT_READ) != 0) {
+    if (mprotect((void *)pageStart, protectSize, posixProtection(currentProtection)) != 0) {
         KSLOG_WARN("mprotect restore failed for binding at %p: %s", (void *)binding, strerror(errno));
         // Continue anyway - the write succeeded, protection restore is best-effort
     }

--- a/Tests/KSCrashRecordingCoreTests/KSCxaThrowSwapper_Tests.mm
+++ b/Tests/KSCrashRecordingCoreTests/KSCxaThrowSwapper_Tests.mm
@@ -31,15 +31,25 @@
 #pragma clang diagnostic pop
 // clang-format on
 
+#include <dlfcn.h>
+#include <errno.h>
+#include <mach-o/getsect.h>
+#include <mach/mach.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
 #include <atomic>
 #include <exception>
 #include <stdexcept>
 #include <string>
 #include <thread>
 #include <typeinfo>
+#include <utility>
 #include <vector>
 
 #include "KSCxaThrowSwapper.h"
+#include "KSPlatformSpecificDefines.h"
 #include "KSSystemCapabilities.h"
 
 #pragma mark - Test Exception Classes
@@ -75,6 +85,103 @@ static void resetHandlerState()
     g_handlerCallCount.store(0, std::memory_order_relaxed);
     g_lastThrownException.store(nullptr, std::memory_order_relaxed);
     g_lastTypeInfo.store(nullptr, std::memory_order_relaxed);
+}
+
+#pragma mark - Memory Protection Helpers
+
+// Deliberately not ksmacho_getSectionProtection, so the code under test is not its own oracle.
+static vm_prot_t protectionOfPage(uintptr_t page)
+{
+    vm_address_t regionAddress = (vm_address_t)page;
+    vm_size_t regionSize = 0;
+    vm_region_basic_info_data_64_t info;
+    mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT_64;
+    memory_object_name_t object;
+    kern_return_t kr = vm_region_64(mach_task_self(), &regionAddress, &regionSize, VM_REGION_BASIC_INFO_64,
+                                    (vm_region_info_64_t)&info, &count, &object);
+    return kr == KERN_SUCCESS ? info.protection : VM_PROT_NONE;
+}
+
+static const mach_header_t *headerOfThisImage(void)
+{
+    Dl_info info;
+    if (dladdr((const void *)&testHandler, &info) == 0) {
+        return NULL;
+    }
+    return (const mach_header_t *)info.dli_fbase;
+}
+
+/// __DATA_CONST of the image containing this test code, which holds its __cxa_throw binding.
+static bool dataConstSegmentOfThisImage(uintptr_t *outStart, size_t *outSize)
+{
+    const mach_header_t *header = headerOfThisImage();
+    if (header == NULL) {
+        return false;
+    }
+    unsigned long size = 0;
+    uint8_t *start = getsegmentdata(header, SEG_DATA_CONST, &size);
+    if (start == NULL || size == 0) {
+        return false;
+    }
+    *outStart = (uintptr_t)start;
+    *outSize = (size_t)size;
+    return true;
+}
+
+/// Copy of this image's __DATA_CONST,__got entries, to detect whether the swapper rewrote one.
+static std::vector<void *> dataConstGotEntriesOfThisImage(void)
+{
+    const mach_header_t *header = headerOfThisImage();
+    if (header == NULL) {
+        return {};
+    }
+    unsigned long size = 0;
+    // Cast via void* to avoid alignment warnings
+    void *sectionStart = getsectiondata(header, SEG_DATA_CONST, "__got", &size);
+    if (sectionStart == NULL) {
+        return {};
+    }
+    void **entries = (void **)sectionStart;
+    return std::vector<void *>(entries, entries + size / sizeof(void *));
+}
+
+static size_t countChangedEntries(const std::vector<void *> &before, const std::vector<void *> &after)
+{
+    size_t changed = 0;
+    for (size_t i = 0; i < before.size() && i < after.size(); i++) {
+        if (before[i] != after[i]) {
+            changed++;
+        }
+    }
+    return changed;
+}
+
+static size_t countPagesWithProtection(uintptr_t start, size_t size, vm_prot_t protection, bool present)
+{
+    size_t pageSize = (size_t)getpagesize();
+    size_t matched = 0;
+    for (uintptr_t page = start & ~(pageSize - 1); page < start + size; page += pageSize) {
+        bool hasProtection = (protectionOfPage(page) & protection) != 0;
+        if (hasProtection == present) {
+            matched++;
+        }
+    }
+    return matched;
+}
+
+static int posixProtection(vm_prot_t protection)
+{
+    int result = PROT_NONE;
+    if (protection & VM_PROT_READ) {
+        result |= PROT_READ;
+    }
+    if (protection & VM_PROT_WRITE) {
+        result |= PROT_WRITE;
+    }
+    if (protection & VM_PROT_EXECUTE) {
+        result |= PROT_EXEC;
+    }
+    return result;
 }
 
 #pragma mark - Test Class
@@ -430,6 +537,102 @@ static void resetHandlerState()
 
         ksct_swapReset();
     }
+}
+
+#pragma mark - Memory Protection Tests
+
+/// Makes this image's __DATA_CONST writable; a teardown block restores each page's original protection.
+- (void)makeDataConstOfThisImageWritable:(uintptr_t)start size:(size_t)size
+{
+    size_t pageSize = (size_t)getpagesize();
+    uintptr_t pageStart = start & ~(pageSize - 1);
+    std::vector<std::pair<uintptr_t, vm_prot_t>> originalProtections;
+    for (uintptr_t page = pageStart; page < start + size; page += pageSize) {
+        originalProtections.emplace_back(page, protectionOfPage(page));
+    }
+    [self addTeardownBlock:^{
+        for (const auto &pageAndProtection : originalProtections) {
+            mprotect((void *)pageAndProtection.first, pageSize, posixProtection(pageAndProtection.second));
+        }
+    }];
+    XCTAssertEqual(mprotect((void *)pageStart, (start - pageStart) + size, PROT_READ | PROT_WRITE), 0,
+                   @"Precondition: could not make __DATA_CONST writable: %s", strerror(errno));
+}
+
+/// A __DATA_CONST page that is writable when the swapper runs must stay writable after swap and reset.
+- (void)testSwapKeepsWritableDataConstWritable
+{
+    XCTSkipIf(KSCRASH_HAS_SANITIZER, @"Sanitizers conflict with __cxa_throw swapper");
+
+    uintptr_t start = 0;
+    size_t size = 0;
+    XCTSkipUnless(dataConstSegmentOfThisImage(&start, &size), @"Test image has no __DATA_CONST segment");
+    [self makeDataConstOfThisImageWritable:start size:size];
+
+    std::vector<void *> gotBeforeSwap = dataConstGotEntriesOfThisImage();
+    ksct_swap(testHandler);
+    XCTSkipIf(countChangedEntries(gotBeforeSwap, dataConstGotEntriesOfThisImage()) == 0,
+              @"__cxa_throw of the test image is not bound in __DATA_CONST on this platform");
+    XCTAssertEqual(countPagesWithProtection(start, size, VM_PROT_WRITE, false), 0UL,
+                   @"ksct_swap must not make a writable __DATA_CONST page read-only");
+
+    ksct_swapReset();
+    XCTAssertEqual(countPagesWithProtection(start, size, VM_PROT_WRITE, false), 0UL,
+                   @"ksct_swapReset must not make a writable __DATA_CONST page read-only");
+}
+
+/// A read-only __DATA_CONST page must come back read-only after swap and reset.
+- (void)testSwapKeepsReadOnlyDataConstReadOnly
+{
+    XCTSkipIf(KSCRASH_HAS_SANITIZER, @"Sanitizers conflict with __cxa_throw swapper");
+
+    uintptr_t start = 0;
+    size_t size = 0;
+    XCTSkipUnless(dataConstSegmentOfThisImage(&start, &size), @"Test image has no __DATA_CONST segment");
+    XCTSkipIf(countPagesWithProtection(start, size, VM_PROT_WRITE, true) != 0,
+              @"__DATA_CONST of the test image is writable on this platform");
+
+    std::vector<void *> gotBeforeSwap = dataConstGotEntriesOfThisImage();
+    ksct_swap(testHandler);
+    XCTSkipIf(countChangedEntries(gotBeforeSwap, dataConstGotEntriesOfThisImage()) == 0,
+              @"__cxa_throw of the test image is not bound in __DATA_CONST on this platform");
+    XCTAssertEqual(countPagesWithProtection(start, size, VM_PROT_WRITE, true), 0UL,
+                   @"ksct_swap must not leave a read-only __DATA_CONST page writable");
+
+    ksct_swapReset();
+    XCTAssertEqual(countPagesWithProtection(start, size, VM_PROT_WRITE, true), 0UL,
+                   @"ksct_swapReset must not leave a read-only __DATA_CONST page writable");
+}
+
+#pragma mark - Image Loading Tests
+
+/// Loads Metal after the swap. On the iOS 26.5 simulator this maps MetalSerializer.framework, whose
+/// unprotected __DATA_CONST page the swapper used to turn read-only, crashing map_images_nolock.
+- (void)testSwapDoesNotBreakImagesLoadedLater
+{
+    XCTSkipIf(KSCRASH_HAS_SANITIZER, @"Sanitizers conflict with __cxa_throw swapper");
+
+    ksct_swap(testHandler);
+
+    void *metal = dlopen("/System/Library/Frameworks/Metal.framework/Metal", RTLD_NOW);
+    XCTSkipIf(metal == NULL, @"Metal is not available on this platform");
+    typedef CFTypeRef (*CreateSystemDefaultDevice)(void);
+    CreateSystemDefaultDevice createDevice = (CreateSystemDefaultDevice)dlsym(metal, "MTLCreateSystemDefaultDevice");
+    XCTSkipIf(createDevice == NULL, @"MTLCreateSystemDefaultDevice is not available on this platform");
+
+    CFTypeRef device = createDevice();
+    if (device != NULL) {
+        CFRelease(device);
+    }
+
+    // Only count this test's throw; images loaded by Metal may throw internally.
+    resetHandlerState();
+    try {
+        throw TestException();
+    } catch (const TestException &e) {
+        (void)e;
+    }
+    XCTAssertEqual(g_handlerCallCount.load(), 1, @"Handler should still be called after loading more images");
 }
 
 @end


### PR DESCRIPTION
# Intro
Since we update from 2.5.1 to 2.6.0 our app crashes on the simulator.  For now our hotfix is disable KSCrash for simulator builds. 

KSCrash 2.6.0 crashes on the iOS 26.5 simulator the first time Metal is loaded, with `enableSwapCxaThrow` at its default:

```
EXC_BAD_ACCESS (SIGBUS) KERN_PROTECTION_FAILURE
libobjc.A.dylib   map_images_nolock
dyld_sim          dyld4::APIs::dlopen_from
Metal             MTLDeviceArrayInitialize
```

# Disclaimer   
The fix was generate by Fable trying to use the best practices. 

# Xcode Project to reproduce the bug
- [kscrash-swapper-repro.zip](https://github.com/user-attachments/files/32056489/kscrash-swapper-repro.zip)
- A minimal SwiftUI app (KSCrash 2.6.0 via SPM, `install(with:)` with a default configuration, then `MTLCreateSystemDefaultDevice()`) is attached as a zip in the comments. On the iOS 26.5 simulator it dies at launch with the stack above; its second scheme sets `enableSwapCxaThrow = false` and runs. With the same commit on top of 2.6.0 (`tanscon/KSCrash`, branch `fix/cxa-throw-swapper-preserve-protection-2.6.0`, since `develop` no longer has the 2.6.0 API) the app runs with the swapper on.

# Details
**Cause.** `writeProtectedBinding()` (#753) restores a fixed `PROT_READ` after rewriting a `__DATA_CONST` binding. dyld only protects `__DATA_CONST` segments flagged `SG_READ_ONLY` and reopens them around ObjC's `map_images`. `MetalSerializer.framework` in the simulator runtime has no `SG_READ_ONLY`, its `__cxa_throw` GOT slot shares a page with `__objc_selrefs`, and the ObjC runtime faults on its first selector write after the swapper turned that page read-only. It is an on-disk image without `MH_DYLIB_IN_CACHE`, so #861 does not cover it. 2.5.1 restored the protection it had queried and was unaffected.

**Fix.** Query the current protection first: write directly if the page is writable, otherwise raise, write, and restore what was observed. `ksct_swapReset()` uses the same path. Cost: one `vm_region` call per `__DATA_CONST` binding write; the warm swap install on macOS goes from ≈30 to ≈52 µs, the other swap benchmarks stay within noise.

**Tests** (`KSCxaThrowSwapper_Tests`):

- `testSwapKeepsWritableDataConstWritable` fails on `develop` and passes with the fix; `testSwapKeepsReadOnlyDataConstReadOnly` guards the other direction. Both skip when the test image's `__cxa_throw` is not bound in `__DATA_CONST` (the iOS simulator bundle binds it lazily in `__DATA`).
- `testSwapDoesNotBreakImagesLoadedLater` loads Metal after the swap. On the iOS 26.5 simulator the `develop` swapper kills the test host with the crash above; the fix passes.

Verified with Xcode 26.6 on macOS and the iOS 26.5 simulator; `KSCrashRecordingCoreTests` and `KSCrashRecordingTests` pass on macOS, clang-format is clean.

🤖 Partly generated with [Claude Code](https://claude.com/claude-code)
