### PR TITLE
Classify a background exit as its own termination reason, not a crash

### DIFF
--- a/Sources/KSCrashRecording/KSCrashRunContext.m
+++ b/Sources/KSCrashRecording/KSCrashRunContext.m
@@ -174,6 +174,12 @@ static KSTerminationReason determineReason(const KSCrash_LifecycleData *prevLife
         return KSTerminationReasonLowBattery;
     }
 
+    // Nothing points at a fault. An app that was not user-perceptible when it last updated its
+    // lifecycle (suspended, or prewarmed and never used) was reclaimed by the system or removed by
+    // the user, which is ordinary iOS behaviour. Only a foreground exit stays unexplained.
+    if (!prevLifecycle->userPerceptible) {
+        return KSTerminationReasonBackgroundExit;
+    }
     return KSTerminationReasonUnexplained;
 }
 

--- a/Sources/KSCrashRecording/KSTerminationReason.c
+++ b/Sources/KSCrashRecording/KSTerminationReason.c
@@ -57,6 +57,8 @@ const char *kstermination_reasonToString(KSTerminationReason reason)
             return "reboot";
         case KSTerminationReasonUnexplained:
             return "unexplained";
+        case KSTerminationReasonBackgroundExit:
+            return "background_exit";
         case KSTerminationReasonNone:
         default:
             return "none";
@@ -82,6 +84,7 @@ KSTerminationReason kstermination_reasonFromString(const char *string)
     if (strcmp(string, "app_upgrade") == 0) return KSTerminationReasonAppUpgrade;
     if (strcmp(string, "reboot") == 0) return KSTerminationReasonReboot;
     if (strcmp(string, "unexplained") == 0) return KSTerminationReasonUnexplained;
+    if (strcmp(string, "background_exit") == 0) return KSTerminationReasonBackgroundExit;
     return KSTerminationReasonNone;
 }
 

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Termination.h
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Termination.h
@@ -34,7 +34,8 @@
  *
  * System changes (OS upgrade, app upgrade, reboot) are checked first because
  * they explain an unclean shutdown without it being a crash. Resource reasons
- * are checked next, falling back to "unexplained" if nothing matches.
+ * are checked next. If nothing matches, an app that was not user-perceptible
+ * ended as a "background_exit" (no report); a foreground exit is "unexplained".
  */
 
 #ifndef KSCrashMonitor_Termination_h

--- a/Sources/KSCrashRecording/include/KSTerminationReason.h
+++ b/Sources/KSCrashRecording/include/KSTerminationReason.h
@@ -89,8 +89,16 @@ enum
 
     // -- Fallback --
 
-    /** The previous run did not exit cleanly but no specific cause was identified. */
+    /** The previous run ended while the app was user-perceptible, no crash handler ran and no specific
+     *  cause was identified. */
     KSTerminationReasonUnexplained,
+
+    // -- Background (appended after Unexplained to keep the existing values stable) --
+
+    /** The previous run ended while the app was not user-perceptible (suspended in the background, or
+     *  prewarmed and never used) and no crash handler ran: the system reclaimed it or the user removed
+     *  it from the app switcher. Not a crash, produces no report. */
+    KSTerminationReasonBackgroundExit,
 };
 #ifndef __OBJC__
 typedef int KSTerminationReason;

--- a/Sources/KSCrashReportModel/Models/TerminationReason.swift
+++ b/Sources/KSCrashReportModel/Models/TerminationReason.swift
@@ -46,6 +46,7 @@ public enum TerminationReason: RawRepresentable, Codable, Sendable, Equatable {
     case cpu
     // Fallback
     case unexplained
+    case backgroundExit
     case unknown(String)
 
     public init(rawValue: String) {
@@ -64,6 +65,7 @@ public enum TerminationReason: RawRepresentable, Codable, Sendable, Equatable {
         case "thermal": self = .thermal
         case "cpu": self = .cpu
         case "unexplained": self = .unexplained
+        case "background_exit": self = .backgroundExit
         default: self = .unknown(rawValue)
         }
     }
@@ -84,6 +86,7 @@ public enum TerminationReason: RawRepresentable, Codable, Sendable, Equatable {
         case .thermal: return "thermal"
         case .cpu: return "cpu"
         case .unexplained: return "unexplained"
+        case .backgroundExit: return "background_exit"
         case .unknown(let value): return value
         }
     }

--- a/Tests/KSCrashRecordingTests/KSCrashMonitor_Termination_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSCrashMonitor_Termination_Tests.m
@@ -48,6 +48,7 @@ static KSCrash_LifecycleData makeLifecycle(bool cleanExit, bool monitorHandlerRa
     lc.version = KSCrash_Lifecycle_CurrentVersion;
     lc.cleanExit = cleanExit;
     lc.monitorHandlerRan = monitorHandlerRan;
+    lc.userPerceptible = true;
     return lc;
 }
 
@@ -411,6 +412,37 @@ static KSCrash_SystemData sameSystem(void) { return makeSystem("17.4", "21E258",
     XCTAssertEqual(ksruncontext_testcode_determineReason(&lc, &res, &sys, &sys), KSTerminationReasonUnexplained);
 }
 
+// MARK: - Background exit
+
+- (void)testNothingCriticalWhileNotUserPerceptibleReturnsBackgroundExit
+{
+    KSCrash_LifecycleData lc = makeLifecycle(false, false);
+    lc.userPerceptible = false;
+    KSCrash_ResourceData res = makeResource();
+    KSCrash_SystemData sys = sameSystem();
+    XCTAssertEqual(ksruncontext_testcode_determineReason(&lc, &res, &sys, &sys), KSTerminationReasonBackgroundExit);
+}
+
+- (void)testCriticalMemoryWhileNotUserPerceptibleStillReturnsMemoryLimit
+{
+    KSCrash_LifecycleData lc = makeLifecycle(false, false);
+    lc.userPerceptible = false;
+    KSCrash_ResourceData res = makeResource();
+    res.memoryLevel = KSCrashAppMemoryStateCritical;
+    KSCrash_SystemData sys = sameSystem();
+    XCTAssertEqual(ksruncontext_testcode_determineReason(&lc, &res, &sys, &sys), KSTerminationReasonMemoryLimit);
+}
+
+- (void)testAppUpgradeWhileNotUserPerceptibleStillReturnsAppUpgrade
+{
+    KSCrash_LifecycleData lc = makeLifecycle(false, false);
+    lc.userPerceptible = false;
+    KSCrash_ResourceData res = makeResource();
+    KSCrash_SystemData prev = makeSystem("17.4", "21E258", "1.0", "100", 1000);
+    KSCrash_SystemData curr = makeSystem("17.4", "21E258", "1.1", "101", 1000);
+    XCTAssertEqual(ksruncontext_testcode_determineReason(&lc, &res, &prev, &curr), KSTerminationReasonAppUpgrade);
+}
+
 // MARK: - reasonToString
 
 - (void)testReasonToString
@@ -429,6 +461,7 @@ static KSCrash_SystemData sameSystem(void) { return makeSystem("17.4", "21E258",
     XCTAssertTrue(strcmp(kstermination_reasonToString(KSTerminationReasonAppUpgrade), "app_upgrade") == 0);
     XCTAssertTrue(strcmp(kstermination_reasonToString(KSTerminationReasonReboot), "reboot") == 0);
     XCTAssertTrue(strcmp(kstermination_reasonToString(KSTerminationReasonUnexplained), "unexplained") == 0);
+    XCTAssertTrue(strcmp(kstermination_reasonToString(KSTerminationReasonBackgroundExit), "background_exit") == 0);
 }
 
 // MARK: - producesReport
@@ -457,6 +490,7 @@ static KSCrash_SystemData sameSystem(void) { return makeSystem("17.4", "21E258",
     XCTAssertFalse(kstermination_producesReport(KSTerminationReasonOSUpgrade));
     XCTAssertFalse(kstermination_producesReport(KSTerminationReasonAppUpgrade));
     XCTAssertFalse(kstermination_producesReport(KSTerminationReasonReboot));
+    XCTAssertFalse(kstermination_producesReport(KSTerminationReasonBackgroundExit));
 }
 
 @end

--- a/Tests/KSCrashReportModelTests/CrashReportDecodingTests.swift
+++ b/Tests/KSCrashReportModelTests/CrashReportDecodingTests.swift
@@ -1081,6 +1081,7 @@ final class CrashReportDecodingTests: XCTestCase {
             ("app_upgrade", .appUpgrade),
             ("reboot", .reboot),
             ("unexplained", .unexplained),
+            ("background_exit", .backgroundExit),
         ] {
             let json = """
                 {

--- a/Tests/KSCrashReportModelTests/CrashReportTests.swift
+++ b/Tests/KSCrashReportModelTests/CrashReportTests.swift
@@ -57,6 +57,7 @@ final class CrashReportTests: XCTestCase {
         XCTAssertEqual(TerminationReason.appUpgrade.rawValue, "app_upgrade")
         XCTAssertEqual(TerminationReason.reboot.rawValue, "reboot")
         XCTAssertEqual(TerminationReason.unexplained.rawValue, "unexplained")
+        XCTAssertEqual(TerminationReason.backgroundExit.rawValue, "background_exit")
     }
 
     func testTerminationReasonUnknown() {


### PR DESCRIPTION
# Intro 
We have a screen in our app which shows the user that the app has crashed and we notice with the update from 2.5.1 to 2.6.0 this screen will always appear when you rebuild and launch the app via Xcode. We fixed the issue locally only showing the screen when there is a real `.crash` but `crashedLastLaunch` will still be falsely true(In my opinion). 

# AI Input
KSCrash 2.6.0 reports `crashedLastLaunch == true` and injects a fatal report with a synthetic SIGKILL after the most ordinary way an iOS app ends: it was suspended and the system reclaimed it, the user removed it from the app switcher, or it was prewarmed and never used.

**Cause.** `determineReason()` falls back to `KSTerminationReasonUnexplained` whenever the previous run recorded no clean exit and nothing else matched: no handler ran, no hang, same OS and app version, no critical resource. `kstermination_producesReport()` and the Termination monitor's `needsStitch()` list that reason next to the resource kills, so it counts as a crash and produces a report, although the monitor's header only claims reports for OS kills and system changes. The Lifecycle sidecar already records `userPerceptible`; the classification never looks at it.

**Change.** When nothing points at a fault and the app was not user-perceptible at its last lifecycle update, the reason is a new `KSTerminationReasonBackgroundExit`: no report, `crashedLastLaunch` stays false, `previousTerminationReason` still says what happened. A foreground exit without an identified cause stays `Unexplained` and keeps its report. The value is appended after `Unexplained` so the numbering released with 2.6.0 does not move; `kstermination_reasonToString` / `reasonFromString` and the Swift `TerminationReason` model learn `background_exit`.

**Tests.** `KSCrashMonitor_Termination_Tests`: not user-perceptible and nothing critical → `BackgroundExit`; not user-perceptible with critical memory → still `MemoryLimit`; not user-perceptible with an app upgrade → still `AppUpgrade`; string and `producesReport` coverage. The fixture now marks runs as user-perceptible, so the existing `Unexplained` expectations describe foreground exits. `KSCrashRecordingTests` and `KSCrashReportModelTests` pass on macOS with Xcode 26.6; clang-format and swift-format are clean.

**Verified on the iOS 26.5 simulator** with a minimal app (`install(with:)`, default monitors, status written at launch), running the same source change on top of 2.6.0:

| Previous run ended by | 2.6.0 / develop | this change |
|---|---|---|
| `kill -9` while in the foreground | unexplained, `crashedLastLaunch` true, report | unchanged |
| reinstall over the running foreground app | unexplained, true, report | unchanged |
| suspended in the background, `kill -9` | unexplained, true, report | background_exit, false, no report |
| suspended in the background, reinstall over it | unexplained, true, report | background_exit, false, no report |
| suspended in the background, `simctl terminate` | unexplained, true, report | background_exit, false, no report |

🤖 Partly generated with [Claude Code](https://claude.com/claude-code)
