### PR TITLE
Wait for the thread name the test set, not the first one read back

### DIFF
--- a/Tests/KSCrashBenchmarks/KSTimeProfilerBenchmarks.swift
+++ b/Tests/KSCrashBenchmarks/KSTimeProfilerBenchmarks.swift
@@ -200,7 +200,11 @@ import XCTest
                 let id2 = profiler.beginProfile(named: "benchmark")
                 let id3 = profiler.beginProfile(named: "benchmark")
 
-                Thread.sleep(forTimeInterval: 0.03)
+                // Ten intervals, the same margin the other 10ms benchmark leaves. Three
+                // was enough on an idle machine and not on a loaded CI runner, where the
+                // sampling timer can miss that many ticks and the run ends with no
+                // samples at all.
+                Thread.sleep(forTimeInterval: 0.1)
 
                 _ = profiler.endProfile(id: id1)
                 _ = profiler.endProfile(id: id2)

--- a/Tests/KSCrashRecordingTests/KSThreadCache_Tests.m
+++ b/Tests/KSCrashRecordingTests/KSThreadCache_Tests.m
@@ -50,28 +50,29 @@ extern void kstc_reset(void);
     kstc_init(1);
     [thread start];
 
-    // Poll until the cache picks up the thread name (up to 10 s).
-    const char *cName = NULL;
+    // Poll until the cache reports the name the thread was given (up to 10 s).
+    // NSThread applies the name as the thread starts, and the cache reads it
+    // with pthread_getname_np from another thread, so a read that wins that
+    // race sees the name absent or part way written. Only the settled value
+    // answers the question, so stopping at the first non-NULL read is what
+    // made this test fail on a loaded machine with a truncated name.
+    NSString *name = nil;
     NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:10.0];
-    while ([deadline timeIntervalSinceNow] > 0) {
+    for (;;) {
         kstc_freeze();
-        cName = kstc_getThreadName(thread.thread);
-        if (cName != NULL) {
+        const char *cName = kstc_getThreadName(thread.thread);
+        // Copy while frozen; the cache owns the buffer.
+        name = cName != NULL ? [NSString stringWithUTF8String:cName] : nil;
+        kstc_unfreeze();
+        if ([name isEqualToString:expectedName] || [deadline timeIntervalSinceNow] <= 0) {
             break;
         }
-        kstc_unfreeze();
         [NSThread sleepForTimeInterval:0.05];
     }
 
-    if (cName != NULL) {
-        NSString *name = [NSString stringWithUTF8String:cName];
-        XCTAssertEqualObjects(name, expectedName, @"Thread name didn't match expected name");
-    } else {
-        XCTFail(@"Failed to get thread name within 10 seconds");
-    }
+    XCTAssertEqualObjects(name, expectedName, @"Thread name didn't match expected name");
 
     [thread cancel];
-    kstc_unfreeze();
 }
 
 @end


### PR DESCRIPTION
The thread name test polled the cache until it returned any name and asserted on the first one it got. The cache reads the name with pthread_getname_np while NSThread is still applying it as the thread starts, so a read that wins that race sees the name absent or only part way written, and on a loaded CI machine that meant asserting on "This is" rather than "This is a test thread".

It now polls until the name settles, and pairs every freeze with an unfreeze; the old timeout path unfroze twice.